### PR TITLE
[Infra] Introduce apache rat plugin to xtable project

### DIFF
--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: License Check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - "main"
+
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Apache License Check
+        run: mvn apache-rat:check -B

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one
+ - or more contributor license agreements.  See the NOTICE file
+ - distributed with this work for additional information
+ - regarding copyright ownership.  The ASF licenses this file
+ - to you under the Apache License, Version 2.0 (the
+ - "License"); you may not use this file except in compliance
+ - with the License.  You may obtain a copy of the License at
+ - 
+ -     http://www.apache.org/licenses/LICENSE-2.0
+ - 
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and 
+ - limitations under the License.
+-->
+
 # Apache XTable™ (Incubating)
 
 [![Build Status](https://dev.azure.com/apache-xtable-ci-org/apache-xtable-ci/_apis/build/status%2Fapachextable-ci.xtable-mirror?branchName=main)](https://dev.azure.com/apache-xtable-ci-org/apache-xtable-ci/_build/latest?definitionId=2&branchName=main)

--- a/ci.md
+++ b/ci.md
@@ -1,3 +1,21 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one
+ - or more contributor license agreements.  See the NOTICE file
+ - distributed with this work for additional information
+ - regarding copyright ownership.  The ASF licenses this file
+ - to you under the Apache License, Version 2.0 (the
+ - "License"); you may not use this file except in compliance
+ - with the License.  You may obtain a copy of the License at
+ - 
+ -     http://www.apache.org/licenses/LICENSE-2.0
+ - 
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and 
+ - limitations under the License.
+-->
+
 # Guide on CI infrastructure
 
 ## Context

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,3 +1,21 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one
+ - or more contributor license agreements.  See the NOTICE file
+ - distributed with this work for additional information
+ - regarding copyright ownership.  The ASF licenses this file
+ - to you under the Apache License, Version 2.0 (the
+ - "License"); you may not use this file except in compliance
+ - with the License.  You may obtain a copy of the License at
+ - 
+ -     http://www.apache.org/licenses/LICENSE-2.0
+ - 
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and 
+ - limitations under the License.
+-->
+
 # Running a Local Demo
 This demo was created for the 2023 Open Source Data Summit. It shows how XTable can be used with two existing datasets.
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <delta.version>2.4.0</delta.version>
         <jackson.version>2.17.1</jackson.version>
         <spotless.version>2.43.0</spotless.version>
+        <apache.rat.version>0.16.1</apache.rat.version>
         <google.java.format.version>1.8</google.java.format.version>
         <delta.standalone.version>0.5.0</delta.standalone.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -595,6 +596,65 @@
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>-Xmx1024m</argLine>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <version>${apache.rat.version}</version>
+                <configuration>
+                    <consoleOutput>true</consoleOutput>
+                    <licenses>
+                        <license>
+                            <family>AL</family>
+                            <text>Licensed under the Apache License, Version 2.0 (the
+                                "License")</text>
+                            <text>Licensed to the Apache Software Foundation (ASF) under
+                                one
+                                or more contributor license agreements; and to You under
+                                the
+                                Apache License, Version 2.0.</text>
+                            <text>http://www.apache.org/licenses/LICENSE-2.0</text>
+                            <text>https://www.apache.org/licenses/LICENSE-2.0</text>
+                            <text>http://www.apache.org/licenses/LICENSE-2.0.html</text>
+                            <text>https://www.apache.org/licenses/LICENSE-2.0.html</text>
+                            <text>http://www.apache.org/licenses/LICENSE-2.0.txt</text>
+                            <text>https://www.apache.org/licenses/LICENSE-2.0.txt</text>
+                        </license>
+                    </licenses>
+                    <families>
+                        <family>
+                            <id>AL</id>
+                            <name>Apache License Version 2.0</name>
+                        </family>
+                    </families>
+                    <excludes>
+                        <exclude>NOTICE</exclude>
+                        <exclude>DISCLAIMER</exclude>
+                        <exclude>**/.*</exclude>
+                        <exclude>**/*.json</exclude>
+                        <exclude>**/*.log</exclude>
+                        <exclude>**/*.png</exclude>
+                        <exclude>**/*.jpg</exclude>
+                        <exclude>**/*.ipynb</exclude>
+                        <exclude>**/demo/data/**</exclude>
+                        <exclude>**/website/**</exclude>
+                        <exclude>**/*NOTICE*</exclude>
+                        <exclude>**/*LICENSE*</exclude>
+                        <exclude>**/dependency-reduced-pom.xml</exclude>
+                        <exclude>**/target/**</exclude>
+                        <exclude>**/generated-sources/**</exclude>
+                        <exclude>.github/**</exclude>
+                        <exclude>**/*.iml</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>

--- a/website/README.md
+++ b/website/README.md
@@ -1,3 +1,21 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one
+ - or more contributor license agreements.  See the NOTICE file
+ - distributed with this work for additional information
+ - regarding copyright ownership.  The ASF licenses this file
+ - to you under the Apache License, Version 2.0 (the
+ - "License"); you may not use this file except in compliance
+ - with the License.  You may obtain a copy of the License at
+ - 
+ -     http://www.apache.org/licenses/LICENSE-2.0
+ - 
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and 
+ - limitations under the License.
+-->
+
 # Apache XTable™ (Incubating) Website Source Code
 
 This repo hosts the source code of [Apache XTable™ (Incubating)](https://github.com/apache/incubator-xtable)

--- a/xtable-core/src/test/resources/schemas/basic_schema.avsc
+++ b/xtable-core/src/test/resources/schemas/basic_schema.avsc
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 {
   "type": "record",
   "name": "Sample",

--- a/xtable-hudi-support/xtable-hudi-support-extensions/README.md
+++ b/xtable-hudi-support/xtable-hudi-support-extensions/README.md
@@ -1,3 +1,21 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one
+ - or more contributor license agreements.  See the NOTICE file
+ - distributed with this work for additional information
+ - regarding copyright ownership.  The ASF licenses this file
+ - to you under the Apache License, Version 2.0 (the
+ - "License"); you may not use this file except in compliance
+ - with the License.  You may obtain a copy of the License at
+ - 
+ -     http://www.apache.org/licenses/LICENSE-2.0
+ - 
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and 
+ - limitations under the License.
+-->
+
 # Hudi Extensions
 ## Writer Extensions
 ### When should you use them?


### PR DESCRIPTION
## *Important Read*
- #449

## What is the purpose of the pull request

As we known, `apache-rat` plugin cat verify whether source code matches standards like the [ASF Source Header and Copyright Notice Policy](https://www.apache.org/legal/src-headers.html), and this plugin is widely used in many projects, like hudi, flink ...

The `spotless-maven-plugin` can only check several file types, so it can't fits our need.

https://creadur.apache.org/rat/apache-rat-plugin/usage.html

## Verify this pull request

Manually verified the change by running a job locally.
