### PR TITLE
[530] xtable-core pom has a hardcoded scala version for jackson-module-scala

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-scala_2.12</artifactId>
+                <artifactId>jackson-module-scala_${scala.version.prefix}</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
 

--- a/xtable-core/pom.xml
+++ b/xtable-core/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-scala_2.12</artifactId>
+            <artifactId>jackson-module-scala_${scala.version.prefix}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## *Important Read*

This pull request aims to address issues [#530](https://github.com/apache/incubator-xtable/issues/530)

## What is the purpose of the pull request

Removing the hardcoded scala version for jackson-module-scala in xtable parent project and xtable-core projects.

## Brief change log

* Removed the hard coded scala version i.e `2.12` and replaced with `${scala.version.prefix}`.

```xml
<dependency>
    <groupId>com.fasterxml.jackson.module</groupId>
    <artifactId>jackson-module-scala_${scala.version.prefix}</artifactId>
    <version>${jackson.version}</version>
</dependency>
```

## Verify this pull request

Verified by running `$ mvn clean install -DskipTests -U` locally.