### PR TITLE
[DOCS] Update catalog docs to show automatic catalog syncs to Snowflake and Glue

### DIFF
--- a/website/docs/glue-catalog.md
+++ b/website/docs/glue-catalog.md
@@ -150,25 +150,6 @@ From your terminal, run the glue crawler.
 Once the crawler succeeds, you’ll be able to query this Iceberg table from Athena,
 EMR and/or Redshift query engines.
 
-<Tabs
-groupId="table-format"
-defaultValue="hudi"
-values={[
-{ label: 'targetFormat: HUDI', value: 'hudi', },
-{ label: 'targetFormat: DELTA', value: 'delta', },
-{ label: 'targetFormat: ICEBERG', value: 'iceberg', },
-]}
->
-
-<TabItem value="hudi">
-
-:::danger LIMITATION for Hudi target format:
-To validate the Hudi targetFormat table results, you need to ensure that the query engine that you're using
-supports Hudi version 0.14.0 as mentioned [here](/docs/features-and-limitations#hudi)
-:::
-
-</TabItem>
-<TabItem value="delta">
 
 #### Method 2: Using XTable APIs to sync with AWS Glue Data Catalog directly
 This applies for iceberg target format only.
@@ -192,7 +173,7 @@ datasets:
 ```
 
 Create a `glue-sync-catalog.yaml` file:
-    
+
 ```yaml md title="yaml"
 catalogImpl: org.apache.iceberg.aws.glue.GlueCatalog
 catalogName: xtable
@@ -206,10 +187,29 @@ Sample command to sync the table with Glue Data Catalog:
 ```shell md title="shell"
 java -cp /path/to/xtable-utilities-0.2.0-SNAPSHOT-bundled.jar:/path/to/iceberg-aws-1.3.1.jar:/path/to/bundle-2.23.9.jar org.apache.xtable.utilities.RunSync  --datasetConfig glue-sync-config.yaml --icebergCatalogConfig glue-sync-catalog.yaml
 ```
-
 ### Validating the results
 After the crawler runs successfully, you can inspect the catalogued tables in Glue
 and also query the table in Amazon Athena like below:
+
+<Tabs
+groupId="table-format"
+defaultValue="hudi"
+values={[
+{ label: 'targetFormat: HUDI', value: 'hudi', },
+{ label: 'targetFormat: DELTA', value: 'delta', },
+{ label: 'targetFormat: ICEBERG', value: 'iceberg', },
+]}
+>
+
+<TabItem value="hudi">
+
+:::danger LIMITATION for Hudi target format:
+To validate the Hudi targetFormat table results, you need to ensure that the query engine that you're using
+supports Hudi version 0.14.0 as mentioned [here](/docs/features-and-limitations#hudi)
+:::
+
+</TabItem>
+<TabItem value="delta">
 
 ```sql
 SELECT * FROM xtable_synced_db.<table_name>;
@@ -218,9 +218,7 @@ SELECT * FROM xtable_synced_db.<table_name>;
 </TabItem>
 <TabItem value="iceberg">
 
-### Validating the results
-After the crawler runs successfully, you can inspect the catalogued tables in Glue
-and also query the table in Amazon Athena like below:
+
 
 ```sql
 SELECT * FROM xtable_synced_db.<table_name>;

--- a/website/docs/snowflake.md
+++ b/website/docs/snowflake.md
@@ -8,11 +8,6 @@ title: "Snowflake"
 Currently, Snowflake supports [Iceberg tables through External Tables](https://www.snowflake.com/blog/expanding-the-data-cloud-with-apache-iceberg/)
 and also [Native Iceberg Tables](https://www.snowflake.com/blog/iceberg-tables-powering-open-standards-with-snowflake-innovations/).
 
-:::note NOTE:
-Iceberg on Snowflake is currently supported in
-[public preview](https://www.snowflake.com/blog/build-open-data-lakehouse-iceberg-tables/)
-:::
-
 ## Steps:
 These are high level steps to help you integrate Apache XTable™ (Incubating) synced Iceberg tables on Snowflake. For more additional information
 refer to the [Getting started with Iceberg tables](https://docs.snowflake.com/LIMITEDACCESS/iceberg-2023/tables-iceberg-getting-started).
@@ -96,7 +91,7 @@ catalogOptions:
   jdbc.password: <snowflake-password>
 ```
 
-Sample command to sync the table with Glue Data Catalog:
+Sample command to sync the table with Snowflake:
 ```shell md title="shell"
 java -cp /path/to/iceberg-spark-runtime-3.2_2.12-1.4.2.jar:/path/to/xtable-utilities-0.2.0-SNAPSHOT-bundled.jar:/path/to/snowflake-jdbc-3.13.28.jar:/path/to/iceberg-aws-1.4.2.jar:/Users/sagarl/Downloads/bundle-2.23.9.jar org.apache.xtable.utilities.RunSync  --datasetConfig snowflake-sync-config.yaml --icebergCatalogConfig snowflake-sync-catalog.yaml
 ```

--- a/website/docs/snowflake.md
+++ b/website/docs/snowflake.md
@@ -47,7 +47,7 @@ TABLE_FORMAT=ICEBERG
 ENABLED=TRUE;
 ```
 
-### Create an Iceberg table from Iceberg metadata in object storage
+### Method 1: Create an Iceberg table from Iceberg metadata in object storage
 Refer to additional [examples](https://docs.snowflake.com/LIMITEDACCESS/iceberg-2023/create-iceberg-table#examples) 
 in the Snowflake Create Iceberg Table guide for more information.
 
@@ -59,3 +59,44 @@ METADATA_FILE_PATH='path/to/metadata/<VERSION>.metadata.json';
 ```
 
 Once the table creation succeeds you can start using the Iceberg table as any other table in Snowflake.
+
+### Method 2: Using XTable APIs to sync with Snowflake Catalog directly
+
+#### Pre-requisites:
+
+* Build Apache XTable™ (Incubating) from [source](https://github.com/apache/incubator-xtable)
+* Download `iceberg-aws-X.X.X.jar` from the [Maven repository](https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-aws)
+* Download `bundle-X.X.X.jar` from the [Maven repository](https://mvnrepository.com/artifact/software.amazon.awssdk/bundle)
+* Download `iceberg-spark-runtime-3.X_2.12/X.X.X.jar` from [here](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/1.4.2/)
+* Download `snowflake-jdbc-X.X.X.jar` from the [Maven repository](https://mvnrepository.com/artifact/net.snowflake/snowflake-jdbc)
+
+Create a `snowflake-sync-config.yaml` file:
+
+```yaml md title="yaml"
+sourceFormat: DELTA
+targetFormats:
+  - ICEBERG
+datasets:
+  -
+    tableBasePath: s3://path/to/table
+    tableName: <table_name>
+    namespace: <db_name>.<schema_name>
+```
+
+Create a `snowflake-sync-catalog.yaml` file:
+
+```yaml md title="yaml"
+catalogImpl: org.apache.iceberg.snowflake.SnowflakeCatalog
+catalogName: <catalog_name>
+catalogOptions:
+  io-impl: org.apache.iceberg.aws.s3.S3FileIO
+  warehouse: s3://path/to/table
+  uri: jdbc:snowflake://<account-identifier>.snowflakecomputing.com
+  jdbc.user: <snowflake-username>
+  jdbc.password: <snowflake-password>
+```
+
+Sample command to sync the table with Glue Data Catalog:
+```shell md title="shell"
+java -cp /path/to/iceberg-spark-runtime-3.2_2.12-1.4.2.jar:/path/to/xtable-utilities-0.2.0-SNAPSHOT-bundled.jar:/path/to/snowflake-jdbc-3.13.28.jar:/path/to/iceberg-aws-1.4.2.jar:/Users/sagarl/Downloads/bundle-2.23.9.jar org.apache.xtable.utilities.RunSync  --datasetConfig snowflake-sync-config.yaml --icebergCatalogConfig snowflake-sync-catalog.yaml
+```


### PR DESCRIPTION
## *Important Read*
https://github.com/apache/incubator-xtable/issues/548

## What is the purpose of the pull request
* Update Glue and Snowflake docs to show better catalog sync methods for iceberg tables

## Brief change log
* Updated Glue catalog doc
* Updated Snowflake integration doc

## Verify this pull request
* Trivial docs work
* Checked with `npm start` locally