### PR TITLE
Add missing tableName field

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ tableFormats:
 dataset:
   -
     tableBasePath: s3://tpc-ds-datasets/1GB/hudi/call_center
+    tablename: call_center
   -
     tableBasePath: s3://tpc-ds-datasets/1GB/hudi/catalog_sales
+    tablename: catalog_sales
     partitionSpec: cs_sold_date_sk:VALUE
   -
     tableBasePath: s3://hudi/multi-partition-dataset
+    tablename: multi_partition_dataset
     partitionSpec: time_millis:DAY:yyyy-MM-dd,type:VALUE
 ```
 - `tableFormats` is a list of formats you want to create from your source Hudi tables

--- a/utilities/src/main/java/io/onetable/utilities/RunSync.java
+++ b/utilities/src/main/java/io/onetable/utilities/RunSync.java
@@ -108,6 +108,7 @@ public class RunSync {
         PerTableConfig config =
             PerTableConfig.builder()
                 .tableBasePath(table.getTableBasePath())
+                .tableName(table.getTableBasePath())
                 .hudiSourceConfig(
                     HudiSourceConfig.builder()
                         .partitionSpecExtractorClass(
@@ -134,6 +135,7 @@ public class RunSync {
     @Data
     public static class Table {
       String tableBasePath;
+      String tableName;
       String partitionSpec;
     }
   }


### PR DESCRIPTION
Fixes #2
This change adds missing tableName field. TableName is mandatory in PerTableConfig for launching OneTable application.

This pull request is a trivial code change and are already covered by existing tests. Launching the application manually does not fail with this change.