### PR TITLE
Fix data file extraction from Hudi restore metadata with log files

### DIFF
--- a/core/src/main/java/io/onetable/hudi/HudiDataFileExtractor.java
+++ b/core/src/main/java/io/onetable/hudi/HudiDataFileExtractor.java
@@ -271,6 +271,7 @@ public class HudiDataFileExtractor implements AutoCloseable {
                 throw new OneIOException("Unable to parse path " + path, e);
               }
             })
+        .filter(uri -> !FSUtils.isLogFile(new Path(uri).getName()))
         .map(HoodieBaseFile::new)
         .map(baseFile -> buildFileWithoutStats(partitionValues, baseFile))
         .collect(toList(deletedPaths.size()));


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the bug (#331) in data file extraction from the Hudi restore metadata when the restore metadata contains log files in the `successDeleteFiles` field, like below.

```
{"startRestoreTime": "20240206231939820", "timeTakenInMillis": 395672, "instantsToRollback": ["20240206224826804", "20240206184945238", "20240206033415397", "20240206033231467", "20240205235951898", "20240205235922526", "20240205215621113", "20240205215536114", "20240205215451379", "20240205211110380", "20240205210452584", "20240205210142189", "20240205210001428"],
"hoodieRestoreMetadata": {"20240205210452584":
[{"HoodieRollbackMetadata": {"startRollbackTime": "20240206232452651", "timeTakenInMillis": 1766, "totalFilesDeleted": 276, "commitsRollback": ["20240205210452584"], "partitionMetadata": {"2024-02-03": {"partitionPath": "2024-02-03",
"successDeleteFiles": ["/path/2024-02-03/.5c639229-8f6a-49cc-a6ef-fcaa517a6910-0_20240205210452584.log.4_1-0-1", "/path/2024-02-03/.999d6bce-8636-434b-9290-9e0fffc21385-0_20240205210452584.log.3_1-0-1", "/path/2024-02-03/.999d6bce-8636-434b-9290-9e0fffc21385-0_20240205210452584.log.4_1-0-1",  ...
```
Exception:
```
java.lang.UnsupportedOperationException: Unknown Hudi Fileformat .1_0-0-0

	at io.onetable.hudi.HudiDataFileExtractor.getFileFormat(HudiDataFileExtractor.java:416)
	at io.onetable.hudi.HudiDataFileExtractor.buildFileWithoutStats(HudiDataFileExtractor.java:398)
	at io.onetable.hudi.HudiDataFileExtractor.lambda$getRemovedFiles$7(HudiDataFileExtractor.java:275)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at io.onetable.hudi.HudiDataFileExtractor.getRemovedFiles(HudiDataFileExtractor.java:276)
	at io.onetable.hudi.HudiDataFileExtractor.lambda$getAddedAndRemovedPartitionInfo$3(HudiDataFileExtractor.java:236)
	at java.base/java.util.HashMap.forEach(HashMap.java:1337)
	at io.onetable.hudi.HudiDataFileExtractor.lambda$getAddedAndRemovedPartitionInfo$4(HudiDataFileExtractor.java:233)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at io.onetable.hudi.HudiDataFileExtractor.lambda$getAddedAndRemovedPartitionInfo$5(HudiDataFileExtractor.java:229)
	at java.base/java.util.HashMap.forEach(HashMap.java:1337)
	at io.onetable.hudi.HudiDataFileExtractor.getAddedAndRemovedPartitionInfo(HudiDataFileExtractor.java:227)
	at io.onetable.hudi.HudiDataFileExtractor.getDiffForCommit(HudiDataFileExtractor.java:133)
	at io.onetable.hudi.HudiClient.getTableChangeForCommit(HudiClient.java:123)
```

## Brief change log

- Filters out log files when retrieve removed base files;
- Adjust IT on Hudi savepoint and restore to cover this case.  Without the fix, the new test fails with MOR table.

## Verify this pull request

This change added tests as described above.