### PR TITLE
[481] Handle null stats in Delta AddFile

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaStatsExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaStatsExtractor.java
@@ -21,6 +21,7 @@ package org.apache.xtable.delta;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +36,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.Value;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.spark.sql.delta.actions.AddFile;
 
@@ -173,6 +176,9 @@ public class DeltaStatsExtractor {
   }
 
   public List<ColumnStat> getColumnStatsForFile(AddFile addFile, List<InternalField> fields) {
+    if (StringUtils.isEmpty(addFile.stats())) {
+      return Collections.emptyList();
+    }
     // TODO: Additional work needed to track maps & arrays.
     try {
       DeltaStats deltaStats = MAPPER.readValue(addFile.stats(), DeltaStats.class);

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaStatsExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaStatsExtractor.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -181,6 +182,15 @@ public class TestDeltaStatsExtractor {
                 .range(Range.vector(10, 20))
                 .build());
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void convertNullStatsToInternalRepresentation() {
+    List<InternalField> fields = getSchemaFields();
+    AddFile addFile = new AddFile("file://path/to/file", null, 0, 0, true, null, null, null);
+    DeltaStatsExtractor extractor = DeltaStatsExtractor.getInstance();
+    List<ColumnStat> actual = extractor.getColumnStatsForFile(addFile, fields);
+    assertEquals(Collections.emptyList(), actual);
   }
 
   private List<InternalField> getSchemaFields() {


### PR DESCRIPTION
## What is the purpose of the pull request

Handles an edge case where the AddFile object has not column stats

## Brief change log

- Return empty list if column stats is null or empty

## Verify this pull request

- Added unit test case