### PR TITLE
Add package deployment workflow

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -1,0 +1,24 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Parse Version Number
+        run: echo "VERSION=$(echo ${{ github.event.release.tag_name }} | sed -e s/v//)" >> $GITHUB_ENV
+      - name: Set Version
+        run: mvn versions:set -DnewVersion="$VERSION"
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -525,4 +525,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/onetable-io/onetable</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
## What is the purpose of the pull request

#196  Sets up the workflow for publishing jars to GitHub artifacts when there is a release created in GitHub

## Brief change log

Changes are based off of https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven

## Verify this pull request

This will require some manual testing after we merge
