### PR TITLE
Refactor: rename classes to fix the prefix

### DIFF
--- a/api/src/main/java/org/apache/xtable/model/InternalSnapshot.java
+++ b/api/src/main/java/org/apache/xtable/model/InternalSnapshot.java
@@ -26,7 +26,7 @@ import lombok.Builder;
 import lombok.Value;
 
 import org.apache.xtable.model.schema.SchemaCatalog;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 
 /**
  * Snapshot represents the view of the table at a specific point in time. Snapshot captures all the
@@ -43,11 +43,11 @@ public class InternalSnapshot {
   // The instant of the Snapshot
   String version;
   // Table reference
-  OneTable table;
+  InternalTable table;
   // Schema catalog referencing the written schema for each data file in the snapshot
   SchemaCatalog schemaCatalog;
   // Data files grouped by partition
-  List<OneFileGroup> partitionedDataFiles;
+  List<PartitionFileGroup> partitionedDataFiles;
   // pending commits before latest commit on the table.
   @Builder.Default List<Instant> pendingCommits = Collections.emptyList();
 }

--- a/api/src/main/java/org/apache/xtable/model/InternalTable.java
+++ b/api/src/main/java/org/apache/xtable/model/InternalTable.java
@@ -35,7 +35,7 @@ import org.apache.xtable.model.storage.DataLayoutStrategy;
  */
 @Value
 @Builder(toBuilder = true)
-public class OneTable {
+public class InternalTable {
   // name of the table
   String name;
   // table format the table currently has data in

--- a/api/src/main/java/org/apache/xtable/model/TableChange.java
+++ b/api/src/main/java/org/apache/xtable/model/TableChange.java
@@ -34,6 +34,6 @@ public class TableChange {
   // Change in files at the specified instant
   DataFilesDiff filesDiff;
 
-  /** The {@link OneTable} at the commit time to which this table change belongs. */
-  OneTable tableAsOfChange;
+  /** The {@link InternalTable} at the commit time to which this table change belongs. */
+  InternalTable tableAsOfChange;
 }

--- a/api/src/main/java/org/apache/xtable/model/TableSyncMetadata.java
+++ b/api/src/main/java/org/apache/xtable/model/TableSyncMetadata.java
@@ -30,9 +30,13 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
+/**
+ * Metadata representing the state of a table sync process. This metadata is stored in the target
+ * table's properties and is used to track the status of previous sync operation.
+ */
 @AllArgsConstructor(staticName = "of")
 @Value
-public class OneTableMetadata {
+public class TableSyncMetadata {
   /**
    * Property name for the lastInstantSynced field from SyncResult, used for persisting
    * lastInstantSynced in the table metadata/properties
@@ -57,7 +61,7 @@ public class OneTableMetadata {
     return map;
   }
 
-  public static Optional<OneTableMetadata> fromMap(Map<String, String> properties) {
+  public static Optional<TableSyncMetadata> fromMap(Map<String, String> properties) {
     if (properties != null) {
       Instant lastInstantSynced = null;
       List<Instant> instantsToConsiderForNextSync = null;
@@ -70,7 +74,7 @@ public class OneTableMetadata {
                 properties.get(INFLIGHT_COMMITS_TO_CONSIDER_FOR_NEXT_SYNC_PROP));
       }
       return Optional.ofNullable(
-          OneTableMetadata.of(lastInstantSynced, instantsToConsiderForNextSync));
+          TableSyncMetadata.of(lastInstantSynced, instantsToConsiderForNextSync));
     }
     return Optional.empty();
   }

--- a/api/src/main/java/org/apache/xtable/model/exception/ErrorCode.java
+++ b/api/src/main/java/org/apache/xtable/model/exception/ErrorCode.java
@@ -18,19 +18,22 @@
  
 package org.apache.xtable.model.exception;
 
-import lombok.ToString;
+import lombok.Getter;
 
-@ToString
-public class OneTableException extends RuntimeException {
-  private final OneTableErrorCode errorCode;
+@Getter
+public enum ErrorCode {
+  INVALID_CONFIGURATION(10001),
+  INVALID_PARTITION_SPEC(10002),
+  INVALID_PARTITION_VALUE(10003),
+  IO_EXCEPTION(10004),
+  INVALID_SCHEMA(10005),
+  UNSUPPORTED_SCHEMA_TYPE(10006),
+  UNSUPPORTED_FEATURE(10007),
+  PARSE_EXCEPTION(10008);
 
-  protected OneTableException(OneTableErrorCode errorCode, String message, Throwable e) {
-    super(message, e);
-    this.errorCode = errorCode;
-  }
+  private final int errorCode;
 
-  protected OneTableException(OneTableErrorCode errorCode, String message) {
-    super(message);
+  ErrorCode(int errorCode) {
     this.errorCode = errorCode;
   }
 }

--- a/api/src/main/java/org/apache/xtable/model/exception/InternalException.java
+++ b/api/src/main/java/org/apache/xtable/model/exception/InternalException.java
@@ -18,12 +18,19 @@
  
 package org.apache.xtable.model.exception;
 
-public class OneParseException extends OneTableException {
-  public OneParseException(String message, Throwable e) {
-    super(OneTableErrorCode.PARSE_EXCEPTION, message, e);
+import lombok.ToString;
+
+@ToString
+public class InternalException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  protected InternalException(ErrorCode errorCode, String message, Throwable e) {
+    super(message, e);
+    this.errorCode = errorCode;
   }
 
-  public OneParseException(String message) {
-    super(OneTableErrorCode.PARSE_EXCEPTION, message);
+  protected InternalException(ErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
   }
 }

--- a/api/src/main/java/org/apache/xtable/model/exception/ParseException.java
+++ b/api/src/main/java/org/apache/xtable/model/exception/ParseException.java
@@ -18,23 +18,13 @@
  
 package org.apache.xtable.model.exception;
 
-public enum OneTableErrorCode {
-  INVALID_CONFIGURATION(10001),
-  INVALID_PARTITION_SPEC(10002),
-  INVALID_PARTITION_VALUE(10003),
-  IO_EXCEPTION(10004),
-  INVALID_SCHEMA(10005),
-  UNSUPPORTED_SCHEMA_TYPE(10006),
-  UNSUPPORTED_FEATURE(10007),
-  PARSE_EXCEPTION(10008);
-
-  private final int errorCode;
-
-  OneTableErrorCode(int errorCode) {
-    this.errorCode = errorCode;
+/** Exception thrown when there is a parsing error, for e.g. parsing a date string. */
+public class ParseException extends InternalException {
+  public ParseException(String message, Throwable e) {
+    super(ErrorCode.PARSE_EXCEPTION, message, e);
   }
 
-  public int getErrorCode() {
-    return errorCode;
+  public ParseException(String message) {
+    super(ErrorCode.PARSE_EXCEPTION, message);
   }
 }

--- a/api/src/main/java/org/apache/xtable/model/storage/FilesDiff.java
+++ b/api/src/main/java/org/apache/xtable/model/storage/FilesDiff.java
@@ -93,7 +93,7 @@ public class FilesDiff<L, P> {
    * @return the set of files that are added
    */
   public static <P> FilesDiff<InternalDataFile, P> findNewAndRemovedFiles(
-      List<OneFileGroup> latestFileGroups, Map<String, P> previousFiles) {
+      List<PartitionFileGroup> latestFileGroups, Map<String, P> previousFiles) {
     Map<String, InternalDataFile> latestFiles =
         latestFileGroups.stream()
             .flatMap(group -> group.getFiles().stream())

--- a/api/src/main/java/org/apache/xtable/model/storage/PartitionFileGroup.java
+++ b/api/src/main/java/org/apache/xtable/model/storage/PartitionFileGroup.java
@@ -31,21 +31,21 @@ import org.apache.xtable.model.stat.PartitionValue;
 /** Represents a grouping of {@link InternalDataFile} with the same partition values. */
 @Value
 @Builder
-public class OneFileGroup {
+public class PartitionFileGroup {
   List<PartitionValue> partitionValues;
   List<InternalDataFile> files;
 
-  public static List<OneFileGroup> fromFiles(List<InternalDataFile> files) {
+  public static List<PartitionFileGroup> fromFiles(List<InternalDataFile> files) {
     return fromFiles(files.stream());
   }
 
-  public static List<OneFileGroup> fromFiles(Stream<InternalDataFile> files) {
+  public static List<PartitionFileGroup> fromFiles(Stream<InternalDataFile> files) {
     Map<List<PartitionValue>, List<InternalDataFile>> filesGrouped =
         files.collect(Collectors.groupingBy(InternalDataFile::getPartitionValues));
     return filesGrouped.entrySet().stream()
         .map(
             entry ->
-                OneFileGroup.builder()
+                PartitionFileGroup.builder()
                     .partitionValues(entry.getKey())
                     .files(entry.getValue())
                     .build())

--- a/api/src/main/java/org/apache/xtable/model/validation/ValidationChecker.java
+++ b/api/src/main/java/org/apache/xtable/model/validation/ValidationChecker.java
@@ -20,16 +20,16 @@ package org.apache.xtable.model.validation;
 
 import java.util.Map;
 
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.storage.TableFormat;
 
 /**
  * Interface to implement a validation checker. Runs the specified list of {@link ValidationCheck}
- * on the {@link OneTable} using the specified {@link TableFormat}
+ * on the {@link InternalTable} using the specified {@link TableFormat}
  *
  * @since 0.1
  */
 public interface ValidationChecker {
   Map<ValidationCheck, ValidationResult> validate(
-      OneTable table, TableFormat tableFormat, ValidationCheck[] checks);
+      InternalTable table, TableFormat tableFormat, ValidationCheck[] checks);
 }

--- a/api/src/main/java/org/apache/xtable/spi/extractor/SourceClient.java
+++ b/api/src/main/java/org/apache/xtable/spi/extractor/SourceClient.java
@@ -24,7 +24,7 @@ import java.time.Instant;
 import org.apache.xtable.model.CommitsBacklog;
 import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
 import org.apache.xtable.model.schema.SchemaCatalog;
 
@@ -35,12 +35,12 @@ import org.apache.xtable.model.schema.SchemaCatalog;
  */
 public interface SourceClient<COMMIT> extends Closeable {
   /**
-   * Extracts the {@link OneTable} definition as of the provided commit.
+   * Extracts the {@link InternalTable} definition as of the provided commit.
    *
    * @param commit the commit to consider for reading the table state
    * @return the table definition
    */
-  OneTable getTable(COMMIT commit);
+  InternalTable getTable(COMMIT commit);
 
   /**
    * Extracts the {@link SchemaCatalog} as of the provided instant.
@@ -49,7 +49,7 @@ public interface SourceClient<COMMIT> extends Closeable {
    * @param commit the commit to consider for reading the schema catalog
    * @return the schema catalog
    */
-  SchemaCatalog getSchemaCatalog(OneTable table, COMMIT commit);
+  SchemaCatalog getSchemaCatalog(InternalTable table, COMMIT commit);
 
   /**
    * Extracts the {@link InternalSnapshot} as of latest state.

--- a/api/src/main/java/org/apache/xtable/spi/extractor/TableExtractor.java
+++ b/api/src/main/java/org/apache/xtable/spi/extractor/TableExtractor.java
@@ -18,13 +18,13 @@
  
 package org.apache.xtable.spi.extractor;
 
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 
 /**
- * Extracts {@link OneTable} from given {@link CLIENT}.
+ * Extracts {@link InternalTable} from given {@link CLIENT}.
  *
  * @param <CLIENT> Extracts canonical table model from table client.
  */
 public interface TableExtractor<CLIENT> {
-  OneTable table(CLIENT tableServiceClient);
+  InternalTable table(CLIENT tableServiceClient);
 }

--- a/api/src/main/java/org/apache/xtable/spi/sync/TargetClient.java
+++ b/api/src/main/java/org/apache/xtable/spi/sync/TargetClient.java
@@ -24,12 +24,12 @@ import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 
 import org.apache.xtable.client.PerTableConfig;
-import org.apache.xtable.model.OneTable;
-import org.apache.xtable.model.OneTableMetadata;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.TableSyncMetadata;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.storage.DataFilesDiff;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 
 /** A client that provides the major functionality for syncing changes to a target system. */
 public interface TargetClient {
@@ -49,12 +49,12 @@ public interface TargetClient {
   void syncPartitionSpec(List<InternalPartitionField> partitionSpec);
 
   /**
-   * Syncs the {@link OneTableMetadata} to the target for tracking metadata between runs. This is
+   * Syncs the {@link TableSyncMetadata} to the target for tracking metadata between runs. This is
    * required for incremental sync.
    *
    * @param metadata the current metadata
    */
-  void syncMetadata(OneTableMetadata metadata);
+  void syncMetadata(TableSyncMetadata metadata);
 
   /**
    * Syncs the provided snapshot files to the target system. This method is required to both add and
@@ -62,7 +62,7 @@ public interface TargetClient {
    *
    * @param partitionedDataFiles the files to sync, grouped by partition
    */
-  void syncFilesForSnapshot(List<OneFileGroup> partitionedDataFiles);
+  void syncFilesForSnapshot(List<PartitionFileGroup> partitionedDataFiles);
 
   /**
    * Syncs the changes in files to the target system. This method is required to both add and remove
@@ -77,13 +77,13 @@ public interface TargetClient {
    *
    * @param table the table that will be synced
    */
-  void beginSync(OneTable table);
+  void beginSync(InternalTable table);
 
   /** Completes the sync and performs any cleanup required. */
   void completeSync();
 
   /** Returns the onetable metadata persisted in the target */
-  Optional<OneTableMetadata> getTableMetadata();
+  Optional<TableSyncMetadata> getTableMetadata();
 
   /** Returns the TableFormat name the client syncs to */
   String getTableFormat();

--- a/api/src/test/java/org/apache/xtable/model/storage/TestFilesDiff.java
+++ b/api/src/test/java/org/apache/xtable/model/storage/TestFilesDiff.java
@@ -38,8 +38,9 @@ public class TestFilesDiff {
     InternalDataFile file1Group2 = InternalDataFile.builder().physicalPath("file1Group2").build();
     InternalDataFile file2Group2 = InternalDataFile.builder().physicalPath("file2Group2").build();
 
-    List<OneFileGroup> latestFileGroups =
-        OneFileGroup.fromFiles(Arrays.asList(file1Group1, file2Group1, file1Group2, file2Group2));
+    List<PartitionFileGroup> latestFileGroups =
+        PartitionFileGroup.fromFiles(
+            Arrays.asList(file1Group1, file2Group1, file1Group2, file2Group2));
 
     Map<String, File> previousFiles = new HashMap<>();
     File file1 = mock(File.class);

--- a/api/src/test/java/org/apache/xtable/spi/extractor/TestExtractFromSource.java
+++ b/api/src/test/java/org/apache/xtable/spi/extractor/TestExtractFromSource.java
@@ -39,21 +39,21 @@ import org.apache.xtable.model.CommitsBacklog;
 import org.apache.xtable.model.IncrementalTableChanges;
 import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
 import org.apache.xtable.model.schema.SchemaCatalog;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.InternalDataFile;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 
 public class TestExtractFromSource {
   private final SourceClient<TestCommit> mockSourceClient = mock(SourceClient.class);
 
   @Test
   public void extractSnapshot() {
-    OneTable table = OneTable.builder().latestCommitTime(Instant.now()).build();
+    InternalTable table = InternalTable.builder().latestCommitTime(Instant.now()).build();
     SchemaCatalog schemaCatalog = new SchemaCatalog(Collections.emptyMap());
-    List<OneFileGroup> dataFiles = Collections.emptyList();
+    List<PartitionFileGroup> dataFiles = Collections.emptyList();
     InternalSnapshot internalSnapshot =
         InternalSnapshot.builder()
             .schemaCatalog(schemaCatalog)
@@ -85,8 +85,8 @@ public class TestExtractFromSource {
 
     // drop a file and add a file
     InternalDataFile newFile1 = getDataFile("file4.parquet");
-    OneTable tableAtFirstInstant =
-        OneTable.builder().latestCommitTime(Instant.now().minus(1, ChronoUnit.DAYS)).build();
+    InternalTable tableAtFirstInstant =
+        InternalTable.builder().latestCommitTime(Instant.now().minus(1, ChronoUnit.DAYS)).build();
     TableChange tableChangeToReturnAtFirstInstant =
         TableChange.builder()
             .tableAsOfChange(tableAtFirstInstant)
@@ -106,7 +106,8 @@ public class TestExtractFromSource {
     InternalDataFile newFile2 = getDataFile("file5.parquet");
     InternalDataFile newFile3 = getDataFile("file6.parquet");
 
-    OneTable tableAtSecondInstant = OneTable.builder().latestCommitTime(Instant.now()).build();
+    InternalTable tableAtSecondInstant =
+        InternalTable.builder().latestCommitTime(Instant.now()).build();
     TableChange tableChangeToReturnAtSecondInstant =
         TableChange.builder()
             .tableAsOfChange(tableAtSecondInstant)

--- a/core/src/main/java/org/apache/xtable/constants/OneTableConstants.java
+++ b/core/src/main/java/org/apache/xtable/constants/OneTableConstants.java
@@ -30,6 +30,6 @@ public class OneTableConstants {
    */
   public static final Integer NUM_ARCHIVED_SYNCS_RESULTS = 10;
 
-  /** OneTable meta directory inside table base path to store sync info. */
+  /** InternalTable meta directory inside table base path to store sync info. */
   public static final String ONETABLE_META_DIR = ".onetable";
 }

--- a/core/src/main/java/org/apache/xtable/delta/DeltaClient.java
+++ b/core/src/main/java/org/apache/xtable/delta/DeltaClient.java
@@ -56,12 +56,12 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.xtable.client.PerTableConfig;
 import org.apache.xtable.exception.NotSupportedException;
-import org.apache.xtable.model.OneTable;
-import org.apache.xtable.model.OneTableMetadata;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.TableSyncMetadata;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.storage.DataFilesDiff;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 import org.apache.xtable.model.storage.TableFormat;
 import org.apache.xtable.spi.sync.TargetClient;
 
@@ -148,7 +148,7 @@ public class DeltaClient implements TargetClient {
   }
 
   @Override
-  public void beginSync(OneTable table) {
+  public void beginSync(InternalTable table) {
     this.transactionState =
         new TransactionState(deltaLog, tableName, table.getLatestCommitTime(), logRetentionInHours);
   }
@@ -174,12 +174,12 @@ public class DeltaClient implements TargetClient {
   }
 
   @Override
-  public void syncMetadata(OneTableMetadata metadata) {
+  public void syncMetadata(TableSyncMetadata metadata) {
     transactionState.setMetadata(metadata);
   }
 
   @Override
-  public void syncFilesForSnapshot(List<OneFileGroup> partitionedDataFiles) {
+  public void syncFilesForSnapshot(List<PartitionFileGroup> partitionedDataFiles) {
     transactionState.setActions(
         dataFileUpdatesExtractor.applySnapshot(
             deltaLog, partitionedDataFiles, transactionState.getLatestSchemaInternal()));
@@ -201,8 +201,8 @@ public class DeltaClient implements TargetClient {
   }
 
   @Override
-  public Optional<OneTableMetadata> getTableMetadata() {
-    return OneTableMetadata.fromMap(
+  public Optional<TableSyncMetadata> getTableMetadata() {
+    return TableSyncMetadata.fromMap(
         JavaConverters.mapAsJavaMapConverter(deltaLog.snapshot().metadata().configuration())
             .asJava());
   }
@@ -223,7 +223,7 @@ public class DeltaClient implements TargetClient {
     private final String tableName;
     @Getter private StructType latestSchema;
     @Getter private InternalSchema latestSchemaInternal;
-    @Setter private OneTableMetadata metadata;
+    @Setter private TableSyncMetadata metadata;
     @Setter private Seq<Action> actions;
 
     private TransactionState(

--- a/core/src/main/java/org/apache/xtable/delta/DeltaDataFileUpdatesExtractor.java
+++ b/core/src/main/java/org/apache/xtable/delta/DeltaDataFileUpdatesExtractor.java
@@ -42,7 +42,7 @@ import org.apache.xtable.model.stat.ColumnStat;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.FilesDiff;
 import org.apache.xtable.model.storage.InternalDataFile;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 import org.apache.xtable.paths.PathUtils;
 
 @Builder
@@ -59,7 +59,9 @@ public class DeltaDataFileUpdatesExtractor {
       DeltaDataFileExtractor.builder().build();
 
   public Seq<Action> applySnapshot(
-      DeltaLog deltaLog, List<OneFileGroup> partitionedDataFiles, InternalSchema tableSchema) {
+      DeltaLog deltaLog,
+      List<PartitionFileGroup> partitionedDataFiles,
+      InternalSchema tableSchema) {
 
     // all files in the current delta snapshot are potential candidates for remove actions, i.e. if
     // the file is not present in the new snapshot (addedFiles) then the file is considered removed

--- a/core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
+++ b/core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
@@ -45,7 +45,7 @@ import org.apache.xtable.model.schema.InternalType;
 import org.apache.xtable.schema.SchemaUtils;
 
 /**
- * Converts between Delta and OneTable schemas. Some items to be aware of:
+ * Converts between Delta and InternalTable schemas. Some items to be aware of:
  *
  * <ul>
  *   <li>Delta schemas are represented as Spark StructTypes which do not have enums so the enum

--- a/core/src/main/java/org/apache/xtable/delta/DeltaTableExtractor.java
+++ b/core/src/main/java/org/apache/xtable/delta/DeltaTableExtractor.java
@@ -28,19 +28,21 @@ import org.apache.spark.sql.delta.Snapshot;
 
 import scala.Option;
 
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.storage.DataLayoutStrategy;
 import org.apache.xtable.model.storage.TableFormat;
 
-/** Extracts {@link OneTable} canonical representation of a table at a point in time for Delta. */
+/**
+ * Extracts {@link InternalTable} canonical representation of a table at a point in time for Delta.
+ */
 @Builder
 public class DeltaTableExtractor {
   @Builder.Default
   private static final DeltaSchemaExtractor schemaExtractor = DeltaSchemaExtractor.getInstance();
 
-  public OneTable table(DeltaLog deltaLog, String tableName, Long version) {
+  public InternalTable table(DeltaLog deltaLog, String tableName, Long version) {
     Snapshot snapshot = deltaLog.getSnapshotAt(version, Option.empty());
     InternalSchema schema = schemaExtractor.toInternalSchema(snapshot.metadata().schema());
     List<InternalPartitionField> partitionFields =
@@ -52,7 +54,7 @@ public class DeltaTableExtractor {
         !partitionFields.isEmpty()
             ? DataLayoutStrategy.HIVE_STYLE_PARTITION
             : DataLayoutStrategy.FLAT;
-    return OneTable.builder()
+    return InternalTable.builder()
         .tableFormat(TableFormat.DELTA)
         .basePath(snapshot.deltaLog().dataPath().toString())
         .name(tableName)

--- a/core/src/main/java/org/apache/xtable/exception/ConfigurationException.java
+++ b/core/src/main/java/org/apache/xtable/exception/ConfigurationException.java
@@ -18,15 +18,15 @@
  
 package org.apache.xtable.exception;
 
-import org.apache.xtable.model.exception.OneTableErrorCode;
-import org.apache.xtable.model.exception.OneTableException;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
-public class ConfigurationException extends OneTableException {
+public class ConfigurationException extends InternalException {
   public ConfigurationException(String message, Throwable e) {
-    super(OneTableErrorCode.INVALID_CONFIGURATION, message, e);
+    super(ErrorCode.INVALID_CONFIGURATION, message, e);
   }
 
   public ConfigurationException(String message) {
-    super(OneTableErrorCode.INVALID_CONFIGURATION, message);
+    super(ErrorCode.INVALID_CONFIGURATION, message);
   }
 }

--- a/core/src/main/java/org/apache/xtable/exception/NotSupportedException.java
+++ b/core/src/main/java/org/apache/xtable/exception/NotSupportedException.java
@@ -18,15 +18,15 @@
  
 package org.apache.xtable.exception;
 
-import org.apache.xtable.model.exception.OneTableErrorCode;
-import org.apache.xtable.model.exception.OneTableException;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
-public class NotSupportedException extends OneTableException {
+public class NotSupportedException extends InternalException {
   public NotSupportedException(String message, Throwable e) {
-    super(OneTableErrorCode.UNSUPPORTED_FEATURE, message, e);
+    super(ErrorCode.UNSUPPORTED_FEATURE, message, e);
   }
 
   public NotSupportedException(String message) {
-    super(OneTableErrorCode.UNSUPPORTED_FEATURE, message);
+    super(ErrorCode.UNSUPPORTED_FEATURE, message);
   }
 }

--- a/core/src/main/java/org/apache/xtable/exception/OneIOException.java
+++ b/core/src/main/java/org/apache/xtable/exception/OneIOException.java
@@ -18,15 +18,15 @@
  
 package org.apache.xtable.exception;
 
-import org.apache.xtable.model.exception.OneTableErrorCode;
-import org.apache.xtable.model.exception.OneTableException;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
-public class OneIOException extends OneTableException {
+public class OneIOException extends InternalException {
   public OneIOException(String message, Throwable e) {
-    super(OneTableErrorCode.IO_EXCEPTION, message, e);
+    super(ErrorCode.IO_EXCEPTION, message, e);
   }
 
   public OneIOException(String message) {
-    super(OneTableErrorCode.IO_EXCEPTION, message);
+    super(ErrorCode.IO_EXCEPTION, message);
   }
 }

--- a/core/src/main/java/org/apache/xtable/exception/PartitionSpecException.java
+++ b/core/src/main/java/org/apache/xtable/exception/PartitionSpecException.java
@@ -18,15 +18,15 @@
  
 package org.apache.xtable.exception;
 
-import org.apache.xtable.model.exception.OneTableErrorCode;
-import org.apache.xtable.model.exception.OneTableException;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
-public class PartitionSpecException extends OneTableException {
+public class PartitionSpecException extends InternalException {
   public PartitionSpecException(String message) {
-    super(OneTableErrorCode.INVALID_PARTITION_SPEC, message);
+    super(ErrorCode.INVALID_PARTITION_SPEC, message);
   }
 
   public PartitionSpecException(String message, Exception e) {
-    super(OneTableErrorCode.INVALID_PARTITION_SPEC, message, e);
+    super(ErrorCode.INVALID_PARTITION_SPEC, message, e);
   }
 }

--- a/core/src/main/java/org/apache/xtable/exception/PartitionValuesExtractorException.java
+++ b/core/src/main/java/org/apache/xtable/exception/PartitionValuesExtractorException.java
@@ -18,15 +18,15 @@
  
 package org.apache.xtable.exception;
 
-import org.apache.xtable.model.exception.OneTableErrorCode;
-import org.apache.xtable.model.exception.OneTableException;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
-public class PartitionValuesExtractorException extends OneTableException {
+public class PartitionValuesExtractorException extends InternalException {
   public PartitionValuesExtractorException(String message) {
-    super(OneTableErrorCode.INVALID_PARTITION_VALUE, message);
+    super(ErrorCode.INVALID_PARTITION_VALUE, message);
   }
 
   public PartitionValuesExtractorException(String message, Exception e) {
-    super(OneTableErrorCode.INVALID_PARTITION_VALUE, message, e);
+    super(ErrorCode.INVALID_PARTITION_VALUE, message, e);
   }
 }

--- a/core/src/main/java/org/apache/xtable/exception/SchemaExtractorException.java
+++ b/core/src/main/java/org/apache/xtable/exception/SchemaExtractorException.java
@@ -18,16 +18,16 @@
  
 package org.apache.xtable.exception;
 
-import org.apache.xtable.model.exception.OneTableErrorCode;
-import org.apache.xtable.model.exception.OneTableException;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
 /** Exception to report for errors during Schema Extraction. */
-public class SchemaExtractorException extends OneTableException {
+public class SchemaExtractorException extends InternalException {
   public SchemaExtractorException(String message) {
-    super(OneTableErrorCode.INVALID_SCHEMA, message);
+    super(ErrorCode.INVALID_SCHEMA, message);
   }
 
   public SchemaExtractorException(String message, Exception e) {
-    super(OneTableErrorCode.INVALID_SCHEMA, message, e);
+    super(ErrorCode.INVALID_SCHEMA, message, e);
   }
 }

--- a/core/src/main/java/org/apache/xtable/exception/UnsupportedSchemaTypeException.java
+++ b/core/src/main/java/org/apache/xtable/exception/UnsupportedSchemaTypeException.java
@@ -18,15 +18,15 @@
  
 package org.apache.xtable.exception;
 
-import org.apache.xtable.model.exception.OneTableErrorCode;
-import org.apache.xtable.model.exception.OneTableException;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
-public class UnsupportedSchemaTypeException extends OneTableException {
+public class UnsupportedSchemaTypeException extends InternalException {
   public UnsupportedSchemaTypeException(String message) {
-    super(OneTableErrorCode.UNSUPPORTED_SCHEMA_TYPE, message);
+    super(ErrorCode.UNSUPPORTED_SCHEMA_TYPE, message);
   }
 
   public UnsupportedSchemaTypeException(String message, Exception e) {
-    super(OneTableErrorCode.UNSUPPORTED_SCHEMA_TYPE, message, e);
+    super(ErrorCode.UNSUPPORTED_SCHEMA_TYPE, message, e);
   }
 }

--- a/core/src/main/java/org/apache/xtable/hudi/BaseFileUpdatesExtractor.java
+++ b/core/src/main/java/org/apache/xtable/hudi/BaseFileUpdatesExtractor.java
@@ -56,7 +56,7 @@ import org.apache.xtable.model.schema.InternalType;
 import org.apache.xtable.model.stat.ColumnStat;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.InternalDataFile;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 
 @AllArgsConstructor(staticName = "of")
 public class BaseFileUpdatesExtractor {
@@ -75,7 +75,9 @@ public class BaseFileUpdatesExtractor {
    * @return The information needed to create a "replace" commit for the Hudi table
    */
   ReplaceMetadata extractSnapshotChanges(
-      List<OneFileGroup> partitionedDataFiles, HoodieTableMetaClient metaClient, String commit) {
+      List<PartitionFileGroup> partitionedDataFiles,
+      HoodieTableMetaClient metaClient,
+      String commit) {
     HoodieMetadataConfig metadataConfig =
         HoodieMetadataConfig.newBuilder()
             .enable(metaClient.getTableConfig().isMetadataTableAvailable())

--- a/core/src/main/java/org/apache/xtable/hudi/HudiClient.java
+++ b/core/src/main/java/org/apache/xtable/hudi/HudiClient.java
@@ -47,7 +47,7 @@ import org.apache.xtable.exception.OneIOException;
 import org.apache.xtable.model.CommitsBacklog;
 import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
 import org.apache.xtable.model.schema.SchemaCatalog;
 import org.apache.xtable.spi.extractor.SourceClient;
@@ -73,12 +73,12 @@ public class HudiClient implements SourceClient<HoodieInstant> {
   }
 
   @Override
-  public OneTable getTable(HoodieInstant commit) {
+  public InternalTable getTable(HoodieInstant commit) {
     return tableExtractor.table(metaClient, commit);
   }
 
   @Override
-  public SchemaCatalog getSchemaCatalog(OneTable table, HoodieInstant commit) {
+  public SchemaCatalog getSchemaCatalog(InternalTable table, HoodieInstant commit) {
     return HudiSchemaCatalogExtractor.catalogWithTableSchema(table);
   }
 
@@ -97,7 +97,7 @@ public class HudiClient implements SourceClient<HoodieInstant> {
             .filterInflightsAndRequested()
             .findInstantsBefore(latestCommit.getTimestamp())
             .getInstants();
-    OneTable table = getTable(latestCommit);
+    InternalTable table = getTable(latestCommit);
     return InternalSnapshot.builder()
         .table(table)
         .schemaCatalog(getSchemaCatalog(table, latestCommit))
@@ -118,7 +118,7 @@ public class HudiClient implements SourceClient<HoodieInstant> {
         activeTimeline
             .filterCompletedInstants()
             .findInstantsBeforeOrEquals(hoodieInstantForDiff.getTimestamp());
-    OneTable table = getTable(hoodieInstantForDiff);
+    InternalTable table = getTable(hoodieInstantForDiff);
     return TableChange.builder()
         .tableAsOfChange(table)
         .filesDiff(

--- a/core/src/main/java/org/apache/xtable/hudi/HudiDataFileExtractor.java
+++ b/core/src/main/java/org/apache/xtable/hudi/HudiDataFileExtractor.java
@@ -60,16 +60,16 @@ import org.apache.hudi.metadata.HoodieTableMetadata;
 
 import org.apache.xtable.collectors.CustomCollectors;
 import org.apache.xtable.exception.OneIOException;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.SchemaVersion;
 import org.apache.xtable.model.stat.PartitionValue;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.FileFormat;
 import org.apache.xtable.model.storage.InternalDataFile;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 
-/** Extracts all the files for Hudi table represented by {@link OneTable}. */
+/** Extracts all the files for Hudi table represented by {@link InternalTable}. */
 public class HudiDataFileExtractor implements AutoCloseable {
   private static final SchemaVersion DEFAULT_SCHEMA_VERSION = new SchemaVersion(1, null);
   private final HoodieTableMetadata tableMetadata;
@@ -109,7 +109,7 @@ public class HudiDataFileExtractor implements AutoCloseable {
     this.fileStatsExtractor = hudiFileStatsExtractor;
   }
 
-  public List<OneFileGroup> getFilesCurrentState(OneTable table) {
+  public List<PartitionFileGroup> getFilesCurrentState(InternalTable table) {
     try {
       List<String> allPartitionPaths =
           tableMetadata != null
@@ -124,7 +124,7 @@ public class HudiDataFileExtractor implements AutoCloseable {
 
   public DataFilesDiff getDiffForCommit(
       HoodieInstant hoodieInstantForDiff,
-      OneTable table,
+      InternalTable table,
       HoodieInstant instant,
       HoodieTimeline visibleTimeline) {
     SyncableFileSystemView fsView = fileSystemViewManager.getFileSystemView(metaClient);
@@ -343,8 +343,8 @@ public class HudiDataFileExtractor implements AutoCloseable {
     return AddedAndRemovedFiles.builder().added(filesToAdd).removed(filesToRemove).build();
   }
 
-  private List<OneFileGroup> getInternalDataFilesForPartitions(
-      List<String> partitionPaths, OneTable table) {
+  private List<PartitionFileGroup> getInternalDataFilesForPartitions(
+      List<String> partitionPaths, InternalTable table) {
 
     SyncableFileSystemView fsView = fileSystemViewManager.getFileSystemView(metaClient);
     Stream<InternalDataFile> filesWithoutStats =
@@ -361,7 +361,7 @@ public class HudiDataFileExtractor implements AutoCloseable {
                 });
     Stream<InternalDataFile> files =
         fileStatsExtractor.addStatsToFiles(tableMetadata, filesWithoutStats, table.getReadSchema());
-    return OneFileGroup.fromFiles(files);
+    return PartitionFileGroup.fromFiles(files);
   }
 
   @Override

--- a/core/src/main/java/org/apache/xtable/hudi/HudiInstantUtils.java
+++ b/core/src/main/java/org/apache/xtable/hudi/HudiInstantUtils.java
@@ -32,7 +32,7 @@ import java.time.temporal.ChronoField;
 
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 
-import org.apache.xtable.model.exception.OneParseException;
+import org.apache.xtable.model.exception.ParseException;
 
 class HudiInstantUtils {
   private static final ZoneId ZONE_ID = ZoneId.of("UTC");
@@ -66,7 +66,7 @@ class HudiInstantUtils {
       LocalDateTime dt = LocalDateTime.parse(timestampInMillis, MILLIS_INSTANT_TIME_FORMATTER);
       return dt.atZone(ZONE_ID).toInstant();
     } catch (DateTimeParseException ex) {
-      throw new OneParseException("Unable to parse date from commit timestamp: " + timestamp, ex);
+      throw new ParseException("Unable to parse date from commit timestamp: " + timestamp, ex);
     }
   }
 

--- a/core/src/main/java/org/apache/xtable/hudi/HudiSchemaCatalogExtractor.java
+++ b/core/src/main/java/org/apache/xtable/hudi/HudiSchemaCatalogExtractor.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.schema.SchemaCatalog;
 import org.apache.xtable.model.schema.SchemaVersion;
@@ -37,7 +37,7 @@ public class HudiSchemaCatalogExtractor implements SchemaCatalogExtractor<Hoodie
     throw new UnsupportedOperationException("Schema catalog extractor not implemented for Hudi");
   }
 
-  public static SchemaCatalog catalogWithTableSchema(OneTable table) {
+  public static SchemaCatalog catalogWithTableSchema(InternalTable table) {
     // does not support schema versions for now
     Map<SchemaVersion, InternalSchema> schemas = new HashMap<>();
     SchemaVersion schemaVersion = new SchemaVersion(1, "");

--- a/core/src/main/java/org/apache/xtable/hudi/HudiTableExtractor.java
+++ b/core/src/main/java/org/apache/xtable/hudi/HudiTableExtractor.java
@@ -33,7 +33,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 
 import org.apache.xtable.exception.SchemaExtractorException;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
@@ -42,7 +42,9 @@ import org.apache.xtable.model.storage.TableFormat;
 import org.apache.xtable.schema.SchemaFieldFinder;
 import org.apache.xtable.spi.extractor.SourcePartitionSpecExtractor;
 
-/** Extracts {@link OneTable} a canonical representation of table at a point in time for Hudi. */
+/**
+ * Extracts {@link InternalTable} a canonical representation of table at a point in time for Hudi.
+ */
 @Singleton
 public class HudiTableExtractor {
   private final HudiSchemaExtractor schemaExtractor;
@@ -55,7 +57,7 @@ public class HudiTableExtractor {
     this.partitionSpecExtractor = sourcePartitionSpecExtractor;
   }
 
-  public OneTable table(HoodieTableMetaClient metaClient, HoodieInstant commit) {
+  public InternalTable table(HoodieTableMetaClient metaClient, HoodieInstant commit) {
     TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
     InternalSchema canonicalSchema;
     Schema avroSchema;
@@ -77,7 +79,7 @@ public class HudiTableExtractor {
         partitionFields.size() > 0
             ? DataLayoutStrategy.DIR_HIERARCHY_PARTITION_VALUES
             : DataLayoutStrategy.FLAT;
-    return OneTable.builder()
+    return InternalTable.builder()
         .tableFormat(TableFormat.HUDI)
         .basePath(metaClient.getBasePathV2().toString())
         .name(metaClient.getTableConfig().getTableName())

--- a/core/src/main/java/org/apache/xtable/hudi/HudiTableManager.java
+++ b/core/src/main/java/org/apache/xtable/hudi/HudiTableManager.java
@@ -36,7 +36,7 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.TableNotFoundException;
 
 import org.apache.xtable.exception.OneIOException;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.storage.DataLayoutStrategy;
@@ -76,13 +76,13 @@ class HudiTableManager {
   }
 
   /**
-   * Initializes a Hudi table with properties matching the provided {@link OneTable}
+   * Initializes a Hudi table with properties matching the provided {@link InternalTable}
    *
    * @param tableDataPath the base path for the data files in the table
    * @param table the table to initialize
    * @return {@link HoodieTableMetaClient} for the table that was created
    */
-  HoodieTableMetaClient initializeHudiTable(String tableDataPath, OneTable table) {
+  HoodieTableMetaClient initializeHudiTable(String tableDataPath, InternalTable table) {
     String recordKeyField = "";
     if (table.getReadSchema() != null) {
       List<String> recordKeys =

--- a/core/src/main/java/org/apache/xtable/iceberg/IcebergColumnStatsConverter.java
+++ b/core/src/main/java/org/apache/xtable/iceberg/IcebergColumnStatsConverter.java
@@ -54,7 +54,7 @@ public class IcebergColumnStatsConverter {
     Map<Integer, Long> columnSizes = new HashMap<>();
     Map<Integer, Long> valueCounts = new HashMap<>();
     Map<Integer, Long> nullValueCounts = new HashMap<>();
-    Map<Integer, Long> nanValueCounts = null; // OneTable currently doesn't track this
+    Map<Integer, Long> nanValueCounts = null; // InternalTable currently doesn't track this
     Map<Integer, ByteBuffer> lowerBounds = new HashMap<>();
     Map<Integer, ByteBuffer> upperBounds = new HashMap<>();
     fieldColumnStats.forEach(

--- a/core/src/main/java/org/apache/xtable/iceberg/IcebergDataFileExtractor.java
+++ b/core/src/main/java/org/apache/xtable/iceberg/IcebergDataFileExtractor.java
@@ -46,7 +46,7 @@ public class IcebergDataFileExtractor {
    * @param dataFile Iceberg data file
    * @param partitionValues representation of partition fields and ranges
    * @param schema current schema for the table, used for mapping field IDs to stats
-   * @return corresponding OneTable data file
+   * @return corresponding InternalTable data file
    */
   InternalDataFile fromIceberg(
       DataFile dataFile, List<PartitionValue> partitionValues, InternalSchema schema) {
@@ -85,10 +85,10 @@ public class IcebergDataFileExtractor {
   }
 
   /**
-   * Maps Iceberg file format to OneTable file format
+   * Maps Iceberg file format to InternalTable file format
    *
    * @param format Iceberg file format
-   * @return corresponding OneTable file format
+   * @return corresponding InternalTable file format
    */
   FileFormat fromIcebergFileFormat(org.apache.iceberg.FileFormat format) {
     switch (format) {

--- a/core/src/main/java/org/apache/xtable/iceberg/IcebergDataFileUpdatesSync.java
+++ b/core/src/main/java/org/apache/xtable/iceberg/IcebergDataFileUpdatesSync.java
@@ -29,11 +29,11 @@ import org.apache.iceberg.io.CloseableIterable;
 
 import org.apache.xtable.exception.NotSupportedException;
 import org.apache.xtable.exception.OneIOException;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.FilesDiff;
 import org.apache.xtable.model.storage.InternalDataFile;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 
 @AllArgsConstructor(staticName = "of")
 public class IcebergDataFileUpdatesSync {
@@ -42,9 +42,9 @@ public class IcebergDataFileUpdatesSync {
 
   public void applySnapshot(
       Table table,
-      OneTable oneTable,
+      InternalTable internalTable,
       Transaction transaction,
-      List<OneFileGroup> partitionedDataFiles,
+      List<PartitionFileGroup> partitionedDataFiles,
       Schema schema,
       PartitionSpec partitionSpec) {
 

--- a/core/src/main/java/org/apache/xtable/iceberg/IcebergPartitionValueConverter.java
+++ b/core/src/main/java/org/apache/xtable/iceberg/IcebergPartitionValueConverter.java
@@ -44,7 +44,7 @@ import org.apache.iceberg.types.Types;
 
 import org.apache.xtable.avro.AvroSchemaConverter;
 import org.apache.xtable.exception.NotSupportedException;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.PartitionTransformType;
@@ -72,13 +72,13 @@ public class IcebergPartitionValueConverter {
   }
 
   public List<PartitionValue> toOneTable(
-      OneTable oneTable, StructLike structLike, PartitionSpec partitionSpec) {
+      InternalTable internalTable, StructLike structLike, PartitionSpec partitionSpec) {
     if (!partitionSpec.isPartitioned()) {
       return Collections.emptyList();
     }
     List<PartitionValue> partitionValues = new ArrayList<>(partitionSpec.fields().size());
     Map<InternalField, Map<PartitionTransformType, InternalPartitionField>> partitionFieldMap =
-        getInternalPartitionFieldMap(oneTable);
+        getInternalPartitionFieldMap(internalTable);
     IndexedRecord partitionData = ((IndexedRecord) structLike);
     for (PartitionField partitionField : partitionSpec.fields()) {
       Object value;
@@ -131,7 +131,7 @@ public class IcebergPartitionValueConverter {
           partitionSpec.schema().findField(partitionField.sourceId());
       InternalField sourceField =
           SchemaFieldFinder.getInstance()
-              .findFieldByPath(oneTable.getReadSchema(), partitionSourceField.name());
+              .findFieldByPath(internalTable.getReadSchema(), partitionSourceField.name());
       // This helps reduce creating these objects for each file processed and re-using them.
       InternalPartitionField internalPartitionField =
           getFromInternalPartitionFieldMap(partitionFieldMap, sourceField, transformType);
@@ -163,8 +163,8 @@ public class IcebergPartitionValueConverter {
   }
 
   private Map<InternalField, Map<PartitionTransformType, InternalPartitionField>>
-      getInternalPartitionFieldMap(OneTable oneTable) {
-    List<InternalPartitionField> internalPartitionFields = oneTable.getPartitioningFields();
+      getInternalPartitionFieldMap(InternalTable internalTable) {
+    List<InternalPartitionField> internalPartitionFields = internalTable.getPartitioningFields();
     return internalPartitionFields.stream()
         .collect(
             Collectors.groupingBy(

--- a/core/src/test/java/org/apache/xtable/ValidationTestHelper.java
+++ b/core/src/test/java/org/apache/xtable/ValidationTestHelper.java
@@ -37,16 +37,16 @@ public class ValidationTestHelper {
       InternalSnapshot internalSnapshot, List<String> allActivePaths) {
     assertNotNull(internalSnapshot);
     assertNotNull(internalSnapshot.getTable());
-    List<String> onetablePaths =
+    List<String> filePaths =
         internalSnapshot.getPartitionedDataFiles().stream()
             .flatMap(group -> group.getFiles().stream())
             .map(InternalDataFile::getPhysicalPath)
             .collect(Collectors.toList());
     replaceFileScheme(allActivePaths);
-    replaceFileScheme(onetablePaths);
+    replaceFileScheme(filePaths);
     Collections.sort(allActivePaths);
-    Collections.sort(onetablePaths);
-    assertEquals(allActivePaths, onetablePaths);
+    Collections.sort(filePaths);
+    assertEquals(allActivePaths, filePaths);
   }
 
   public static void validateTableChanges(
@@ -90,7 +90,7 @@ public class ValidationTestHelper {
 
   public static List<String> getAllFilePaths(InternalSnapshot internalSnapshot) {
     return internalSnapshot.getPartitionedDataFiles().stream()
-        .flatMap(oneFileGroup -> oneFileGroup.getFiles().stream())
+        .flatMap(fileGroup -> fileGroup.getFiles().stream())
         .map(InternalDataFile::getPhysicalPath)
         .collect(Collectors.toList());
   }

--- a/core/src/test/java/org/apache/xtable/delta/ITDeltaSourceClient.java
+++ b/core/src/test/java/org/apache/xtable/delta/ITDeltaSourceClient.java
@@ -58,7 +58,7 @@ import org.apache.xtable.client.PerTableConfigImpl;
 import org.apache.xtable.model.CommitsBacklog;
 import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
@@ -199,7 +199,7 @@ public class ITDeltaSourceClient {
     List<ColumnStat> columnStats = Arrays.asList(COL1_COLUMN_STAT, COL2_COLUMN_STAT);
     Assertions.assertEquals(1, snapshot.getPartitionedDataFiles().size());
     validatePartitionDataFiles(
-        OneFileGroup.builder()
+        PartitionFileGroup.builder()
             .files(
                 Collections.singletonList(
                     InternalDataFile.builder()
@@ -286,7 +286,7 @@ public class ITDeltaSourceClient {
                 .range(Range.scalar("SingleValue"))
                 .build());
     validatePartitionDataFiles(
-        OneFileGroup.builder()
+        PartitionFileGroup.builder()
             .partitionValues(partitionValue)
             .files(
                 Collections.singletonList(
@@ -665,19 +665,19 @@ public class ITDeltaSourceClient {
   }
 
   private static void validateTable(
-      OneTable oneTable,
+      InternalTable internalTable,
       String tableName,
       String tableFormat,
       InternalSchema readSchema,
       DataLayoutStrategy dataLayoutStrategy,
       String basePath,
       List<InternalPartitionField> partitioningFields) {
-    Assertions.assertEquals(tableName, oneTable.getName());
-    Assertions.assertEquals(tableFormat, oneTable.getTableFormat());
-    Assertions.assertEquals(readSchema, oneTable.getReadSchema());
-    Assertions.assertEquals(dataLayoutStrategy, oneTable.getLayoutStrategy());
-    Assertions.assertEquals(basePath, oneTable.getBasePath());
-    Assertions.assertEquals(partitioningFields, oneTable.getPartitioningFields());
+    Assertions.assertEquals(tableName, internalTable.getName());
+    Assertions.assertEquals(tableFormat, internalTable.getTableFormat());
+    Assertions.assertEquals(readSchema, internalTable.getReadSchema());
+    Assertions.assertEquals(dataLayoutStrategy, internalTable.getLayoutStrategy());
+    Assertions.assertEquals(basePath, internalTable.getBasePath());
+    Assertions.assertEquals(partitioningFields, internalTable.getPartitioningFields());
   }
 
   private void validateSchemaCatalog(
@@ -686,7 +686,7 @@ public class ITDeltaSourceClient {
   }
 
   private void validatePartitionDataFiles(
-      OneFileGroup expectedPartitionFiles, OneFileGroup actualPartitionFiles)
+      PartitionFileGroup expectedPartitionFiles, PartitionFileGroup actualPartitionFiles)
       throws URISyntaxException {
     assertEquals(
         expectedPartitionFiles.getPartitionValues(), actualPartitionFiles.getPartitionValues());

--- a/core/src/test/java/org/apache/xtable/delta/TestDeltaSync.java
+++ b/core/src/test/java/org/apache/xtable/delta/TestDeltaSync.java
@@ -78,7 +78,7 @@ import io.delta.standalone.types.StringType;
 
 import org.apache.xtable.client.PerTableConfigImpl;
 import org.apache.xtable.model.InternalSnapshot;
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
@@ -89,7 +89,7 @@ import org.apache.xtable.model.stat.Range;
 import org.apache.xtable.model.storage.DataLayoutStrategy;
 import org.apache.xtable.model.storage.FileFormat;
 import org.apache.xtable.model.storage.InternalDataFile;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 import org.apache.xtable.model.storage.TableFormat;
 import org.apache.xtable.schema.SchemaFieldFinder;
 import org.apache.xtable.spi.sync.TableFormatSync;
@@ -150,8 +150,8 @@ public class TestDeltaSync {
                     .build())
             .build());
     InternalSchema schema2 = getInternalSchema().toBuilder().fields(fields2).build();
-    OneTable table1 = getOneTable(tableName, basePath, schema1, null, LAST_COMMIT_TIME);
-    OneTable table2 = getOneTable(tableName, basePath, schema2, null, LAST_COMMIT_TIME);
+    InternalTable table1 = getOneTable(tableName, basePath, schema1, null, LAST_COMMIT_TIME);
+    InternalTable table2 = getOneTable(tableName, basePath, schema2, null, LAST_COMMIT_TIME);
 
     InternalDataFile dataFile1 = getDataFile(1, Collections.emptyList(), basePath);
     InternalDataFile dataFile2 = getDataFile(2, Collections.emptyList(), basePath);
@@ -183,7 +183,7 @@ public class TestDeltaSync {
                     .build())
             .transformType(PartitionTransformType.VALUE)
             .build();
-    OneTable table =
+    InternalTable table =
         getOneTable(
             tableName,
             basePath,
@@ -241,7 +241,7 @@ public class TestDeltaSync {
                     .build())
             .transformType(PartitionTransformType.VALUE)
             .build();
-    OneTable table =
+    InternalTable table =
         getOneTable(
             tableName,
             basePath,
@@ -307,7 +307,7 @@ public class TestDeltaSync {
             .sourceField(SchemaFieldFinder.getInstance().findFieldByPath(schema, "timestamp_field"))
             .transformType(transformType)
             .build();
-    OneTable table =
+    InternalTable table =
         getOneTable(
             tableName,
             basePath,
@@ -401,20 +401,20 @@ public class TestDeltaSync {
         internalDataFiles.size(), count, "Number of files from DeltaScan don't match expectation");
   }
 
-  private InternalSnapshot buildSnapshot(OneTable table, InternalDataFile... dataFiles) {
+  private InternalSnapshot buildSnapshot(InternalTable table, InternalDataFile... dataFiles) {
     return InternalSnapshot.builder()
         .table(table)
-        .partitionedDataFiles(OneFileGroup.fromFiles(Arrays.asList(dataFiles)))
+        .partitionedDataFiles(PartitionFileGroup.fromFiles(Arrays.asList(dataFiles)))
         .build();
   }
 
-  private OneTable getOneTable(
+  private InternalTable getOneTable(
       String tableName,
       Path basePath,
       InternalSchema schema,
       List<InternalPartitionField> partitionFields,
       Instant lastCommitTime) {
-    return OneTable.builder()
+    return InternalTable.builder()
         .name(tableName)
         .basePath(basePath.toUri().toString())
         .layoutStrategy(DataLayoutStrategy.FLAT)

--- a/core/src/test/java/org/apache/xtable/hudi/TestBaseFileUpdatesExtractor.java
+++ b/core/src/test/java/org/apache/xtable/hudi/TestBaseFileUpdatesExtractor.java
@@ -63,7 +63,7 @@ import org.apache.xtable.model.stat.Range;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.FileFormat;
 import org.apache.xtable.model.storage.InternalDataFile;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 import org.apache.xtable.testutil.ColumnStatMapUtil;
 
 public class TestBaseFileUpdatesExtractor {
@@ -180,9 +180,9 @@ public class TestBaseFileUpdatesExtractor {
     BaseFileUpdatesExtractor extractor =
         BaseFileUpdatesExtractor.of(CONTEXT, new CachingPath(tableBasePath));
 
-    List<OneFileGroup> partitionedDataFiles =
+    List<PartitionFileGroup> partitionedDataFiles =
         Arrays.asList(
-            OneFileGroup.builder()
+            PartitionFileGroup.builder()
                 .partitionValues(
                     Collections.singletonList(
                         PartitionValue.builder()
@@ -191,7 +191,7 @@ public class TestBaseFileUpdatesExtractor {
                             .build()))
                 .files(Arrays.asList(addedFile1, addedFile2))
                 .build(),
-            OneFileGroup.builder()
+            PartitionFileGroup.builder()
                 .partitionValues(
                     Collections.singletonList(
                         PartitionValue.builder()
@@ -271,9 +271,9 @@ public class TestBaseFileUpdatesExtractor {
         createFile(
             String.format("%s/%s/%s", tableBasePath, partitionPath2, existingFileName2),
             Collections.emptyList());
-    List<OneFileGroup> partitionedDataFiles =
+    List<PartitionFileGroup> partitionedDataFiles =
         Arrays.asList(
-            OneFileGroup.builder()
+            PartitionFileGroup.builder()
                 .files(Arrays.asList(addedFile1, existingFile))
                 .partitionValues(
                     Collections.singletonList(
@@ -282,7 +282,7 @@ public class TestBaseFileUpdatesExtractor {
                             .range(Range.scalar(partitionPath2))
                             .build()))
                 .build(),
-            OneFileGroup.builder()
+            PartitionFileGroup.builder()
                 .files(Collections.singletonList(addedFile2))
                 .partitionValues(
                     Collections.singletonList(
@@ -356,9 +356,9 @@ public class TestBaseFileUpdatesExtractor {
     InternalDataFile existingFile =
         createFile(
             String.format("%s/%s", tableBasePath, existingFileName2), Collections.emptyList());
-    List<OneFileGroup> partitionedDataFiles =
+    List<PartitionFileGroup> partitionedDataFiles =
         Collections.singletonList(
-            OneFileGroup.builder()
+            PartitionFileGroup.builder()
                 .files(Arrays.asList(addedFile1, existingFile))
                 .partitionValues(Collections.emptyList())
                 .build());

--- a/core/src/test/java/org/apache/xtable/hudi/TestHudiTableManager.java
+++ b/core/src/test/java/org/apache/xtable/hudi/TestHudiTableManager.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
@@ -82,8 +82,8 @@ public class TestHudiTableManager {
                 .sourceField(InternalField.builder().name(field2).build())
                 .transformType(PartitionTransformType.VALUE)
                 .build());
-    OneTable table =
-        OneTable.builder()
+    InternalTable table =
+        InternalTable.builder()
             .name(tableName)
             .partitioningFields(inputPartitionFields)
             .readSchema(tableSchema)

--- a/core/src/test/java/org/apache/xtable/hudi/TestHudiTargetClient.java
+++ b/core/src/test/java/org/apache/xtable/hudi/TestHudiTargetClient.java
@@ -42,15 +42,15 @@ import org.apache.hudi.common.util.Option;
 
 import org.apache.xtable.avro.AvroSchemaConverter;
 import org.apache.xtable.exception.NotSupportedException;
-import org.apache.xtable.model.OneTable;
-import org.apache.xtable.model.OneTableMetadata;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.TableSyncMetadata;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.schema.InternalType;
 import org.apache.xtable.model.schema.PartitionTransformType;
 import org.apache.xtable.model.storage.DataFilesDiff;
-import org.apache.xtable.model.storage.OneFileGroup;
+import org.apache.xtable.model.storage.PartitionFileGroup;
 
 /**
  * Unit tests that focus on the basic control flow of the HudiTargetClient. Functional tests are in
@@ -62,8 +62,12 @@ public class TestHudiTargetClient {
   private static final Instant COMMIT_TIME = Instant.ofEpochMilli(1598644800000L);
   private static final String COMMIT = "20200828200000000";
   private static final String BASE_PATH = "test-base-path";
-  private static final OneTable TABLE =
-      OneTable.builder().name("table").basePath(BASE_PATH).latestCommitTime(COMMIT_TIME).build();
+  private static final InternalTable TABLE =
+      InternalTable.builder()
+          .name("table")
+          .basePath(BASE_PATH)
+          .latestCommitTime(COMMIT_TIME)
+          .build();
 
   private final BaseFileUpdatesExtractor mockBaseFileUpdatesExtractor =
       mock(BaseFileUpdatesExtractor.class);
@@ -135,10 +139,10 @@ public class TestHudiTargetClient {
   void syncMetadata() {
     HudiTargetClient targetClient = getTargetClient(null);
     HudiTargetClient.CommitState mockCommitState = initMocksForBeginSync(targetClient).getLeft();
-    OneTableMetadata metadata = OneTableMetadata.of(COMMIT_TIME, Collections.emptyList());
+    TableSyncMetadata metadata = TableSyncMetadata.of(COMMIT_TIME, Collections.emptyList());
     targetClient.syncMetadata(metadata);
     // validate that metadata is set in commitState
-    verify(mockCommitState).setOneTableMetadata(metadata);
+    verify(mockCommitState).setTableSyncMetadata(metadata);
   }
 
   @Test
@@ -223,7 +227,7 @@ public class TestHudiTargetClient {
     HudiTargetClient.CommitState mockCommitState = mocks.getLeft();
     HoodieTableMetaClient mockMetaClient = mocks.getRight();
     String instant = "commit";
-    List<OneFileGroup> input = Collections.emptyList();
+    List<PartitionFileGroup> input = Collections.emptyList();
     BaseFileUpdatesExtractor.ReplaceMetadata output =
         BaseFileUpdatesExtractor.ReplaceMetadata.of(
             Collections.emptyMap(), Collections.emptyList());

--- a/core/src/test/java/org/apache/xtable/iceberg/TestIcebergPartitionValueConverter.java
+++ b/core/src/test/java/org/apache/xtable/iceberg/TestIcebergPartitionValueConverter.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.types.Types;
 
-import org.apache.xtable.model.OneTable;
+import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
@@ -108,13 +108,13 @@ public class TestIcebergPartitionValueConverter {
     assertEquals(expectedPartitionValues, partitionValues);
   }
 
-  private OneTable buildOnetable(boolean isPartitioned) {
+  private InternalTable buildOnetable(boolean isPartitioned) {
     return buildOnetable(isPartitioned, null, null);
   }
 
-  private OneTable buildOnetable(
+  private InternalTable buildOnetable(
       boolean isPartitioned, String sourceField, PartitionTransformType transformType) {
-    return OneTable.builder()
+    return InternalTable.builder()
         .readSchema(IcebergSchemaExtractor.getInstance().fromIceberg(SCHEMA))
         .partitioningFields(
             isPartitioned

--- a/hudi-support/extensions/src/main/java/org/apache/xtable/hudi/sync/OneTableSyncTool.java
+++ b/hudi-support/extensions/src/main/java/org/apache/xtable/hudi/sync/OneTableSyncTool.java
@@ -43,7 +43,10 @@ import org.apache.xtable.model.schema.PartitionTransformType;
 import org.apache.xtable.model.sync.SyncMode;
 import org.apache.xtable.model.sync.SyncResult;
 
-/** A HoodieSyncTool for syncing a Hudi table to other formats (Delta and Iceberg) with OneTable. */
+/**
+ * A HoodieSyncTool for syncing a Hudi table to other formats (Delta and Iceberg) with
+ * InternalTable.
+ */
 public class OneTableSyncTool extends HoodieSyncTool {
   private final OneTableSyncConfig config;
   private final HudiSourceClientProvider hudiSourceClientProvider;
@@ -87,7 +90,7 @@ public class OneTableSyncTool extends HoodieSyncTool {
             .map(entry -> entry.getKey().toString())
             .collect(Collectors.joining(","));
     if (!failingFormats.isEmpty()) {
-      throw new HoodieException("Unable to sync to OneTable for formats: " + failingFormats);
+      throw new HoodieException("Unable to sync to InternalTable for formats: " + failingFormats);
     }
   }
 

--- a/hudi-support/extensions/src/test/java/org/apache/xtable/hudi/sync/TestOneTableSyncTool.java
+++ b/hudi-support/extensions/src/test/java/org/apache/xtable/hudi/sync/TestOneTableSyncTool.java
@@ -104,8 +104,8 @@ public class TestOneTableSyncTool {
     properties.putAll(options);
 
     new OneTableSyncTool(properties, new Configuration()).syncHoodieTable();
-    // lightweight check to make sure metadata dirs are made - assumes that OneTable sync is correct
-    // if it succeeds
+    // lightweight check to make sure metadata dirs are made - assumes that InternalTable sync is
+    // correct if it succeeds
     assertTrue(Files.exists(Paths.get(URI.create(path + "/_delta_log"))));
     assertTrue(Files.exists(Paths.get(URI.create(path + "/metadata"))));
   }

--- a/utilities/src/main/java/org/apache/xtable/utilities/RunSync.java
+++ b/utilities/src/main/java/org/apache/xtable/utilities/RunSync.java
@@ -87,7 +87,7 @@ public class RunSync {
               CLIENTS_CONFIG_PATH,
               "clientsConfig",
               true,
-              "The path to a yaml file containing OneTable client configurations. "
+              "The path to a yaml file containing InternalTable client configurations. "
                   + "These configs will override the default")
           .addOption(
               ICEBERG_CATALOG_CONFIG_PATH,

--- a/utilities/src/main/resources/onetable-client-defaults.yaml
+++ b/utilities/src/main/resources/onetable-client-defaults.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-## This file contains the default configuration of known OneTable tableFormatsClients for both source and target
+## This file contains the default configuration of known InternalTable tableFormatsClients for both source and target
 ## table formats. The config maps a table format name to a client class, and contains the default configuration
 ## values needed by the client.
 


### PR DESCRIPTION
The change fixes name of classes with old product-specific prefix (One), either replaces "One" with prefix "internal", as it more accurately reflects the class's function and distinguishes the class from classes in table format packages, or removes "One" altogether from the class name.

The following class name changes are introduced:
. OneTable is now InternalTable (#394)
. OneTableErrorCode is now ErrorCode (#397)
. OneTableException is now InternalException (#396)
. OneParseException is now OneParseException (#396)
