### PR TITLE
Set keep_files as false in GH action for site deploy to remove lingering pages

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           personal_token: ${{ secrets.XTABLE_SITE_DEPLOY }}
           external_repository: apache/incubator-xtable-site
-          keep_files: true
+          keep_files: false
           publish_branch: main
           publish_dir: ./website/build
           user_name: ${{ github.actor }}


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

The previous PR removed the downloads page from the website and worked locally but GH action had this config as true so downloads page wasn't removed completely from http and was lingering around.

https://xtable.apache.org/releases/downloads/  
https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-keeping-existing-files-keep_files


## Brief change log

*(for example:)*
- *Fix GH action to remove pages*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.