### PR TITLE
Fix Flakiness in Delta data generation

### DIFF
--- a/core/src/test/java/io/onetable/delta/TestDeltaHelper.java
+++ b/core/src/test/java/io/onetable/delta/TestDeltaHelper.java
@@ -247,11 +247,9 @@ public class TestDeltaHelper {
 
   private Timestamp generateRandomTimeGivenYear(int yearValue) {
     int month = RANDOM.nextInt(12) + 1;
-    int daysInMonth = YearMonth.of(yearValue, month).lengthOfMonth();
-    // Adjust days in December to avoid timezone issues with Delta generated columns check
-    // constraint for tests.
-    int maxDay = month == 12 ? daysInMonth - 5 : daysInMonth;
-    int day = RANDOM.nextInt(maxDay) + 1;
+    // Adjust days to avoid timezone issues with Delta generated columns check constraint for tests.
+    int daysToConsider = YearMonth.of(yearValue, month).lengthOfMonth() - 5;
+    int day = RANDOM.nextInt(daysToConsider) + 1;
 
     LocalDateTime localDateTime =
         LocalDateTime.of(


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

In certain cases Delta check constraint for generated columns fails with year and timestamp mismatched and in all those cases it is due to timezone difference. 

## Brief change log

1. Fix data generation to avoid generating dates for such boundaries.

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.