### PR TITLE
[377] updated urls to apache site

### DIFF
--- a/website/blog/OneTable-is-now-Apache-XTable.md
+++ b/website/blog/OneTable-is-now-Apache-XTable.md
@@ -54,7 +54,7 @@ the public good.
 marginRight:'auto', marginTop:'18pt', marginBottom:'18pt'}} />
 
 For those interested in exploring Apache XTable™, the official website is a good starting point. The documentation 
-section hosts a great hands-on [quickstart](https://onetable.dev/docs/how-to) guide to getting acquainted with XTable, 
+section hosts a great hands-on [quickstart](https://xtable.apache.org/docs/how-to) guide to getting acquainted with XTable, 
 providing a straightforward way to experience its interoperability capabilities firsthand. If you have specific ideas, 
 questions, or seek direct interaction, the [discussions](https://github.com/apache/incubator-xtable/discussions) section 
 is available for more in-depth exchanges. We invite you to contribute to the project by submitting pull requests or 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,12 +8,12 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Apache XTable™ (Incubating)',
   favicon: 'images/xtable-favicon.png',
-  url: 'https://onetable.dev',
+  url: 'https://xtable.apache.org',
   baseUrl: '/',
 
   // GitHub pages deployment config.
-  organizationName: 'onetable-io',
-  projectName: 'onetable',
+  organizationName: 'apache',
+  projectName: 'incubator-xtable',
 
   onBrokenLinks: 'ignore',
   onBrokenMarkdownLinks: 'warn',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,1 +1,1 @@
-onetable.dev
+xtable.apache.org

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -32,8 +32,8 @@
       <a href="#" class="brand w-nav-brand"><img src="images/xtable-white.png" loading="lazy" alt="" class="nav-logo"></a>
       <nav role="navigation" class="nav-menu w-nav-menu">
         <a href="#" class="nav-link w-nav-link">Home</a>
-        <a href="https://onetable.dev/docs/setup/" class="nav-link w-nav-link">Docs</a>
-        <a href="https://onetable.dev/blog" class="nav-link w-nav-link">Blogs</a><img src="images/break.svg" loading="lazy" alt="" class="image-10">
+        <a href="https://xtable.apache.org/docs/setup/" class="nav-link w-nav-link">Docs</a>
+        <a href="https://xtable.apache.org/blog" class="nav-link w-nav-link">Blogs</a><img src="images/break.svg" loading="lazy" alt="" class="image-10">
         <a href="https://github.com/apache/incubator-xtable" class="nav-icon-link1 w-inline-block"><img src="images/Github.svg" loading="lazy" alt=""></a>
         <a href="https://www.linkedin.com/company/apache-xtable/" class="nav-icon-link1 w-inline-block"><img src="images/linkedin.svg" loading="lazy" alt=""></a>
         <a href="https://twitter.com/apachextable" class="nav-icon-link1 w-inline-block"><img src="images/twitter.svg" loading="lazy" alt=""></a>
@@ -48,8 +48,8 @@
       <a href="#" class="brand-copy w-nav-brand"><img src="images/xtable-white.png" loading="lazy" alt="" class="nav-logo-copy"></a>
       <nav role="navigation" class="nav-menu-copy w-nav-menu">
         <a href="#" class="nav-link-copy w-nav-link">Home</a>
-        <a href="https://onetable.dev/docs/setup/" class="nav-link-copy w-nav-link">Docs</a>
-        <a href="https://onetable.dev/blog" class="nav-link-copy w-nav-link">Blogs</a>
+        <a href="https://xtable.apache.org/docs/setup/" class="nav-link-copy w-nav-link">Docs</a>
+        <a href="https://xtable.apache.org/blog" class="nav-link-copy w-nav-link">Blogs</a>
         <a href="https://github.com/apache/incubator-xtable" class="nav-link-copy w-nav-link">GitHub</a>
         <a href="#" class="nav-link-copy w-nav-link">LinkedIn</a>
         <a href="#" class="nav-link-copy w-nav-link">Twitter</a>
@@ -66,7 +66,7 @@
         <div class="hero-textblock">Seamlessly interoperate cross-table between Apache Hudi, Delta Lake, and Apache Iceberg</div>
         <div class="button-group">
           <a href="https://github.com/apache/incubator-xtable" class="primary-button w-button">Try it on GitHub</a>
-          <a href="https://onetable.dev/docs/setup/" class="secondary-button w-button">Learn More</a>
+          <a href="https://xtable.apache.org/docs/setup/" class="secondary-button w-button">Learn More</a>
         </div>
       </div>
       <div class="right-hero"><img src="images/xtable-hero.svg" loading="lazy" alt="" class="hero-image"></div>
@@ -213,7 +213,7 @@
     <div class="main-container-footer">
       <div class="div-block-25"><img src="images/xtable-white.png" loading="lazy" alt="" class="image-8"></div>
       <div class="footer-block-three">
-        <a href="https://onetable.dev/docs/setup/" class="footer-link-three">Docs</a>
+        <a href="https://xtable.apache.org/docs/setup/" class="footer-link-three">Docs</a>
         <a href="https://github.com/apache/incubator-xtable" class="footer-link-three">GitHub</a>
         <a href="https://www.linkedin.com/company/apache-xtable/" class="footer-link-three">LinkedIn</a>
         <a href="https://twitter.com/apachextable" class="footer-link-three l">Twitter</a>


### PR DESCRIPTION
## What is the purpose of the pull request

From [377](https://github.com/apache/incubator-xtable/issues/377), I updated all references to onetable.dev to point to xtable.apache.org.

@jcamachor can you double check that the cname is ok? Also in the docusaurus it references the ghpages project. Can you let me know if that looks ok?

## Brief change log

- updated url references
- updated cname
- updated docusaurus config

## Verify this pull request

I built and verified the site following the website readme