### PR TITLE
[XTABLE-CI] Add labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,3 +31,10 @@ demo:
 
 website:
   - website/**/*
+
+ci:
+  - '.github/actions/**/*'
+  - '.github/workflows/**/*'
+  - '.github/labeler.yml'
+  - '.github/PULL_REQUEST_TEMPLATE.md'
+  - '.github/ISSUE_TEMPLATE/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+xtable-api:
+  - xtable-api/**/*
+
+xtable-core:
+  - xtable-core/**/*
+
+xtable-hudi-support:
+  - xtable-hudi-support/**/*
+
+xtable-utilities:
+  - xtable-utilities/**/*
+
+demo:
+  - demo/**/*
+
+website:
+  - website/**/*

--- a/.github/workflows/ci_labeler.yml
+++ b/.github/workflows/ci_labeler.yml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: XTable Pull Request Labeler
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on: pull_request_target
+
+jobs:
+  label:
+    name: Add labeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## What is the purpose of the pull request

Using [labeler](https://github.com/actions/labeler) to automatically label new pull requests based on the paths of files being changed. The label of PR can make people clearly know what it does.

By the way, the `.github/labeler.yml` file contains a list of labels and minimatch globs to match to apply the label. We can add more labels, such as `CI/CD`, `docs`, `UT`, and enrich this list.

