### PR TITLE
Fix google-java-format version mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
         <delta.version>2.4.0</delta.version>
         <jackson.version>2.14.2</jackson.version>
         <test.plugin.version>2.22.2</test.plugin.version>
-        <spotless.version>2.27.2</spotless.version>
-        <google.java.format.version>1.8</google.java.format.version>
+        <spotless.version>2.29.0</spotless.version>
+        <google.java.format.version>1.7</google.java.format.version>
         <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
         <delta.standalone.version>0.5.0</delta.standalone.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>


### PR DESCRIPTION

## Fix the issue of Google Java format version mismatch causing compilation failure

<img width="1364" alt="image" src="https://github.com/apache/incubator-xtable/assets/29206593/a2e36c22-fb4e-44f2-ba6c-97d1a4b200de">

