### PR TITLE
minor change iceberg source interface

### DIFF
--- a/core/src/main/java/io/onetable/iceberg/IcebergSourceClientProvider.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergSourceClientProvider.java
@@ -18,13 +18,11 @@
  
 package io.onetable.iceberg;
 
-import org.apache.iceberg.Snapshot;
-
 import io.onetable.client.PerTableConfig;
 import io.onetable.client.SourceClientProvider;
 
 /** A concrete implementation of {@link SourceClientProvider} for Hudi table format. */
-public class IcebergSourceClientProvider extends SourceClientProvider<Snapshot> {
+public class IcebergSourceClientProvider extends SourceClientProvider<Long> {
   @Override
   public IcebergSourceClient getSourceClientInstance(PerTableConfig sourceTableConfig) {
     return IcebergSourceClient.builder()


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Minor change in Iceberg source interface to consider snapshotId as the checkpoint as it aligns with Hudi Instant and Delta version number and has little serialization overhead.

## Brief change log

Minor change in Iceberg source interface to consider snapshotId as the checkpoint as it aligns with Hudi Instant and Delta version number and has little serialization overhead.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is already covered by existing tests, such as *(please describe tests)*.
