### PR TITLE
Pass in location when creating the iceberg table

### DIFF
--- a/core/src/main/java/io/onetable/iceberg/IcebergTableManager.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergTableManager.java
@@ -82,6 +82,7 @@ class IcebergTableManager {
                         tableIdentifier,
                         schema,
                         partitionSpec,
+                        basePath,
                         getDefaultMappingProperties(schema)))
             .orElseGet(
                 () ->

--- a/core/src/test/java/io/onetable/iceberg/StubCatalog.java
+++ b/core/src/test/java/io/onetable/iceberg/StubCatalog.java
@@ -70,8 +70,9 @@ public class StubCatalog implements Catalog {
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec,
+      String location,
       Map<String, String> properties) {
-    return mockedCatalog.createTable(identifier, schema, spec, properties);
+    return mockedCatalog.createTable(identifier, schema, spec, location, properties);
   }
 
   @Override

--- a/core/src/test/java/io/onetable/iceberg/TestIcebergTableManager.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergTableManager.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMappingParser;
 
 public class TestIcebergTableManager {
+  private static final String BASE_PATH = "file:///basePath/";
   private static final Map<String, String> OPTIONS = Collections.singletonMap("key", "value");
   private static final TableIdentifier IDENTIFIER = TableIdentifier.of("database1", "table1");
   private static final Configuration CONFIGURATION = new Configuration();
@@ -61,7 +62,7 @@ public class TestIcebergTableManager {
     when(mockCatalog.loadTable(IDENTIFIER)).thenReturn(mockTable);
 
     IcebergTableManager tableManager = IcebergTableManager.of(CONFIGURATION);
-    Table actual = tableManager.getTable(catalogConfig, IDENTIFIER, "basePath");
+    Table actual = tableManager.getTable(catalogConfig, IDENTIFIER, BASE_PATH);
     assertEquals(mockTable, actual);
     verify(mockCatalog).initialize(catalogName, OPTIONS);
   }
@@ -84,7 +85,7 @@ public class TestIcebergTableManager {
     Schema schema = new Schema();
     PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
     Table actual =
-        tableManager.getOrCreateTable(catalogConfig, IDENTIFIER, "basePath", schema, partitionSpec);
+        tableManager.getOrCreateTable(catalogConfig, IDENTIFIER, BASE_PATH, schema, partitionSpec);
     assertEquals(mockTable, actual);
     verify(mockCatalog).initialize(catalogName, OPTIONS);
     verify(mockCatalog, never()).createTable(any(), any(), any(), any());
@@ -108,6 +109,7 @@ public class TestIcebergTableManager {
             IDENTIFIER,
             schema,
             partitionSpec,
+            BASE_PATH,
             Collections.singletonMap(
                 TableProperties.DEFAULT_NAME_MAPPING,
                 NameMappingParser.toJson(MappingUtil.create(schema)))))
@@ -116,7 +118,7 @@ public class TestIcebergTableManager {
     IcebergTableManager tableManager = IcebergTableManager.of(CONFIGURATION);
 
     Table actual =
-        tableManager.getOrCreateTable(catalogConfig, IDENTIFIER, "basePath", schema, partitionSpec);
+        tableManager.getOrCreateTable(catalogConfig, IDENTIFIER, BASE_PATH, schema, partitionSpec);
     assertEquals(mockTable, actual);
     verify(mockCatalog).initialize(catalogName, OPTIONS);
     verify(mockCatalog, never()).loadTable(any());
@@ -140,6 +142,7 @@ public class TestIcebergTableManager {
             IDENTIFIER,
             schema,
             partitionSpec,
+            BASE_PATH,
             Collections.singletonMap(
                 TableProperties.DEFAULT_NAME_MAPPING,
                 NameMappingParser.toJson(MappingUtil.create(schema)))))
@@ -149,7 +152,7 @@ public class TestIcebergTableManager {
     IcebergTableManager tableManager = IcebergTableManager.of(CONFIGURATION);
 
     Table actual =
-        tableManager.getOrCreateTable(catalogConfig, IDENTIFIER, "basePath", schema, partitionSpec);
+        tableManager.getOrCreateTable(catalogConfig, IDENTIFIER, BASE_PATH, schema, partitionSpec);
     assertEquals(mockTable, actual);
     verify(mockCatalog).initialize(catalogName, OPTIONS);
   }


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Fixes #169 by passing in the location during creation of the table in the catalog

## Brief change log

- Pass in optional arg for the table location

## Verify this pull request

Updated existing test expectations
