### PR TITLE
[Demo] Fix UnknownHostException: host.docker.internal in docker demo

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -18,6 +18,7 @@ version: "3.9"
 services:
   trino:
     container_name: trino
+    hostname: trino
     ports:
       - '8080:8080'
     image: 'trinodb/trino:428'
@@ -27,6 +28,7 @@ services:
 
   presto:
     container_name: presto
+    hostname: presto
     ports:
       - '8082:8082'
     image: 'prestodb/presto:0.283'

--- a/demo/notebook/demo.ipynb
+++ b/demo/notebook/demo.ipynb
@@ -114,7 +114,7 @@
     "val namespace = \"demo\" // requires that this db is already created in your HMS, in Trino you can run `create schema hive.demo`\n",
     "val namespaceArray = Array(namespace)\n",
     "val catalogOptions = new HashMap[String, String]();\n",
-    "catalogOptions.put(\"uri\", \"thrift://host.docker.internal:9083\");\n",
+    "catalogOptions.put(\"uri\", \"thrift://hive-metastore:9083\");\n",
     "val icebergCatalogConfig = IcebergCatalogConfig.builder()\n",
     "    .catalogImpl(\"org.apache.iceberg.hive.HiveCatalog\")\n",
     "    .catalogName(\"iceberg\")\n",
@@ -182,7 +182,7 @@
    "outputs": [],
    "source": [
     "import java.sql._\n",
-    "val url = \"jdbc:trino://host.docker.internal:8080/iceberg/\" + namespace + \"?user=admin\"\n",
+    "val url = \"jdbc:trino://trino:8080/iceberg/\" + namespace + \"?user=admin\"\n",
     "val connection = DriverManager.getConnection(url)\n",
     "val statement = connection.createStatement()\n",
     "statement.executeUpdate(\"INSERT INTO hudi_dimCustomer(_c0,CustomerKey,GeographyKey,FirstName,LastName,BirthDate,MaritalStatus,Gender,YearlyIncome,TotalChildren,NumberChildrenAtHome,Education,Occupation,HouseOwnerFlag,NumberCarsOwned) \" +\n",


### PR DESCRIPTION
## *Important Read*

Fixed #429

## What is the purpose of the pull request

Fix UnknownHostException: host.docker.internal in docker demo under Linux OS.

```
MetaException(message:Could not connect to meta store using any of the URIs provided. Most recent failure: org.apache.thrift.transport.TTransportException: java.net.UnknownHostException: host.docker.internal
	at org.apache.thrift.transport.TSocket.open(TSocket.java:226)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.open(HiveMetaStoreClient.java:478)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:245)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.hadoop.hive.metastore.MetaStoreUtils.newInstance(MetaStoreUtils.java:1740)
	at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.<init>(RetryingMetaStoreClient.java:83)
	at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:133)
	at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:104)
	at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:97)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.iceberg.common.DynMethods$UnboundMethod.invokeChecked(DynMeth
```

## Brief change log

We can use docker container hostname.

## Verify this pull request

locally.
