### PR TITLE
Hudi Target: initial bug fixes

### DIFF
--- a/core/src/main/java/io/onetable/hudi/BaseFileUpdatesExtractor.java
+++ b/core/src/main/java/io/onetable/hudi/BaseFileUpdatesExtractor.java
@@ -48,6 +48,7 @@ import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.ExternalFilePathUtil;
+import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.metadata.HoodieMetadataFileSystemView;
 
 import io.onetable.model.OneTable;
@@ -65,7 +66,7 @@ public class BaseFileUpdatesExtractor {
       Pattern.compile(
           "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[0-9]_[0-9a-fA-F-]+_[0-9]+\\.");
   private final HoodieEngineContext engineContext;
-  private final String tableBasePath;
+  private final Path tableBasePath;
 
   /**
    * Extracts the changes between the snapshot files and the base files in the Hudi table currently.
@@ -85,6 +86,7 @@ public class BaseFileUpdatesExtractor {
     HoodieTableFileSystemView fsView =
         new HoodieMetadataFileSystemView(
             engineContext, metaClient, metaClient.getActiveTimeline(), metadataConfig);
+    boolean isTableInitialized = metaClient.isTimelineNonEmpty();
     // Track the partitions that are not present in the snapshot, so the files for those partitions
     // can be dropped
     Set<String> partitionPathsToDrop =
@@ -94,21 +96,20 @@ public class BaseFileUpdatesExtractor {
     ReplaceMetadata replaceMetadata =
         snapshotFiles.getFiles().stream()
             .map(
-                file -> {
+                files -> {
+                  OneDataFiles oneDataFiles = (OneDataFiles) files;
+                  String partitionPath = getPartitionPath(tableBasePath, oneDataFiles);
                   // remove the partition from the set of partitions to drop since it is present in
                   // the snapshot
-                  partitionPathsToDrop.remove(file.getPartitionPath());
+                  partitionPathsToDrop.remove(partitionPath);
                   // create a map of file path to the data file, any entries not in the hudi table
                   // will be added
                   Map<String, OneDataFile> physicalPathToFile =
-                      DefaultSnapshotVisitor.extractDataFilePaths(
-                          OneDataFiles.collectionBuilder()
-                              .files(Collections.singletonList(file))
-                              .build());
+                      DefaultSnapshotVisitor.extractDataFilePaths(oneDataFiles);
                   List<HoodieBaseFile> baseFiles =
-                      fsView
-                          .getLatestBaseFiles(file.getPartitionPath())
-                          .collect(Collectors.toList());
+                      isTableInitialized
+                          ? fsView.getLatestBaseFiles(partitionPath).collect(Collectors.toList())
+                          : Collections.emptyList();
                   Set<String> existingPaths =
                       baseFiles.stream().map(HoodieBaseFile::getPath).collect(Collectors.toSet());
                   // Mark fileIds for removal if the file paths are no longer present in the
@@ -127,12 +128,15 @@ public class BaseFileUpdatesExtractor {
                           .map(
                               snapshotFile ->
                                   toWriteStatus(
-                                      metaClient.getBasePathV2().toString(), commit, snapshotFile))
+                                      tableBasePath,
+                                      commit,
+                                      snapshotFile,
+                                      Optional.of(partitionPath)))
                           .collect(Collectors.toList());
                   return ReplaceMetadata.of(
                       fileIdsToRemove.isEmpty()
                           ? Collections.emptyMap()
-                          : Collections.singletonMap(file.getPartitionPath(), fileIdsToRemove),
+                          : Collections.singletonMap(partitionPath, fileIdsToRemove),
                       writeStatuses);
                 })
             .reduce(ReplaceMetadata::combine)
@@ -152,6 +156,7 @@ public class BaseFileUpdatesExtractor {
                       Collections.emptyList());
                 })
             .reduce(ReplaceMetadata::combine);
+    fsView.close();
     return droppedPartitions.map(replaceMetadata::combine).orElse(replaceMetadata);
   }
 
@@ -166,20 +171,21 @@ public class BaseFileUpdatesExtractor {
     // For all removed files, group by partition and extract the file id
     Map<String, List<String>> partitionToReplacedFileIds =
         oneDataFilesDiff.getFilesRemoved().stream()
+            .map(file -> new CachingPath(file.getPhysicalPath()))
             .collect(
                 Collectors.groupingBy(
-                    OneDataFile::getPartitionPath,
+                    path -> getPartitionPath(tableBasePath, path),
                     Collectors.mapping(this::getFileId, Collectors.toList())));
     // For all added files, group by partition and extract the file id
     List<WriteStatus> writeStatuses =
         oneDataFilesDiff.getFilesAdded().stream()
-            .map(file -> toWriteStatus(tableBasePath, commit, file))
+            .map(file -> toWriteStatus(tableBasePath, commit, file, Optional.empty()))
             .collect(Collectors.toList());
     return ReplaceMetadata.of(partitionToReplacedFileIds, writeStatuses);
   }
 
-  private String getFileId(OneDataFile file) {
-    String fileName = new Path(file.getPhysicalPath()).getName();
+  private String getFileId(Path filePath) {
+    String fileName = filePath.getName();
     // if file was created by Hudi use original fileId, otherwise use the file name as IDs
     if (isFileCreatedByHudiWriter(fileName)) {
       return FSUtils.getFileId(fileName);
@@ -198,18 +204,25 @@ public class BaseFileUpdatesExtractor {
     return HUDI_BASE_FILE_PATTERN.matcher(fileName).find();
   }
 
-  private WriteStatus toWriteStatus(String tableBasePath, String commitTime, OneDataFile file) {
+  private WriteStatus toWriteStatus(
+      Path tableBasePath,
+      String commitTime,
+      OneDataFile file,
+      Optional<String> partitionPathOptional) {
     WriteStatus writeStatus = new WriteStatus();
-    String fileId = getFileId(file);
-    String filePath = file.getPhysicalPath().substring(tableBasePath.length() + 1);
-    String fileName = filePath.substring(file.getPartitionPath().length() + 1);
+    Path path = new CachingPath(file.getPhysicalPath());
+    String partitionPath =
+        partitionPathOptional.orElseGet(() -> getPartitionPath(tableBasePath, path));
+    String fileId = getFileId(path);
+    String filePath = file.getPhysicalPath().substring(tableBasePath.toString().length() + 1);
+    String fileName = path.getName();
     writeStatus.setFileId(fileId);
-    writeStatus.setPartitionPath(file.getPartitionPath());
+    writeStatus.setPartitionPath(partitionPath);
     HoodieDeltaWriteStat writeStat = new HoodieDeltaWriteStat();
     writeStat.setFileId(fileId);
     writeStat.setPath(
         ExternalFilePathUtil.appendCommitTimeAndExternalFileMarker(filePath, commitTime));
-    writeStat.setPartitionPath(file.getPartitionPath());
+    writeStat.setPartitionPath(partitionPath);
     writeStat.setNumWrites(file.getRecordCount());
     writeStat.setTotalWriteBytes(file.getFileSizeBytes());
     writeStat.setFileSizeInBytes(file.getFileSizeBytes());
@@ -257,5 +270,18 @@ public class BaseFileUpdatesExtractor {
       writeStatuses.addAll(other.writeStatuses);
       return ReplaceMetadata.of(partitionToReplacedFileIds, writeStatuses);
     }
+  }
+
+  private String getPartitionPath(Path tableBasePath, OneDataFiles files) {
+    return getPartitionPath(
+        tableBasePath, new CachingPath(files.getFiles().get(0).getPhysicalPath()));
+  }
+
+  private String getPartitionPath(Path tableBasePath, Path filePath) {
+    String fileName = filePath.getName();
+    String pathStr = filePath.toString();
+    int startIndex = tableBasePath.toString().length() + 1;
+    int endIndex = pathStr.length() - fileName.length() - 1;
+    return endIndex <= startIndex ? "" : pathStr.substring(startIndex, endIndex);
   }
 }

--- a/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
+++ b/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
@@ -73,6 +73,7 @@ import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.hadoop.CachingPath;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.table.HoodieJavaTable;
 import org.apache.hudi.table.action.clean.CleanPlanner;
@@ -109,7 +110,8 @@ public class HudiTargetClient implements TargetClient {
         perTableConfig.getTargetMetadataRetentionInHours(),
         HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.defaultValue(),
         BaseFileUpdatesExtractor.of(
-            new HoodieJavaEngineContext(configuration), perTableConfig.getTableBasePath()),
+            new HoodieJavaEngineContext(configuration),
+            new CachingPath(perTableConfig.getTableBasePath())),
         AvroSchemaConverter.getInstance(),
         HudiTableManager.of(configuration),
         CommitState::new);
@@ -125,7 +127,8 @@ public class HudiTargetClient implements TargetClient {
         perTableConfig.getTargetMetadataRetentionInHours(),
         maxNumDeltaCommitsBeforeCompaction,
         BaseFileUpdatesExtractor.of(
-            new HoodieJavaEngineContext(configuration), perTableConfig.getTableBasePath()),
+            new HoodieJavaEngineContext(configuration),
+            new CachingPath(perTableConfig.getTableBasePath())),
         AvroSchemaConverter.getInstance(),
         HudiTableManager.of(configuration),
         CommitState::new);

--- a/core/src/test/java/io/onetable/hudi/TestBaseFileUpdatesExtractor.java
+++ b/core/src/test/java/io/onetable/hudi/TestBaseFileUpdatesExtractor.java
@@ -50,6 +50,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.hadoop.CachingPath;
 
 import io.onetable.model.schema.OneField;
 import io.onetable.model.stat.ColumnStat;
@@ -116,7 +117,8 @@ public class TestBaseFileUpdatesExtractor {
             .filesRemoved(Arrays.asList(removedFile1, removedFile2, removedFile3))
             .build();
 
-    BaseFileUpdatesExtractor extractor = BaseFileUpdatesExtractor.of(CONTEXT, tableBasePath);
+    BaseFileUpdatesExtractor extractor =
+        BaseFileUpdatesExtractor.of(CONTEXT, new CachingPath(tableBasePath));
     BaseFileUpdatesExtractor.ReplaceMetadata replaceMetadata =
         extractor.convertDiff(diff, COMMIT_TIME);
 
@@ -171,7 +173,8 @@ public class TestBaseFileUpdatesExtractor {
             String.format("%s/%s/%s", tableBasePath, partitionPath2, fileName3),
             getColumnStatMap());
 
-    BaseFileUpdatesExtractor extractor = BaseFileUpdatesExtractor.of(CONTEXT, tableBasePath);
+    BaseFileUpdatesExtractor extractor =
+        BaseFileUpdatesExtractor.of(CONTEXT, new CachingPath(tableBasePath));
     OneDataFiles snapshotFiles =
         OneDataFiles.collectionBuilder()
             .files(
@@ -272,7 +275,8 @@ public class TestBaseFileUpdatesExtractor {
                         .partitionPath(partitionPath3)
                         .build()))
             .build();
-    BaseFileUpdatesExtractor extractor = BaseFileUpdatesExtractor.of(CONTEXT, tableBasePath);
+    BaseFileUpdatesExtractor extractor =
+        BaseFileUpdatesExtractor.of(CONTEXT, new CachingPath(tableBasePath));
     BaseFileUpdatesExtractor.ReplaceMetadata replaceMetadata =
         extractor.extractSnapshotChanges(snapshotFiles, metaClient, COMMIT_TIME);
 
@@ -345,7 +349,8 @@ public class TestBaseFileUpdatesExtractor {
                         .partitionPath("")
                         .build()))
             .build();
-    BaseFileUpdatesExtractor extractor = BaseFileUpdatesExtractor.of(CONTEXT, tableBasePath);
+    BaseFileUpdatesExtractor extractor =
+        BaseFileUpdatesExtractor.of(CONTEXT, new CachingPath(tableBasePath));
     BaseFileUpdatesExtractor.ReplaceMetadata replaceMetadata =
         extractor.extractSnapshotChanges(snapshotFiles, metaClient, COMMIT_TIME);
 


### PR DESCRIPTION
## What is the purpose of the pull request

#130 

Fixes initial issues around the assumption that sources will set the partition path in OneDataFile. This will allow us to eventually remove this field and rely on the extracted partition values.

Also fixes issue on the first sync where Hudi will attempt to create a view from files that were not created by Hudi causing exceptions.

## Brief change log

- Parse partition value from the path of a file
- Check if table is initialized before trying to load existing files in the table.

## Verify this pull request

This is covered by existing test cases