### PR TITLE
[561] Add timeout to Github Action 

### DIFF
--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -32,6 +32,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/pom.xml
+++ b/pom.xml
@@ -637,6 +637,7 @@
                     <skip>${skipUTs}</skip>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <trimStackTrace>false</trimStackTrace>
+                    <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                 </configuration>
             </plugin>
             <plugin>
@@ -657,6 +658,7 @@
                     <forkCount>6</forkCount>
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>-Xmx1024m</argLine>
+                    <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Avoids long running github actions pipelines when there is an issue with a PR

## Brief change log

- Set timeout on the Github Action pipeline
- Add timeout for forked process in surefire and failsafe

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

