### PR TITLE
Create .asf.yaml file

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,6 +33,10 @@ github:
     # We prefer linear history, so creating merge commits is disabled in UI
     merge:   false
     rebase:  true
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
 notifications:
     commits:      commits@xtable.apache.org
     issues:       commits@xtable.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+github:
+  description: "Apache XTable (incubating) is a cross-table converter for lakehouse table formats that facilitates interoperability across data processing systems and query engines."
+  homepage: https://xtable.apache.org/
+  labels:
+    - apache-iceberg
+    - apache-hudi
+    - delta-lake
+  features:
+    wiki: false
+    issues: true
+    projects: true
+    discussions: true
+  enabled_merge_buttons:
+    # "squash and merge" replaces committer with noreply@github, and we don't want that
+    # See https://lists.apache.org/thread/vxxpt1x316kjryb4dptsbs95p66d9xrv
+    squash:  false
+    # We prefer linear history, so creating merge commits is disabled in UI
+    merge:   false
+    rebase:  true
+notifications:
+    commits:      commits@xtable.apache.org
+    issues:       commits@xtable.apache.org
+    pullrequests: commits@xtable.apache.org


### PR DESCRIPTION
## What is the purpose of the pull request

This PR creates the .asf.yaml file for the project. More information about the supported options can be found here: https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
The current options basically preserve the behavior that was enabled before the transfer to the ASF organization.
