### PR TITLE
[bug] use correct timestamp type in Iceberg schema

### DIFF
--- a/core/src/main/java/io/onetable/iceberg/IcebergSchemaExtractor.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergSchemaExtractor.java
@@ -109,7 +109,7 @@ public class IcebergSchemaExtractor {
       case DATE:
         return Types.DateType.get();
       case TIMESTAMP:
-        return Types.TimestampType.withoutZone();
+        return Types.TimestampType.withZone();
       case DOUBLE:
         return Types.DoubleType.get();
       case DECIMAL:

--- a/core/src/test/java/io/onetable/iceberg/TestIcebergSchemaExtractor.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergSchemaExtractor.java
@@ -392,15 +392,15 @@ public class TestIcebergSchemaExtractor {
             Types.NestedField.required(17, "requiredDate", Types.DateType.get()),
             Types.NestedField.optional(18, "optionalDate", Types.DateType.get()),
             Types.NestedField.required(
-                19, "requiredTimestampMillis", Types.TimestampType.withoutZone()),
+                19, "requiredTimestampMillis", Types.TimestampType.withZone()),
             Types.NestedField.optional(
-                20, "optionalTimestampMillis", Types.TimestampType.withoutZone()),
+                20, "optionalTimestampMillis", Types.TimestampType.withZone()),
             Types.NestedField.required(21, "requiredTimestampNtzMillis", Types.LongType.get()),
             Types.NestedField.optional(22, "optionalTimestampNtzMillis", Types.LongType.get()),
             Types.NestedField.required(
-                23, "requiredTimestampMicros", Types.TimestampType.withoutZone()),
+                23, "requiredTimestampMicros", Types.TimestampType.withZone()),
             Types.NestedField.optional(
-                24, "optionalTimestampMicros", Types.TimestampType.withoutZone()),
+                24, "optionalTimestampMicros", Types.TimestampType.withZone()),
             Types.NestedField.required(25, "requiredTimestampNtzMicros", Types.LongType.get()),
             Types.NestedField.optional(26, "optionalTimestampNtzMicros", Types.LongType.get()),
             Types.NestedField.required(27, "requiredFixed", Types.FixedType.ofLength(fixedSize)),


### PR DESCRIPTION
## What is the purpose of the pull request

Fixes issue found in testing where type did not match underlying parquet type for timestamp

## Brief change log

- use timestamp with zone

## Verify this pull request

Test expectations updated
