### PR TITLE
[531] xtable poms are missing license details.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,19 +19,32 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>org.apache.xtable</groupId>
-    <artifactId>xtable</artifactId>
-    <name>xtable</name>
-    <inceptionYear>2024</inceptionYear>
-    <version>0.2.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
         <version>33</version>
     </parent>
+
+    <groupId>org.apache.xtable</groupId>
+    <artifactId>xtable</artifactId>
+    <name>XTable Project Parent POM</name>
+    <inceptionYear>2024</inceptionYear>
+    <version>0.2.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <url>https://xtable.apache.org/</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>The Apache Software Foundation</name>
+        <url>https://www.apache.org</url>
+    </organization>
 
     <modules>
         <module>xtable-api</module>

--- a/xtable-api/pom.xml
+++ b/xtable-api/pom.xml
@@ -19,14 +19,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>xtable-api</artifactId>
-    <name>xtable-api</name>
-
     <parent>
         <groupId>org.apache.xtable</groupId>
         <artifactId>xtable</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>xtable-api</artifactId>
+    <name>XTable Project API</name>
 
     <dependencies>
         <dependency>

--- a/xtable-core/pom.xml
+++ b/xtable-core/pom.xml
@@ -19,14 +19,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>xtable-core</artifactId>
-    <name>xtable-core</name>
-
     <parent>
         <groupId>org.apache.xtable</groupId>
         <artifactId>xtable</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>xtable-core</artifactId>
+    <name>XTable Project Core</name>
 
     <dependencies>
         <dependency>

--- a/xtable-hudi-support/pom.xml
+++ b/xtable-hudi-support/pom.xml
@@ -26,8 +26,8 @@
     </parent>
 
     <artifactId>xtable-hudi-support</artifactId>
+    <name>XTable Project Hudi Support Parent POM</name>
     <packaging>pom</packaging>
-
 
     <modules>
         <module>xtable-hudi-support-utils</module>

--- a/xtable-hudi-support/xtable-hudi-support-extensions/pom.xml
+++ b/xtable-hudi-support/xtable-hudi-support-extensions/pom.xml
@@ -19,13 +19,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>xtable-hudi-support-extensions</artifactId>
-
     <parent>
         <groupId>org.apache.xtable</groupId>
         <artifactId>xtable-hudi-support</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>xtable-hudi-support-extensions</artifactId>
+    <name>XTable Project Hudi Support Extensions</name>
 
     <dependencies>
         <dependency>

--- a/xtable-hudi-support/xtable-hudi-support-utils/pom.xml
+++ b/xtable-hudi-support/xtable-hudi-support-utils/pom.xml
@@ -19,13 +19,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>xtable-hudi-support-utils</artifactId>
-
     <parent>
         <groupId>org.apache.xtable</groupId>
         <artifactId>xtable-hudi-support</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>xtable-hudi-support-utils</artifactId>
+    <name>XTable Project Hudi Support Utils</name>
 
     <dependencies>
         <!-- Logging API -->

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -18,14 +18,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.xtable</groupId>
         <artifactId>xtable</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>xtable-utilities</artifactId>
+    <name>XTable Project Utilities</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## *Important Read*

This pull request aims to address issue [#531](https://github.com/apache/incubator-xtable/issues/531)

## What is the purpose of the pull request

Adding the <licenses> tag to xtable project and updating the project name.

## Brief change log

* Added the <licenses> and <organization> in the xtable parent project

```xml
<licenses>
    <license>
        <name>Apache License, Version 2.0</name>
        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
        <distribution>repo</distribution>
    </license>
</licenses>

<organization>
    <name>The Apache Software Foundation</name>
    <url>https://www.apache.org</url>
</organization>
```

* Updated the project name for each module, for example

```xml
<name>XTable Parent Project</name>
```

## Verify this pull request

Verified by running `$ mvn clean install -DskipTests -U` locally.
