### PR TITLE
Read empty state file without error and add loggging

### DIFF
--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -281,16 +281,19 @@ public class OneTableClient {
   private void persistOneTableState(OneTableState state) {
     try {
       storage.write(state);
-    } catch (IOException e) {
-      throw new OneIOException("Failed to persist sync result", e);
+    } catch (IOException ex) {
+      LOG.error(String.format("Failed to persist one table state for table path: %s",
+          state.getTable().getBasePath()), ex);
+      throw new OneIOException("Failed to persist sync result", ex);
     }
   }
 
   private Optional<OneTableState> getSyncState(String tableBasePath) {
     try {
       return storage.read(tableBasePath);
-    } catch (IOException e) {
-      throw new OneIOException("Failed to get one table state", e);
+    } catch (IOException ex) {
+      LOG.error(String.format("Failed to get one table state for table path: %s", tableBasePath), ex);
+      throw new OneIOException("Failed to get one table state", ex);
     }
   }
 

--- a/core/src/main/java/io/onetable/persistence/OneTableStateStorage.java
+++ b/core/src/main/java/io/onetable/persistence/OneTableStateStorage.java
@@ -139,7 +139,11 @@ public class OneTableStateStorage {
               new BufferedReader(
                   new InputStreamReader(fsDataInputStream, StandardCharsets.UTF_8))) {
         String readLine = bufferedReader.readLine();
-        return Optional.of(MAPPER.readValue(readLine, OneTableState.class));
+        if (readLine != null) {
+          return Optional.of(MAPPER.readValue(readLine, OneTableState.class));
+        } else {
+          return Optional.empty();
+        }
       }
     }
     return Optional.empty();

--- a/core/src/test/java/io/onetable/persistence/TestOneTableStateStorage.java
+++ b/core/src/test/java/io/onetable/persistence/TestOneTableStateStorage.java
@@ -19,13 +19,14 @@
 package io.onetable.persistence;
 
 import static io.onetable.constants.OneTableConstants.ONETABLE_META_DIR;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
@@ -244,6 +246,19 @@ class TestOneTableStateStorage {
         }
       }
     }
+  }
+
+  @Test
+  void testReadEmptyFile() throws IOException {
+    Path basePath = tempDir.resolve(TABLE_NAME);
+    Path oneTableStatePath = basePath.resolve(ONETABLE_META_DIR);
+    if (!Files.exists(oneTableStatePath)) {
+      Files.createDirectories(oneTableStatePath);
+    }
+    Path stateFilePath = oneTableStatePath.resolve("state");
+    Files.createFile(stateFilePath);
+    Optional<OneTableState> stateFromStorage = storage.read(basePath.toString());
+    assertFalse(stateFromStorage.isPresent());
   }
 
   private OneDataFile getOneDataFile(


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

1. Do not error out on read of empty onetable state file and add unit-test.
2. Add logging to give more visibility around creation of empty state file.

## Brief change log

1. Do not error out on read of empty onetable state file and add unit-test.
2. Add logging to give more visibility around creation of empty state file.

## Verify this pull request

Unit-tests.
