### PR TITLE
[551] Exclude xtable-utilities from release guide

### DIFF
--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -188,7 +188,7 @@ Set up a few environment variables to simplify Maven commands that follow. This 
         3. git clone git@github.com:apache/incubator-xtable.git incubator-xtable-tmp-clone && cd incubator-xtable-tmp-clone && git checkout ${RELEASE_BRANCH} && cd ..
         4. tar -zxvf apache-xtable-${RELEASE_VERSION}.src.tgz 
         5. diff -qr apache-xtable-${RELEASE_VERSION} incubator-xtable-tmp-clone
-        6. Ensure the diff contains assets,demo,website and non-binary files only in incubator-xtable-tmp-clone.
+        6. Ensure the diff contains assets,demo,website,xtable-utilities and non-binary files only in incubator-xtable-tmp-clone.
         7. cd apache-xtable-${RELEASE_VERSION} && mvn clean package -DskipTests
         8. If they pass, delete the repository we got from the tar-ball
           - cd ../ && rm -rf apache-xtable-${RELEASE_VERSION} && rm -rf incubator-xtable-tmp-clone

--- a/release/scripts/create_source_release.sh
+++ b/release/scripts/create_source_release.sh
@@ -63,7 +63,7 @@ rsync -a \
   --exclude ".git" --exclude ".gitignore" --exclude ".gitattributes" --exclude ".travis.yml" \
   --exclude ".github" --exclude "target" --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" \
   --exclude "build-target" --exclude ".rubydeps" --exclude "rfc" --exclude "docker/images" \
-  --exclude "assets" --exclude "demo" --exclude "website" --exclude "style/IDE.png" . apache-xtable-$RELEASE_VERSION
+  --exclude "assets" --exclude "demo" --exclude "website" --exclude "style/IDE.png" --exclude "xtable-utilities" . apache-xtable-$RELEASE_VERSION
 
 tar czf ${RELEASE_DIR}/apache-xtable-${RELEASE_VERSION}.src.tgz apache-xtable-$RELEASE_VERSION
 gpg --armor --local-user E391B3E8179C4FD9BB8BF72002AB8E945EFD1E91 --detach-sig ${RELEASE_DIR}/apache-xtable-${RELEASE_VERSION}.src.tgz

--- a/release/scripts/validate_staged_bundles.sh
+++ b/release/scripts/validate_staged_bundles.sh
@@ -26,7 +26,7 @@ declare -a extensions=("-javadoc.jar" "-javadoc.jar.asc" "-javadoc.jar.md5" "-ja
 "-sources.jar.asc" "-sources.jar.md5" "-sources.jar.sha1" ".jar" ".jar.asc" ".jar.md5" ".jar.sha1" ".pom" ".pom.asc"
 ".pom.md5" ".pom.sha1")
 
-declare -a bundles=("xtable-api" "xtable-core" "xtable-hudi-support-extensions" "xtable-hudi-support-utils" "xtable-utilities" )
+declare -a bundles=("xtable-api" "xtable-core_2.12" "xtable-hudi-support-extensions_2.12" "xtable-hudi-support-utils")
 
 NOW=$(date +%s)
 TMP_DIR_FOR_BUNDLES=/tmp/${NOW}


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Excludes xtable-utilities from release scripts for generating source and validations.

## Brief change log

*(for example:)*
- *Excludes xtable-utilities from release scripts*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

Verified the scripts through dry run and used them for releasing 0.2.0-incubating rc1 as well.