### PR TITLE
Make build depend on Apache Maven Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,17 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>org.apache.xtable</groupId>
     <artifactId>xtable</artifactId>
     <name>xtable</name>
+
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>31</version>
+    </parent>
+
     <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -32,13 +40,9 @@
         <iceberg.version>1.4.2</iceberg.version>
         <delta.version>2.4.0</delta.version>
         <jackson.version>2.14.2</jackson.version>
-        <test.plugin.version>2.22.2</test.plugin.version>
         <spotless.version>2.43.0</spotless.version>
         <google.java.format.version>1.8</google.java.format.version>
-        <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
         <delta.standalone.version>0.5.0</delta.standalone.version>
-        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-        <maven-shade-plugin.version>3.4.0</maven-shade-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Test properties -->
         <skipTests>false</skipTests>
@@ -431,7 +435,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>${maven-shade-plugin.version}</version>
                     <executions>
                         <execution>
                             <phase>package</phase>
@@ -463,7 +466,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-logging</id>
@@ -486,7 +488,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${java.version}</release>
                 </configuration>
@@ -494,7 +495,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${test.plugin.version}</version>
                 <configuration>
                     <skip>${skipUTs}</skip>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -504,7 +504,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${test.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION

## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

This will simplify maven plugin maintenance so we don't need to update plugins independently to be up to date.
Maven plugin dependencies will be updated by upgrading the parent POM version.

This also removes warnings for non pinned plugin versions and updates some of them.

## Brief change log

- *Added parent pom to root project*
- *Remove explicit plugin versions*

## Verify this pull request

This pull request is already covered by existing tests.
