### PR TITLE
Upgrade spotless-maven-plugin from 2.27.2 to 2.43.0

### DIFF
--- a/core/src/main/java/io/onetable/delta/DeltaSourceClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaSourceClient.java
@@ -41,6 +41,7 @@ import org.apache.spark.sql.delta.actions.AddFile;
 import org.apache.spark.sql.delta.actions.RemoveFile;
 
 import scala.Option;
+
 import io.delta.tables.DeltaTable;
 
 import io.onetable.exception.OneIOException;

--- a/core/src/test/java/io/onetable/delta/TestDeltaSync.java
+++ b/core/src/test/java/io/onetable/delta/TestDeltaSync.java
@@ -62,6 +62,7 @@ import org.apache.spark.sql.delta.GeneratedColumn;
 
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
+
 import io.delta.standalone.DeltaLog;
 import io.delta.standalone.DeltaScan;
 import io.delta.standalone.Snapshot;

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <delta.version>2.4.0</delta.version>
         <jackson.version>2.14.2</jackson.version>
         <test.plugin.version>2.22.2</test.plugin.version>
-        <spotless.version>2.27.2</spotless.version>
+        <spotless.version>2.43.0</spotless.version>
         <google.java.format.version>1.8</google.java.format.version>
         <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
         <delta.standalone.version>0.5.0</delta.standalone.version>
@@ -533,7 +533,7 @@
                             <groupArtifact>com.google.googlejavaformat:google-java-format</groupArtifact>
                         </googleJavaFormat>
                         <importOrder>
-                            <order>java,javax,org,org.apache.hudi,org.apache.iceberg,org.apache.spark.sql.delta,com,io.onetable</order>
+                            <order>java,javax,lombok,org,org.apache.hudi,org.apache.iceberg,org.apache.spark.sql.delta,scala,com,io.delta,io.onetable</order>
                         </importOrder>
                         <removeUnusedImports/>
                         <licenseHeader>


### PR DESCRIPTION
## What is the purpose of the pull request

Upgrade spotless-maven-plugin to latest to benefit from recent fixes and improvements.

## Brief change log

- Upgrade spotless-maven-plugin from 2.27.2 to 2.43.0
- Add some additional import order rules to retain the existing order and avoid having a large diff due to fixes/changes in the plugin. If a different order is desired then it can be done in a separate commit.
- Add missing spaces between scala and io imports in 2 files.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.
