### PR TITLE
[446] Upgrade or remove dependencies with known vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,13 @@
         <hadoop.version>3.3.6</hadoop.version>
         <hudi.version>0.14.0</hudi.version>
         <parquet.version>1.12.2</parquet.version>
-        <scala.version>2.12.12</scala.version>
+        <scala.version>2.12.15</scala.version>
         <scala.version.prefix>2.12</scala.version.prefix>
         <spark.version>3.4.2</spark.version>
         <spark.version.prefix>3.4</spark.version.prefix>
         <iceberg.version>1.4.2</iceberg.version>
         <delta.version>2.4.0</delta.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.17.1</jackson.version>
         <spotless.version>2.43.0</spotless.version>
         <google.java.format.version>1.8</google.java.format.version>
         <delta.standalone.version>0.5.0</delta.standalone.version>
@@ -172,6 +172,10 @@
                         <groupId>org.apache.hadoop</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -186,6 +190,10 @@
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -265,6 +273,10 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
                 </exclusions>
                 <scope>provided</scope>
             </dependency>
@@ -300,6 +312,10 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -333,21 +349,8 @@
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>gcs-connector</artifactId>
-                <version>hadoop3-2.2.8</version>
+                <version>hadoop3-2.2.22</version>
                 <scope>runtime</scope>
-            </dependency>
-
-            <!-- Hive -->
-            <dependency>
-                <groupId>org.apache.hive</groupId>
-                <artifactId>hive-common</artifactId>
-                <version>3.1.3</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- Protobuf -->
@@ -452,10 +455,51 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.12.0</version>
             </dependency>
+
+            <!-- Manage transitive dependency versions that have vulnerabilities reported -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.1</version>
+            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
-                <version>4.1.74.Final</version>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.110.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>9.4.54.v20240208</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>9.37.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ivy</groupId>
+                <artifactId>ivy</artifactId>
+                <version>2.5.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -89,13 +89,6 @@
            <scope>compile</scope>
        </dependency>
 
-        <!-- Hive dependencies -->
-        <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-common</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
         <dependency>
            <groupId>org.apache.parquet</groupId>
            <artifactId>parquet-avro</artifactId>


### PR DESCRIPTION
## What is the purpose of the pull request

Addresses #446 
Upgrades or removes some dependencies that were flagged by security tooling for identifying vulnerable dependencies.

## Brief change log

- Exclude zookeeper as we do not require it and the version had a vulnerability reported
- Upgrade jackson to avoid vulnerabilities in the library modules and its dependencies
- Remove Hive from the path - this jar was just included for the utilities bundle but users can add their own implementation to the path
- netty - upgrade version by using BOM to ensure consistent version
- jetty - upgrade version by using BOM to ensure consistent version
- Pin versions for transitive dependencies like: snappy, commons-compress, commons-configuration, ivy, jettison, numbus-jose-jwt

## Verify this pull request

- Synced Hudi -> Iceberg, Delta and Delta -> Iceberg, Hudi on S3
- Validate that all existing tests pass