### PR TITLE
Consider completed commits for hudi & minor fix with test

### DIFF
--- a/core/src/main/java/io/onetable/hudi/HudiClient.java
+++ b/core/src/main/java/io/onetable/hudi/HudiClient.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 
 import io.onetable.exception.OneIOException;
 import io.onetable.model.OneTable;
@@ -93,18 +94,18 @@ public class HudiClient implements SourceClient<HoodieInstant> {
     return dataFileExtractor.getDiffBetweenCommits(startCommit, endCommit, table);
   }
 
+  private HoodieTimeline getCompletedCommits() {
+    return metaClient.getActiveTimeline().filterCompletedInstants();
+  }
+
   @Override
   public List<HoodieInstant> getCommits(HoodieInstant afterCommit) {
-    return metaClient
-        .getActiveTimeline()
-        .findInstantsAfter(afterCommit.getTimestamp())
-        .getInstants();
+    return getCompletedCommits().findInstantsAfter(afterCommit.getTimestamp()).getInstants();
   }
 
   @Override
   public HoodieInstant getLatestCommit() {
-    return metaClient
-        .getActiveTimeline()
+    return getCompletedCommits()
         .lastInstant()
         .orElseThrow(
             () -> new OneIOException("Unable to read latest commit from Hudi source table"));
@@ -112,8 +113,7 @@ public class HudiClient implements SourceClient<HoodieInstant> {
 
   @Override
   public HoodieInstant getCommitAtInstant(Instant instant) {
-    return metaClient
-        .getActiveTimeline()
+    return getCompletedCommits()
         .findInstantsBeforeOrEquals(MILLIS_INSTANT_TIME_FORMATTER.format(instant))
         .lastInstant()
         .get();

--- a/core/src/test/java/io/onetable/TestHudiTable.java
+++ b/core/src/test/java/io/onetable/TestHudiTable.java
@@ -466,7 +466,6 @@ public class TestHudiTable implements Closeable {
             .collect(Collectors.toList());
     JavaRDD<HoodieRecord<HoodieAvroPayload>> writeRecords = jsc.parallelize(updates, 2);
     String instant = getStartCommitInstant();
-    writeClient.startCommitWithTime(instant);
     JavaRDD<WriteStatus> result = writeClient.upsert(writeRecords, instant);
     if (checkForNoErrors) {
       assertNoWriteErrors(result.collect());


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

1. Filter for completed commits only in Hudi.
2. Fix for test in upsert records to hudi where we don't start commit twice (resulting rollbacks)

## Brief change log

1. Filter for completed commits only in Hudi.
2. Fix for test in upsert records to hudi where we don't start commit twice (resulting rollbacks)

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.
