### PR TITLE
Upgrade parent pom version from 31 to 33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>31</version>
+        <version>33</version>
     </parent>
 
     <version>0.1.0-SNAPSHOT</version>


### PR DESCRIPTION
## What is the purpose of the pull request

* Upgrade the parent pom version to the latest (33) to use more recent versions for the various plugins and take advantage of the updated properties (e.g., `project.build.outputTimestamp`) which are taken into account for jar generation, NOTICE files, etc.

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.