### PR TITLE
Reenable CI using Azure Pipelines

### DIFF
--- a/.azure-pipelines/workflows/azure_ci.js
+++ b/.azure-pipelines/workflows/azure_ci.js
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+async function checkAzureCiAndCreateCommitStatus({ github, context, prNumber, latestCommitHash }) {
+  console.log(`- Checking Azure CI status of PR: ${prNumber} ${latestCommitHash}`);
+  const botUsername = 'xtable-bot';
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: prNumber,
+    sort: 'updated',
+    direction: 'desc',
+    per_page: 100
+  });
+
+  // Find the latest comment from xtable-bot containing the Azure CI report
+  const botComments = comments.filter(comment => comment.user.login === botUsername);
+
+  let status = 'pending';
+  let message = 'In progress';
+  let azureRunLink = '';
+
+  if (botComments.length > 0) {
+    const lastComment = botComments[0];
+    const reportPrefix = `${latestCommitHash} Azure: `
+    const successReportString = `${reportPrefix}[SUCCESS]`
+    const failureReportString = `${reportPrefix}[FAILURE]`
+
+    if (lastComment.body.includes(reportPrefix)) {
+      if (lastComment.body.includes(successReportString)) {
+        message = 'Successful on the latest commit';
+        status = 'success';
+      } else if (lastComment.body.includes(failureReportString)) {
+        message = 'Failed on the latest commit';
+        status = 'failure';
+      }
+    }
+
+    const linkRegex = /\[[a-zA-Z]+\]\((https?:\/\/[^\s]+)\)/;
+    const parts = lastComment.body.split(reportPrefix);
+    const secondPart = parts.length > 1 ? parts[1] : '';
+    const match = secondPart.match(linkRegex);
+
+    if (match) {
+      azureRunLink = match[1];
+    }
+  }
+
+  console.log(`Status: ${status}`);
+  console.log(`Azure Run Link: ${azureRunLink}`);
+  console.log(`${message}`);
+
+  console.log(`- Create commit status of PR based on Azure CI status: ${prNumber} ${latestCommitHash}`);
+  // Create or update the commit status for Azure CI
+  await github.rest.repos.createCommitStatus({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    sha: latestCommitHash,
+    state: status,
+    target_url: azureRunLink,
+    description: message,
+    context: 'Azure CI'
+  });
+
+  return { status, message, azureRunLink };
+}
+
+module.exports = checkAzureCiAndCreateCommitStatus;

--- a/.azure-pipelines/workflows/azure_ci_check.yml
+++ b/.azure-pipelines/workflows/azure_ci_check.yml
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Azure CI
+
+on:
+  issue_comment:
+    types: [ created, edited, deleted ]
+
+permissions:
+  statuses: write
+  pull-requests: read
+  issues: read
+
+jobs:
+  check-azure-ci-and-add-commit-status:
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login == 'xtable-bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check PR state
+        id: check_pr_state
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: issueNumber
+            });
+            
+            // Only check open PRs and a PR that is not a HOTFIX
+            const shouldSkip = (pullRequest.body.includes('HOTFIX: SKIP AZURE CI')
+              || pullRequest.state != 'open');
+            
+            if (!shouldSkip) {
+              const commitHash = pullRequest.head.sha;
+              console.log(`Latest commit hash: ${commitHash}`);
+              // Set the output variable to be used in subsequent step
+              core.setOutput("latest_commit_hash", commitHash);
+            }
+            console.log(`Should skip Azure CI? ${shouldSkip}`);
+            return shouldSkip;
+
+      - name: Check Azure CI report and create commit status to PR
+        if: steps.check_pr_state.outputs.result != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const latestCommitHash = '${{ steps.check_pr_state.outputs.latest_commit_hash }}'            
+            const issueNumber = context.issue.number;
+            const checkAzureCiAndCreateCommitStatus = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/azure_ci.js`);
+            
+            await checkAzureCiAndCreateCommitStatus({
+              github,
+              context,
+              prNumber: issueNumber,
+              latestCommitHash: latestCommitHash
+            });

--- a/.azure-pipelines/workflows/maven.yml
+++ b/.azure-pipelines/workflows/maven.yml
@@ -1,11 +1,7 @@
 trigger:
-- main
-
-pr:
-  autoCancel: true
   branches:
     include:
-    - main
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository

--- a/.azure-pipelines/workflows/scheduled_workflow.yml
+++ b/.azure-pipelines/workflows/scheduled_workflow.yml
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Scheduled Workflow
+
+on:
+  schedule:
+    # Runs every 5 minutes
+    - cron: '*/5 * * * *'
+
+permissions:
+  statuses: write
+  pull-requests: read
+  issues: read
+
+jobs:
+  process-new-and-updated-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Process new and updated PRs
+        # We have to run any actions that require write permissions here
+        # since the workflow triggered by events from a PR in a fork
+        # (not apache/xtable but other_owner/xtable) does not run on a
+        # GITHUB_TOKEN with write permissions (this is prohibited by
+        # Apache).
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Cron schedule may not be reliable so giving buffer time to avoid missing recent PRs
+            const since = new Date(new Date().getTime() - (900 * 1000)).toISOString();
+            const query = `repo:${context.repo.owner}/${context.repo.repo} type:pr state:open base:master updated:>=${since}`;
+            const openPrs = await github.paginate(github.rest.search.issuesAndPullRequests, {
+              q: query,
+              sort: 'updated',
+              order: 'desc',
+              per_page: 100
+            });
+            
+            const checkAzureCiAndCreateCommitStatus = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/azure_ci.js`);
+            
+            console.log(`Number of PRs to process: ${openPrs.length}`);
+            
+            for (const pr of openPrs) {
+              console.log(`*** Processing PR: ${pr.title}, URL: ${pr.html_url}`);
+            
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              });
+              const latestCommitHash = pullRequest.head.sha;
+            
+              // Create commit status based on Azure CI report to PR
+              await checkAzureCiAndCreateCommitStatus({
+                github,
+                context,
+                prNumber: pr.number,
+                latestCommitHash: latestCommitHash
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OneTable
 
-[![Build Status](https://dev.azure.com/onetable-io/onetable-io/_apis/build/status%2Fonetable-io.onetable?branchName=main)](https://dev.azure.com/onetable-io/onetable-io/_build/latest?definitionId=1&branchName=main)
+[![Build Status](https://dev.azure.com/apache-xtable-ci-org/apache-xtable-ci/_apis/build/status%2Fapachextable-ci.xtable-mirror?branchName=main)](https://dev.azure.com/apache-xtable-ci-org/apache-xtable-ci/_build/latest?definitionId=2&branchName=main)
 
 OneTable is an omni-directional converter for table formats that facilitates interoperability across data processing systems
 and query engines.

--- a/ci.md
+++ b/ci.md
@@ -1,0 +1,68 @@
+# Guide on CI infrastructure
+
+## Context
+Apache XTable (incubating) uses Azure DevOps and Azure infrastructure for its CI, providing more flexibility by not being constrained to the Apache org's shared quota for CI. 
+This approach is similar to those adopted by Apache Flink and Apache Hudi communities.
+
+## Overview
+We have created [apachextable-ci](https://github.com/apachextable-ci) to manage all CI-related repositories:
+
+- [xtable-mirror](https://github.com/apachextable-ci/xtable-mirror): This repository mirrors the official repository (apache/incubator-xtable) to build commits merged into master and release-* branches.
+- [xtable-branch-ci](https://github.com/apachextable-ci/xtable-branch-ci): This repository is dedicated to building branches created PRs. Its main branch remains at the commit of the branch's creation and does not require synchronization with the official repository.
+
+The diagram below gives an overview of the infrastructure.
+
+!TODO
+
+
+## Azure VM
+We are running a B1s VM instance in this [Azure XTable account]().
+
+### Bootstrap Steps
+
+```sh
+sudo apt update -y
+sudo apt install -y git cron openjdk-8-jdk maven
+git clone git@github.com:apachextable-ci/git-repo-sync.git
+git clone git@github.com:apachextable-ci/ci-bot.git
+cd ci-bot
+mvn clean install
+```
+
+### Mirroring Master & Release Commits
+Use `crontab -e` to schedule the mirroring job, currently configured to mirror `main` and release commits to the `apachextable-ci` repository.
+
+```sh
+*/10 * * * * $HOME/git-repo-sync/sync_repo.sh > /dev/null 2>&1
+```
+
+### Scanning PRs and Triggering Branch Builds
+Run `$HOME/git-repo-sync/run_cibot.sh` to start the CI branch builds in the background.
+
+### Maintenance
+Manage the background process with `htop`.
+Typical maintenance steps include killing the process from `htop`, cleaning up `~/ci-bot.log`, and re-running the script.
+
+Check the expiry date of Azure and GitHub tokens and update them accordingly. They are used in `$HOME/git-repo-sync/run_cibot.sh`.
+
+### Potential Issues
+- Mirrored repositories (e.g., master, release-*) not being pushed, leading to failure in mirrored CI execution.
+	- Issues with `git fetch` or `push` in `$HOME/git-repo-sync/sync_repo.sh`. Manually execute the git commands and troubleshoot as needed.
+
+## Azure Pipelines
+There are two pipelines defined in this [Azure DevOps project](https://dev.azure.com/apache-xtable-ci-org/apache-xtable-ci).
+
+- xtable-mirror: for master/release version builds
+- xtable-branch-ci: for PR builds
+
+For each `xtable-branch-ci` build, xtable-bot will post and update comments on its corresponding PR as follows.
+
+!TODO
+
+PR reviewers should consider the results of this CI report as one of the merging criteria.
+
+### Get Help
+- Azure DevOps docs:
+	- [Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/?view=azure-devops).
+	- [Troubleshooting](https://docs.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/troubleshooting?view=azure-devops).
+- For community support, raise questions on [developercommunity.visualstudio.com](https://developercommunity.visualstudio.com/).


### PR DESCRIPTION
## What is the purpose of the pull request

The project used Azure Pipelines to run build and test workflow before migrating to ASF infrastructure.
This PR will reenable the pipeline (see #363 for more details, including details on Azure Pipelines not being natively supported in ASF infrastructure).

## Brief change log

- Creates documentation for CI setup.
- Updates status badge in README.md.
- Creates workflows for PR status update.

## Verify this pull request

- This PR is still work in progress.