### PR TITLE
Incorrect product name and distribution years in NOTICE file inside jars (#509)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.apache.xtable</groupId>
     <artifactId>xtable</artifactId>
     <name>xtable</name>
-
+    <inceptionYear>2024</inceptionYear>
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
@@ -547,6 +547,20 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-resource-bundles</id>
+                        <configuration>
+                            <properties>
+                                <projectName>Apache XTable (incubating)</projectName>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>


### PR DESCRIPTION
## What is the purpose of the pull request

#509 

## Brief change log

Configure `maven-remote-resources-plugin` to use "Apache XTable (incubating) as the product name inside the NOTICE files.

## Verify this pull request

This change added tests and can be verified as follows:
```
$ mvn clean install -DskipTests
$ for i in `find . -name "*jar"`; do echo $i; jar xf $i META-INF; cat META-INF/NOTICE; done
```