### PR TITLE
add delta field id extraction to schema extraction

### DIFF
--- a/core/src/main/java/io/onetable/delta/DeltaSchemaExtractor.java
+++ b/core/src/main/java/io/onetable/delta/DeltaSchemaExtractor.java
@@ -56,6 +56,7 @@ import io.onetable.model.schema.OneType;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DeltaSchemaExtractor {
+  private static final String DELTA_COLUMN_MAPPING_ID = "delta.columnMapping.id";
   private static final DeltaSchemaExtractor INSTANCE = new DeltaSchemaExtractor();
 
   public static DeltaSchemaExtractor getInstance() {
@@ -183,6 +184,10 @@ public class DeltaSchemaExtractor {
             Arrays.stream(structType.fields())
                 .map(
                     field -> {
+                      Integer fieldId =
+                          field.metadata().contains(DELTA_COLUMN_MAPPING_ID)
+                              ? (int) field.metadata().getLong(DELTA_COLUMN_MAPPING_ID)
+                              : null;
                       String fieldComment =
                           field.getComment().isDefined() ? field.getComment().get() : null;
                       OneSchema schema =
@@ -193,6 +198,7 @@ public class DeltaSchemaExtractor {
                               fieldComment);
                       return OneField.builder()
                           .name(field.name())
+                          .fieldId(fieldId)
                           .parentPath(parentPath)
                           .schema(schema)
                           .defaultValue(


### PR DESCRIPTION
## What is the purpose of the pull request

Addresses #76 
Extracts the field ID from the delta schema if it is present

## Brief change log

- Parses the field metadata for the column mapping ID

## Verify this pull request

Added unit test
