### PR TITLE
Modify module names in pom.xml to reflect the apache compliant names in NOTICE file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.apache.xtable</groupId>
     <artifactId>xtable</artifactId>
-    <name>xtable</name>
+    <name>Apache XTable (incubating) Parent</name>
 
     <parent>
         <groupId>org.apache</groupId>

--- a/xtable-api/pom.xml
+++ b/xtable-api/pom.xml
@@ -20,7 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>xtable-api</artifactId>
-    <name>xtable-api</name>
+    <name>Apache XTable (incubating) Api</name>
 
     <parent>
         <groupId>org.apache.xtable</groupId>

--- a/xtable-core/pom.xml
+++ b/xtable-core/pom.xml
@@ -20,7 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>xtable-core</artifactId>
-    <name>xtable-core</name>
+    <name>Apache XTable (incubating) Core</name>
 
     <parent>
         <groupId>org.apache.xtable</groupId>

--- a/xtable-hudi-support/pom.xml
+++ b/xtable-hudi-support/pom.xml
@@ -26,6 +26,7 @@
     </parent>
 
     <artifactId>xtable-hudi-support</artifactId>
+    <name>Apache XTable (incubating) Hudi Support</name>
     <packaging>pom</packaging>
 
 

--- a/xtable-hudi-support/xtable-hudi-support-extensions/pom.xml
+++ b/xtable-hudi-support/xtable-hudi-support-extensions/pom.xml
@@ -20,6 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>xtable-hudi-support-extensions</artifactId>
+    <name>Apache XTable (incubating) Hudi Support Extensions</name>
 
     <parent>
         <groupId>org.apache.xtable</groupId>

--- a/xtable-hudi-support/xtable-hudi-support-utils/pom.xml
+++ b/xtable-hudi-support/xtable-hudi-support-utils/pom.xml
@@ -20,6 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>xtable-hudi-support-utils</artifactId>
+    <name>Apache XTable (incubating) Hudi Support Utils</name>
 
     <parent>
         <groupId>org.apache.xtable</groupId>

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -26,6 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>xtable-utilities</artifactId>
+    <name>Apache XTable (incubating) Utilities</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

https://github.com/apache/incubator-xtable/issues/509
Addressing the feedback provided by @zabetak in rc3, modifying the module name in pom.xml, which generates a NOTICE file like this. 
```
Apache XTable (incubating) Core
Copyright 2024 The Apache Software Foundation


This product includes software developed at
The Apache Software Foundation (http://www.apache.org/).

```  

## Brief change log

*(for example:)*
- *Modify module names in pom.xml to reflect the apache compliant names in NOTICE file*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.