### PR TITLE
Error when generating Javadoc due to old JDK7 compiler version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </modules>
 
     <properties>
-        <java.version>8</java.version>
+        <maven.compiler.target>8</maven.compiler.target>
         <avro.version>1.11.3</avro.version>
         <log4j.version>2.22.0</log4j.version>
         <junit.version>5.9.0</junit.version>
@@ -605,9 +605,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>${java.version}</release>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION

## What is the purpose of the pull request

The javadoc goal fails since we are trying to create Javadoc for JDK7 while the code has language features of JDK8.
```
mvn org.apache.maven.plugins:maven-javadoc-plugin:javadoc -Prelease
```
There are various errors such as the one shown below.
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.7.0:javadoc (default-cli) on project xtable-api: An error has occurred in Javadoc report generation:
[ERROR] Exit code: 1
[ERROR] /home/stamatis/Projects/Apache/incubator-xtable/xtable-api/src/main/java/org/apache/xtable/spi/sync/TableFormatSync.java:74: error: lambda expressions are not supported in -source 1.7
[ERROR]                 target -> target.syncFilesForSnapshot(snapshot.getPartitionedDataFiles()),
[ERROR]                        ^
[ERROR]   (use -source 8 or higher to enable lambda expressions)
```

The Apache parent pom sets the `maven.compiler.source` and `maven.compiler.target` to (JDK) 7 and that is being picked up by various plugins including the maven-javadoc-plugin leading to the error below.

## Brief change log

1. Override compiler's `target` (and implicitly `source`) property to use JDK 8.
2. Remove explicit `release` configuration from maven-compiler-plugin since it is set by the Apache parent pom.

## Verify this pull request

```
mvn org.apache.maven.plugins:maven-javadoc-plugin:javadoc -Prelease
```
completes without errors.