### PR TITLE
Enable CI for macOS. Creates a template for compile-and-test steps

### DIFF
--- a/workflows/azure-pipelines/compile-and-test.yml
+++ b/workflows/azure-pipelines/compile-and-test.yml
@@ -1,0 +1,11 @@
+steps:
+- task: Maven@3
+  inputs:
+    mavenPomFile: 'pom.xml'
+    mavenOptions: '-Xmx3072m'
+    javaHomeOption: 'JDKVersion'
+    jdkVersionOption: '1.11'
+    jdkArchitectureOption: 'x64'
+    publishJUnitResults: true
+    testResultsFiles: '**/surefire-reports/TEST-*.xml'
+    goals: 'package'

--- a/workflows/azure-pipelines/maven.yml
+++ b/workflows/azure-pipelines/maven.yml
@@ -4,17 +4,16 @@ trigger:
 pr:
 - main
 
-pool:
-  vmImage: ubuntu-latest
-
-steps:
-- task: Maven@3
-  inputs:
-    mavenPomFile: 'pom.xml'
-    mavenOptions: '-Xmx3072m'
-    javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.11'
-    jdkArchitectureOption: 'x64'
-    publishJUnitResults: true
-    testResultsFiles: '**/surefire-reports/TEST-*.xml'
-    goals: 'package'
+stages:
+- stage: build
+  jobs:
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - template: compile-and-test.yml
+  - job: macOS
+    pool:
+      vmImage: 'macos-latest'
+    steps:
+    - template: compile-and-test.yml


### PR DESCRIPTION
See #38.

## What is the purpose of the pull request

This PR enables CI for macOS.

## Brief change log

- Split yml file to have a template for compile and tests that can be called from maven.yml for different OS.
- Accordingly modify maven.yml to call the new template for Linux and macOS.

## Verify this pull request

- Through GH CI.