### PR TITLE
[560] Increment Protobuf version due to vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <junit.version>5.9.0</junit.version>
         <lombok.version>1.18.30</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
-        <hadoop.version>3.3.6</hadoop.version>
+        <hadoop.version>3.4.0</hadoop.version>
         <hudi.version>0.14.0</hudi.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <parquet.version>1.12.2</parquet.version>
+        <protobuf.version>3.25.5</protobuf.version>
         <scala12.version>2.12.20</scala12.version>
         <scala13.version>2.13.14</scala13.version>
         <scala.version>${scala12.version}</scala.version>
@@ -386,12 +387,12 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.21.9</version>
+                <version>${protobuf.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java-util</artifactId>
-                <version>3.21.9</version>
+                <version>${protobuf.version}</version>
             </dependency>
 
             <!-- Guava -->


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request
Addresses #560 
Updates version based on dependabot's findings

## Brief change log

- Set protobuf dependencies to 3.25.5
- Update hadoop dependency which brings in the proto dependency

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

