### PR TITLE
Fix broken links after move to Apache and rename from onetable (#384)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For setting up the repo on IntelliJ, open the project and change the java versio
 You have found a bug, or have a cool idea you that want to contribute to the project ? Please file a GitHub issue [here](https://github.com/apache/incubator-xtable/issues)
 
 ## Adding a new target format
-Adding a new target format requires a developer implement [TargetClient](./api/src/main/java/io/onetable/spi/sync/TargetClient.java). Once you have implemented that interface, you can integrate it into the [OneTableClient](./core/src/main/java/io/onetable/client/OneTableClient.java). If you think others may find that target useful, please raise a Pull Request to add it to the project.
+Adding a new target format requires a developer implement [TargetClient](./api/src/main/java/org/apache/xtable/spi/sync/TargetClient.java). Once you have implemented that interface, you can integrate it into the [OneTableClient](./core/src/main/java/org/apache/xtable/client/OneTableClient.java). If you think others may find that target useful, please raise a Pull Request to add it to the project.
 
 ## Overview of the sync process
 ![img.png](assets/images/sync_flow.jpg)

--- a/core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
+++ b/core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
@@ -61,7 +61,7 @@ public class DeltaActionsConverter {
             : Collections.emptyList();
     long recordCount =
         columnStats.stream().map(ColumnStat::getNumValues).max(Long::compareTo).orElse(0L);
-    // TODO(https://github.com/onetable-io/onetable/issues/102): removed record count.
+    // TODO(https://github.com/apache/incubator-xtable/issues/102): removed record count.
     return OneDataFile.builder()
         .physicalPath(getFullPathToFile(deltaSnapshot, addFile.path()))
         .fileFormat(fileFormat)

--- a/core/src/main/java/org/apache/xtable/delta/DeltaIncrementalChangesState.java
+++ b/core/src/main/java/org/apache/xtable/delta/DeltaIncrementalChangesState.java
@@ -51,8 +51,6 @@ public class DeltaIncrementalChangesState {
    */
   @Builder
   public DeltaIncrementalChangesState(DeltaLog deltaLog, Long versionToStartFrom) {
-    // TODO (https://github.com/onetable-io/onetable/issues/103) Fall back to snapshot sync in
-    // vacuum cases.
     List<Tuple2<Long, List<Action>>> changesList =
         getChangesList(deltaLog.getChanges(versionToStartFrom, false));
     Long maxSeenVersion = null;

--- a/core/src/test/java/org/apache/xtable/delta/ITDeltaSourceClient.java
+++ b/core/src/test/java/org/apache/xtable/delta/ITDeltaSourceClient.java
@@ -317,7 +317,6 @@ public class ITDeltaSourceClient {
     DeltaSourceClient client = clientProvider.getSourceClientInstance(tableConfig);
     // Get current snapshot
     OneSnapshot snapshot = client.getCurrentSnapshot();
-    // TODO: Complete and enable test (see https://github.com/onetable-io/onetable/issues/90)
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/xtable/testutil/Issues.java
+++ b/core/src/test/java/org/apache/xtable/testutil/Issues.java
@@ -20,6 +20,6 @@ package org.apache.xtable.testutil;
 
 public class Issues {
 
-  /** Refer to <a href="https://github.com/onetable-io/onetable/issues/102">GitHub #102</a> */
+  /** Refer to <a href="https://github.com/apache/incubator-xtable/issues/102">GitHub #102</a> */
   public static final boolean ISSUE_102_FIXED = false;
 }


### PR DESCRIPTION

## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

This fixes some URL breakage produced by #374

## Brief change log

- *Update URLs to the new package structure*
- *Remove TODOs with URLs for already fixed issues*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is already covered by existing tests

