### PR TITLE
[112] Add a UUID Type

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/model/schema/InternalSchema.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/schema/InternalSchema.java
@@ -78,6 +78,8 @@ public class InternalSchema {
     MILLIS
   }
 
+  public static final String XTABLE_LOGICAL_TYPE = "xtableLogicalType";
+
   /**
    * Performs a level-order traversal of the schema and returns a list of all fields. Use this
    * method to get a list that includes nested fields. Use {@link InternalSchema#getFields()} when

--- a/xtable-api/src/main/java/org/apache/xtable/model/schema/InternalType.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/schema/InternalType.java
@@ -38,6 +38,7 @@ public enum InternalType {
   LIST,
   MAP,
   UNION,
+  UUID,
   FIXED,
   STRING,
   BYTES,

--- a/xtable-core/src/main/java/org/apache/xtable/avro/AvroSchemaConverter.java
+++ b/xtable-core/src/main/java/org/apache/xtable/avro/AvroSchemaConverter.java
@@ -132,8 +132,13 @@ public class AvroSchemaConverter {
           break;
         }
         if (schema.getType() == Schema.Type.FIXED) {
-          metadata.put(InternalSchema.MetadataKey.FIXED_BYTES_SIZE, schema.getFixedSize());
-          newDataType = InternalType.FIXED;
+          String xtableLogicalType = schema.getProp(InternalSchema.XTABLE_LOGICAL_TYPE);
+          if ("uuid".equals(xtableLogicalType)) {
+            newDataType = InternalType.UUID;
+          } else {
+            metadata.put(InternalSchema.MetadataKey.FIXED_BYTES_SIZE, schema.getFixedSize());
+            newDataType = InternalType.FIXED;
+          }
         } else {
           newDataType = InternalType.BYTES;
         }
@@ -435,6 +440,11 @@ public class AvroSchemaConverter {
             Schema.createFixed(
                 internalSchema.getName(), internalSchema.getComment(), null, fixedSize),
             internalSchema);
+      case UUID:
+        Schema uuidSchema =
+            Schema.createFixed(internalSchema.getName(), internalSchema.getComment(), null, 16);
+        uuidSchema.addProp(InternalSchema.XTABLE_LOGICAL_TYPE, "uuid");
+        return finalizeSchema(uuidSchema, internalSchema);
       default:
         throw new UnsupportedSchemaTypeException(
             "Encountered unhandled type during InternalSchema to Avro conversion: "

--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiPartitionValuesExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiPartitionValuesExtractor.java
@@ -159,6 +159,7 @@ public class HudiPartitionValuesExtractor {
         break;
       case FIXED:
       case BYTES:
+      case UUID:
         parsedValue = valueAsString.getBytes(StandardCharsets.UTF_8);
         break;
       case BOOLEAN:

--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergSchemaExtractor.java
@@ -199,6 +199,8 @@ public class IcebergSchemaExtractor {
         return Types.DecimalType.of(precision, scale);
       case RECORD:
         return Types.StructType.of(convertFields(field.getSchema(), fieldIdTracker));
+      case UUID:
+        return Types.UUIDType.get();
       case MAP:
         InternalField key =
             field.getSchema().getFields().stream()
@@ -305,7 +307,7 @@ public class IcebergSchemaExtractor {
                 InternalSchema.MetadataKey.FIXED_BYTES_SIZE, fixedType.length());
         break;
       case UUID:
-        type = InternalType.FIXED;
+        type = InternalType.UUID;
         metadata = Collections.singletonMap(InternalSchema.MetadataKey.FIXED_BYTES_SIZE, 16);
         break;
       case STRUCT:

--- a/xtable-core/src/test/java/org/apache/xtable/GenericTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/GenericTable.java
@@ -127,6 +127,22 @@ public interface GenericTable<T, Q> extends AutoCloseable {
     }
   }
 
+  static GenericTable getInstanceWithUUIDColumns(
+      String tableName,
+      Path tempDir,
+      SparkSession sparkSession,
+      JavaSparkContext jsc,
+      String sourceFormat,
+      boolean isPartitioned) {
+    switch (sourceFormat) {
+      case ICEBERG:
+        return TestIcebergTable.forSchemaWithUUIDColumns(
+            tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration());
+      default:
+        throw new IllegalArgumentException("Unsupported source format: " + sourceFormat);
+    }
+  }
+
   static String getTableName() {
     return "test_table_" + UUID.randomUUID().toString().replaceAll("-", "_");
   }

--- a/xtable-core/src/test/java/org/apache/xtable/TestIcebergTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/TestIcebergTable.java
@@ -88,7 +88,7 @@ public class TestIcebergTable implements GenericTable<Record, String> {
         hadoopConf,
         DEFAULT_RECORD_KEY_FIELD,
         Collections.singletonList(partitionField),
-        false);
+        TestIcebergDataHelper.SchemaType.COMMON);
   }
 
   public static TestIcebergTable forSchemaWithAdditionalColumnsAndPartitioning(
@@ -99,7 +99,18 @@ public class TestIcebergTable implements GenericTable<Record, String> {
         hadoopConf,
         DEFAULT_RECORD_KEY_FIELD,
         Collections.singletonList(partitionField),
-        true);
+        TestIcebergDataHelper.SchemaType.COMMON_WITH_ADDITIONAL_COLUMNS);
+  }
+
+  public static TestIcebergTable forSchemaWithUUIDColumns(
+      String tableName, String partitionField, Path tempDir, Configuration hadoopConf) {
+    return new TestIcebergTable(
+        tableName,
+        tempDir,
+        hadoopConf,
+        DEFAULT_RECORD_KEY_FIELD,
+        Collections.singletonList(partitionField),
+        TestIcebergDataHelper.SchemaType.COMMON_WITH_UUID_COLUMN);
   }
 
   public TestIcebergTable(
@@ -108,12 +119,12 @@ public class TestIcebergTable implements GenericTable<Record, String> {
       Configuration hadoopConf,
       String recordKeyField,
       List<String> partitionFields,
-      boolean includeAdditionalColumns) {
+      TestIcebergDataHelper.SchemaType schemaType) {
     this.tableName = tableName;
     this.basePath = tempDir.toUri().toString();
     this.icebergDataHelper =
         TestIcebergDataHelper.createIcebergDataHelper(
-            recordKeyField, filterNullFields(partitionFields), includeAdditionalColumns);
+            recordKeyField, filterNullFields(partitionFields), schemaType);
     this.schema = icebergDataHelper.getTableSchema();
 
     PartitionSpec partitionSpec = icebergDataHelper.getPartitionSpec();

--- a/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergSchemaExtractor.java
@@ -372,7 +372,7 @@ public class TestIcebergSchemaExtractor {
                         .schema(
                             InternalSchema.builder()
                                 .name("uuid")
-                                .dataType(InternalType.FIXED)
+                                .dataType(InternalType.UUID)
                                 .isNullable(false)
                                 .metadata(fixedMetadata)
                                 .build())
@@ -383,7 +383,7 @@ public class TestIcebergSchemaExtractor {
                         .schema(
                             InternalSchema.builder()
                                 .name("uuid")
-                                .dataType(InternalType.FIXED)
+                                .dataType(InternalType.UUID)
                                 .isNullable(true)
                                 .metadata(fixedMetadata)
                                 .build())
@@ -391,6 +391,7 @@ public class TestIcebergSchemaExtractor {
                         .build()))
             .build();
     assertEquals(expectedSchema, (SCHEMA_EXTRACTOR.fromIceberg(inputSchema)));
+    assertTrue(inputSchema.sameSchema(SCHEMA_EXTRACTOR.toIceberg(expectedSchema)));
   }
 
   @Test


### PR DESCRIPTION
## *Important Read*
Aim to address #112 

## What is the purpose of the pull request

Create a UUID type in OneType and handle it appropriately in all converters. Only Iceberg has a concept of a UUID and it is a fixed size byte array in the underlying parquet files. We should aim to preserve the metadata that this byte array came from a UUID for round trip conversions.

## Brief change log

- Add a `UUID` type in InternalType
- Handle UUID internal type in Iceberg/Delta/Avro(for Hudi) Converters as a fixed-size byte array
- Adding unit tests

## Verify this pull request

This pull request is already covered by existing tests, all existing tests should pass
