### PR TITLE
Simplify IcebergDataFileExtractor initialization

### DIFF
--- a/core/src/main/java/io/onetable/iceberg/IcebergDataFileExtractor.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergDataFileExtractor.java
@@ -20,7 +20,10 @@ package io.onetable.iceberg;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import lombok.Builder;
 
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
@@ -29,57 +32,96 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterator;
 
 import io.onetable.exception.NotSupportedException;
+import io.onetable.model.schema.OnePartitionField;
+import io.onetable.model.stat.Range;
 import io.onetable.model.storage.FileFormat;
 import io.onetable.model.storage.OneDataFile;
 import io.onetable.model.storage.OneDataFiles;
 import io.onetable.spi.extractor.PartitionedDataFileIterator;
 
 /** Extractor of data files for Iceberg */
-public class IcebergDataFileExtractor implements PartitionedDataFileIterator {
-  private final CloseableIterator<CombinedScanTask> iceScan;
-  private final IcebergPartitionValueConverter partitionValueConverter;
-  private final PartitionSpec partitionSpec;
+@Builder
+public class IcebergDataFileExtractor {
 
-  public IcebergDataFileExtractor(
-      Table iceTable, IcebergPartitionValueConverter partitionValueConverter) {
-    this.partitionSpec = iceTable.spec();
-    this.iceScan = iceTable.newScan().planTasks().iterator();
-    this.partitionValueConverter = partitionValueConverter;
+  @Builder.Default
+  private IcebergPartitionValueConverter partitionValueConverter =
+      IcebergPartitionValueConverter.getInstance();
+
+  /**
+   * Initializes an iterator for Iceberg files.
+   *
+   * @return Iceberg table file iterator
+   */
+  public PartitionedDataFileIterator iterator(Table iceTable) {
+    return new IcebergDataFileIterator(iceTable);
   }
 
-  @Override
-  public void close() throws Exception {
-    iceScan.close();
+  public class IcebergDataFileIterator implements PartitionedDataFileIterator {
+    private final Table iceTable;
+    private final CloseableIterator<CombinedScanTask> iceScan;
+
+    private IcebergDataFileIterator(Table iceTable) {
+      this.iceTable = iceTable;
+      this.iceScan = iceTable.newScan().planTasks().iterator();
+    }
+
+    @Override
+    public void close() throws Exception {
+      iceScan.close();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iceScan.hasNext();
+    }
+
+    @Override
+    public OneDataFiles next() {
+      if (iceScan == null) {
+        throw new IllegalStateException("Iterator is not initialized");
+      }
+
+      PartitionSpec partitionSpec = iceTable.spec();
+      CombinedScanTask combinedScan = iceScan.next();
+      List<OneDataFile> files =
+          combinedScan.files().stream()
+              .map(
+                  fileScanTask -> {
+                    DataFile dataFile = fileScanTask.file();
+                    Map<OnePartitionField, Range> onePartitionFieldRangeMap =
+                        partitionValueConverter.toOneTable(dataFile.partition(), partitionSpec);
+                    return fromIceberg(dataFile, onePartitionFieldRangeMap);
+                  })
+              .collect(Collectors.toList());
+      return OneDataFiles.collectionBuilder().files(files).build();
+    }
   }
 
-  @Override
-  public boolean hasNext() {
-    return iceScan.hasNext();
+  /**
+   * Builds {@link OneDataFile} representation from Iceberg {@link DataFile}
+   *
+   * @param dataFile Iceberg data file
+   * @param partitionsInfo representation of partition fields and ranges
+   * @return corresponding OneTable data file
+   */
+  OneDataFile fromIceberg(DataFile dataFile, Map<OnePartitionField, Range> partitionsInfo) {
+    return OneDataFile.builder()
+        .physicalPath(dataFile.path().toString())
+        .fileFormat(fromIcebergFileFormat(dataFile.format()))
+        .fileSizeBytes(dataFile.fileSizeInBytes())
+        .recordCount(dataFile.recordCount())
+        .partitionValues(partitionsInfo)
+        .columnStats(Collections.emptyMap())
+        .build();
   }
 
-  @Override
-  public OneDataFiles next() {
-    CombinedScanTask combinedScan = iceScan.next();
-    List<OneDataFile> files =
-        combinedScan.files().stream()
-            .map(
-                fileScanTask -> {
-                  DataFile dataFile = fileScanTask.file();
-                  return OneDataFile.builder()
-                      .physicalPath(dataFile.path().toString())
-                      .fileFormat(getFileFormat(dataFile.format()))
-                      .fileSizeBytes(dataFile.fileSizeInBytes())
-                      .recordCount(dataFile.recordCount())
-                      .partitionValues(
-                          partitionValueConverter.toOneTable(dataFile.partition(), partitionSpec))
-                      .columnStats(Collections.emptyMap())
-                      .build();
-                })
-            .collect(Collectors.toList());
-    return OneDataFiles.collectionBuilder().files(files).build();
-  }
-
-  private FileFormat getFileFormat(org.apache.iceberg.FileFormat format) {
+  /**
+   * Maps Iceberg file format to OneTable file format
+   *
+   * @param format Iceberg file format
+   * @return corresponding OneTable file format
+   */
+  FileFormat fromIcebergFileFormat(org.apache.iceberg.FileFormat format) {
     switch (format) {
       case PARQUET:
         return FileFormat.APACHE_PARQUET;

--- a/core/src/main/java/io/onetable/iceberg/IcebergDataFileUpdatesSync.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergDataFileUpdatesSync.java
@@ -51,8 +51,9 @@ public class IcebergDataFileUpdatesSync {
       Schema schema,
       PartitionSpec partitionSpec) {
     List<OneDataFile> dataFiles = new ArrayList<>();
-    try (PartitionedDataFileIterator fileIterator =
-        new IcebergDataFileExtractor(table, partitionValueConverter)) {
+    IcebergDataFileExtractor dataFileExtractor =
+        IcebergDataFileExtractor.builder().partitionValueConverter(partitionValueConverter).build();
+    try (PartitionedDataFileIterator fileIterator = dataFileExtractor.iterator(table)) {
       fileIterator.forEachRemaining(dataFiles::add);
     } catch (Exception e) {
       throw new OneIOException("Failed to iterate through Iceberg data files", e);


### PR DESCRIPTION
Fixes #87 

This change splits the data file extractor into common conversion code and an iterator. Converting iceberg files to oneFile or mapping file format does not require iterator functionality. This simplifies the constructors. Now, lombok can be leveraged to take care of injecting mocks when needed.

This pull request is mainly refactoring the code  and is covered by existing tests.