### PR TITLE
[Enhancement] Support restore/rollback sync during conversion (1/3)

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/model/IncrementalTableChanges.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/IncrementalTableChanges.java
@@ -33,4 +33,5 @@ public class IncrementalTableChanges {
   Iterator<TableChange> tableChanges;
   // pending commits before latest commit(write) on the table.
   @Builder.Default List<Instant> pendingCommits = Collections.emptyList();
+  @Builder.Default String sourceIdentifier = "";
 }

--- a/xtable-api/src/main/java/org/apache/xtable/model/InternalSnapshot.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/InternalSnapshot.java
@@ -41,6 +41,9 @@ import org.apache.xtable.model.storage.PartitionFileGroup;
 public class InternalSnapshot {
   // The instant of the Snapshot
   String version;
+  // The source table snapshot identifier
+  // Snapshot ID in Iceberg, version ID in Delta, and instant <timestamp_action> in Hudi
+  String sourceIdentifier;
   // Table reference
   InternalTable table;
   // Data files grouped by partition

--- a/xtable-api/src/main/java/org/apache/xtable/model/metadata/TableSyncMetadata.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/metadata/TableSyncMetadata.java
@@ -42,6 +42,7 @@ import org.apache.xtable.model.exception.ParseException;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TableSyncMetadata {
   private static final int CURRENT_VERSION = 0;
+  private static final String DEFAULT_IDENTIFIER = "";
   private static final ObjectMapper MAPPER =
       new ObjectMapper()
           .registerModule(new JavaTimeModule())
@@ -55,6 +56,13 @@ public class TableSyncMetadata {
   List<Instant> instantsToConsiderForNextSync;
   int version;
   String sourceIdentifier;
+
+  public static TableSyncMetadata of(
+          Instant lastInstantSynced,
+          List<Instant> instantsToConsiderForNextSync) {
+    return new TableSyncMetadata(
+            lastInstantSynced, instantsToConsiderForNextSync, CURRENT_VERSION, DEFAULT_IDENTIFIER);
+  }
 
   public static TableSyncMetadata of(
       Instant lastInstantSynced,

--- a/xtable-api/src/main/java/org/apache/xtable/model/metadata/TableSyncMetadata.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/metadata/TableSyncMetadata.java
@@ -54,10 +54,14 @@ public class TableSyncMetadata {
   Instant lastInstantSynced;
   List<Instant> instantsToConsiderForNextSync;
   int version;
+  String sourceIdentifier;
 
   public static TableSyncMetadata of(
-      Instant lastInstantSynced, List<Instant> instantsToConsiderForNextSync) {
-    return new TableSyncMetadata(lastInstantSynced, instantsToConsiderForNextSync, CURRENT_VERSION);
+      Instant lastInstantSynced,
+      List<Instant> instantsToConsiderForNextSync,
+      String sourceIdentifier) {
+    return new TableSyncMetadata(
+        lastInstantSynced, instantsToConsiderForNextSync, CURRENT_VERSION, sourceIdentifier);
   }
 
   public String toJson() {

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ConversionSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ConversionSource.java
@@ -78,4 +78,13 @@ public interface ConversionSource<COMMIT> extends Closeable {
    *     false.
    */
   boolean isIncrementalSyncSafeFrom(Instant instant);
+
+  /**
+   * Extract the identifier of the provided commit, the identifier defined as 1. Snapshot ID in
+   * Iceberg 2. Version ID in Delta 3. <timestamp_action> in Hudi
+   *
+   * @param commit The provided commit
+   * @return the string version of commit identifier
+   */
+  String getCommitIdentifier(COMMIT commit);
 }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ConversionSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ConversionSource.java
@@ -20,12 +20,14 @@ package org.apache.xtable.spi.extractor;
 
 import java.io.Closeable;
 import java.time.Instant;
+import java.util.Optional;
 
 import org.apache.xtable.model.CommitsBacklog;
 import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
+import org.apache.xtable.model.metadata.TableSyncMetadata;
 
 /**
  * A client that provides the major functionality for extracting the state at a given instant in a
@@ -64,6 +66,15 @@ public interface ConversionSource<COMMIT> extends Closeable {
    * @return {@link CommitsBacklog} to process.
    */
   CommitsBacklog<COMMIT> getCommitsBacklog(InstantsForIncrementalSync instantsForIncrementalSync);
+
+  /**
+   * Extracts the rollback snapshot as {@link InternalSnapshot} from the changes since the last sync
+   * of the source table.
+   *
+   * @param lastSyncMetadata The last sync metadata
+   * @return {@link InternalSnapshot} represent the rollback snapshot
+   */
+  Optional<InternalSnapshot> getRollbackSnapshot(TableSyncMetadata lastSyncMetadata);
 
   /**
    * Determines whether an incremental sync is safe from a given instant. This method checks for a

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ExtractFromSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ExtractFromSource.java
@@ -19,6 +19,7 @@
 package org.apache.xtable.spi.extractor;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,6 +29,7 @@ import org.apache.xtable.model.IncrementalTableChanges;
 import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
 import org.apache.xtable.model.TableChange;
+import org.apache.xtable.model.metadata.TableSyncMetadata;
 
 @AllArgsConstructor(staticName = "of")
 @Getter
@@ -54,5 +56,9 @@ public class ExtractFromSource<COMMIT> {
         .pendingCommits(commitsBacklog.getInFlightInstants())
         .sourceIdentifier(conversionSource.getCommitIdentifier(lastCommit))
         .build();
+  }
+
+  public Optional<InternalSnapshot> extractRollbackSnapshot(TableSyncMetadata lastSyncMetadata) {
+    return conversionSource.getRollbackSnapshot(lastSyncMetadata);
   }
 }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ExtractFromSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ExtractFromSource.java
@@ -47,9 +47,12 @@ public class ExtractFromSource<COMMIT> {
         commitsBacklog.getCommitsToProcess().stream()
             .map(conversionSource::getTableChangeForCommit)
             .iterator();
+    COMMIT lastCommit =
+        commitsBacklog.getCommitsToProcess().get(commitsBacklog.getCommitsToProcess().size() - 1);
     return IncrementalTableChanges.builder()
         .tableChanges(tableChangeIterator)
         .pendingCommits(commitsBacklog.getInFlightInstants())
+        .sourceIdentifier(conversionSource.getCommitIdentifier(lastCommit))
         .build();
   }
 }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/ConversionTarget.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/ConversionTarget.java
@@ -90,4 +90,7 @@ public interface ConversionTarget {
 
   /** Initializes the client with provided configuration */
   void init(TargetTable targetTable, Configuration configuration);
+
+  /**  Return the commit identifier from target table */
+  Optional<String> getTargetCommitIdentifier(String sourceIdentifier);
 }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/TableFormatSync.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/TableFormatSync.java
@@ -73,7 +73,8 @@ public class TableFormatSync {
                 internalTable,
                 target -> target.syncFilesForSnapshot(snapshot.getPartitionedDataFiles()),
                 startTime,
-                snapshot.getPendingCommits()));
+                snapshot.getPendingCommits(),
+                snapshot.getSourceIdentifier()));
       } catch (Exception e) {
         log.error("Failed to sync snapshot", e);
         results.put(
@@ -121,7 +122,8 @@ public class TableFormatSync {
                   change.getTableAsOfChange(),
                   target -> target.syncFilesForDiff(change.getFilesDiff()),
                   startTime,
-                  changes.getPendingCommits()));
+                  changes.getPendingCommits(),
+                  changes.getSourceIdentifier()));
         } catch (Exception e) {
           log.error("Failed to sync table changes", e);
           resultsForFormat.add(buildResultForError(SyncMode.INCREMENTAL, startTime, e));
@@ -149,7 +151,8 @@ public class TableFormatSync {
       InternalTable tableState,
       SyncFiles fileSyncMethod,
       Instant startTime,
-      List<Instant> pendingCommits) {
+      List<Instant> pendingCommits,
+      String sourceIdentifier) {
     // initialize the sync
     conversionTarget.beginSync(tableState);
     // sync schema updates
@@ -160,7 +163,7 @@ public class TableFormatSync {
     fileSyncMethod.sync(conversionTarget);
     // Persist the latest commit time in table properties for incremental syncs.
     TableSyncMetadata latestState =
-        TableSyncMetadata.of(tableState.getLatestCommitTime(), pendingCommits);
+        TableSyncMetadata.of(tableState.getLatestCommitTime(), pendingCommits, sourceIdentifier);
     conversionTarget.syncMetadata(latestState);
     conversionTarget.completeSync();
 

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -89,6 +89,7 @@ public class DeltaConversionSource implements ConversionSource<Long> {
     return InternalSnapshot.builder()
         .table(table)
         .partitionedDataFiles(getInternalDataFiles(snapshot, table.getReadSchema()))
+        .sourceIdentifier(String.valueOf(snapshot.version()))
         .build();
   }
 
@@ -156,6 +157,11 @@ public class DeltaConversionSource implements ConversionSource<Long> {
     // earliest commit of the table, hence the additional check.
     Instant deltaCommitInstant = Instant.ofEpochMilli(deltaCommitAtOrBeforeInstant.getTimestamp());
     return deltaCommitInstant.equals(instant) || deltaCommitInstant.isBefore(instant);
+  }
+
+  @Override
+  public String getCommitIdentifier(Long commit) {
+    return String.valueOf(commit);
   }
 
   private DeltaIncrementalChangesState getChangesState() {

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -31,6 +31,7 @@ import lombok.extern.log4j.Log4j2;
 
 import org.apache.spark.sql.SparkSession;
 
+import org.apache.spark.sql.delta.DeltaHistory;
 import org.apache.spark.sql.delta.DeltaHistoryManager;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.Snapshot;
@@ -39,6 +40,7 @@ import org.apache.spark.sql.delta.actions.AddFile;
 import org.apache.spark.sql.delta.actions.RemoveFile;
 
 import scala.Option;
+import scala.collection.Seq;
 
 import io.delta.tables.DeltaTable;
 
@@ -48,6 +50,7 @@ import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
+import org.apache.xtable.model.metadata.TableSyncMetadata;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.FileFormat;
@@ -157,6 +160,36 @@ public class DeltaConversionSource implements ConversionSource<Long> {
     // earliest commit of the table, hence the additional check.
     Instant deltaCommitInstant = Instant.ofEpochMilli(deltaCommitAtOrBeforeInstant.getTimestamp());
     return deltaCommitInstant.equals(instant) || deltaCommitInstant.isBefore(instant);
+  }
+
+  /**
+   * Extracts the rollback snapshot through the following steps: 1. Retrieve all commits made after
+   * the last sync 2. Identify the latest restore log among these commits 3. Return the {@link
+   * InternalSnapshot} from the latest restore log
+   */
+  @Override
+  public Optional<InternalSnapshot> getRollbackSnapshot(TableSyncMetadata lastSyncMetadata) {
+    DeltaHistoryManager.Commit deltaCommitAtLastSyncInstant =
+        deltaLog
+            .history()
+            .getActiveCommitAtTime(
+                Timestamp.from(lastSyncMetadata.getLastInstantSynced()), true, false, true);
+    long lastSyncVersion = deltaCommitAtLastSyncInstant.getVersion();
+    Seq<DeltaHistory> deltaCommits = deltaLog.history().getHistory(lastSyncVersion, null);
+    // Using find to get first "RESTORE" operation from history (latest to oldest)
+    Option<DeltaHistory> restoreLog =
+        deltaCommits.find(history -> "RESTORE".equals(history.operation()));
+    if (restoreLog.isDefined()) {
+      DeltaHistory unwrapRestoreLog = restoreLog.get();
+      InternalTable table = getTable(unwrapRestoreLog.getVersion());
+      Snapshot snapshot = deltaLog.getSnapshotAt(lastSyncVersion, Option.empty());
+      return Optional.of(
+          InternalSnapshot.builder()
+              .table(table)
+              .partitionedDataFiles(getInternalDataFiles(snapshot, table.getReadSchema()))
+              .build());
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionTarget.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionTarget.java
@@ -41,6 +41,7 @@ import org.apache.spark.sql.delta.DeltaConfigs;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.DeltaOperations;
 import org.apache.spark.sql.delta.OptimisticTransaction;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.actions.Action;
 import org.apache.spark.sql.delta.actions.AddFile;
 import org.apache.spark.sql.delta.actions.Format;
@@ -213,6 +214,28 @@ public class DeltaConversionTarget implements ConversionTarget {
   @Override
   public String getTableFormat() {
     return TableFormat.DELTA;
+  }
+
+  @Override
+  public Optional<String> getTargetCommitIdentifier(String sourceIdentifier) {
+    Snapshot currentSnapshot = deltaLog.currentSnapshot().snapshot();
+
+    // Iterate backward from the current version
+    for (long version = currentSnapshot.version(); version >= 0; version--) {
+      Snapshot snapshot = deltaLog.getSnapshotAt(version, null);
+      Optional<TableSyncMetadata> metadata =
+          TableSyncMetadata.fromJson(
+              snapshot
+                  .metadata()
+                  .configuration()
+                  .getOrElse(TableSyncMetadata.XTABLE_METADATA, () -> null));
+      if (metadata.isPresent()
+          && String.valueOf(metadata.get().getSourceIdentifier()).equals(sourceIdentifier)) {
+        return Optional.of(String.valueOf(snapshot.version()));
+      }
+    }
+
+    return Optional.empty();
   }
 
   @EqualsAndHashCode

--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiConversionSource.java
@@ -92,6 +92,7 @@ public class HudiConversionSource implements ConversionSource<HoodieInstant> {
             .findInstantsBefore(latestCommit.getTimestamp())
             .getInstants();
     InternalTable table = getTable(latestCommit);
+    HoodieInstant lastPendingInstant = pendingInstants.get(pendingInstants.size() - 1);
     return InternalSnapshot.builder()
         .table(table)
         .partitionedDataFiles(dataFileExtractor.getFilesCurrentState(table))
@@ -101,6 +102,7 @@ public class HudiConversionSource implements ConversionSource<HoodieInstant> {
                     hoodieInstant ->
                         HudiInstantUtils.parseFromInstantTime(hoodieInstant.getTimestamp()))
                 .collect(CustomCollectors.toList(pendingInstants.size())))
+        .sourceIdentifier(lastPendingInstant.getTimestamp() + "_" + latestCommit.getAction())
         .build();
   }
 
@@ -146,6 +148,11 @@ public class HudiConversionSource implements ConversionSource<HoodieInstant> {
   @Override
   public boolean isIncrementalSyncSafeFrom(Instant instant) {
     return doesCommitExistsAsOfInstant(instant) && !isAffectedByCleanupProcess(instant);
+  }
+
+  @Override
+  public String getCommitIdentifier(HoodieInstant commit) {
+    return commit.getTimestamp() + "_" + commit.getAction();
   }
 
   private boolean doesCommitExistsAsOfInstant(Instant instant) {

--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiConversionSource.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.Builder;
@@ -49,6 +50,7 @@ import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
+import org.apache.xtable.model.metadata.TableSyncMetadata;
 import org.apache.xtable.spi.extractor.ConversionSource;
 
 public class HudiConversionSource implements ConversionSource<HoodieInstant> {
@@ -153,6 +155,39 @@ public class HudiConversionSource implements ConversionSource<HoodieInstant> {
   @Override
   public String getCommitIdentifier(HoodieInstant commit) {
     return commit.getTimestamp() + "_" + commit.getAction();
+  }
+
+  @Override
+  public Optional<InternalSnapshot> getRollbackSnapshot(TableSyncMetadata lastSyncMetadata) {
+    String lastSyncCommit =
+        HudiInstantUtils.convertInstantToCommit(lastSyncMetadata.getLastInstantSynced());
+    HoodieTimeline pendingTimeline = getCompletedCommits().findInstantsAfter(lastSyncCommit);
+    List<HoodieInstant> instantsAfterLastSync = pendingTimeline.getInstants();
+    Optional<HoodieInstant> rollbackInstant =
+        instantsAfterLastSync.stream()
+            .filter(instant -> "rollback".equalsIgnoreCase(instant.getAction()))
+            .findFirst();
+    if (rollbackInstant.isPresent()) {
+      String rollbackTimestamp = rollbackInstant.get().getTimestamp();
+      List<HoodieInstant> pendingInstants =
+          pendingTimeline.findInstantsBeforeOrEquals(rollbackTimestamp).getInstants();
+      InternalTable table = getTable(rollbackInstant.get());
+      return Optional.of(
+          InternalSnapshot.builder()
+              .table(table)
+              .partitionedDataFiles(dataFileExtractor.getFilesCurrentState(table))
+              .pendingCommits(
+                  pendingInstants.stream()
+                      .map(
+                          hoodieInstant ->
+                              HudiInstantUtils.parseFromInstantTime(hoodieInstant.getTimestamp()))
+                      .collect(CustomCollectors.toList(pendingInstants.size())))
+              .sourceIdentifier(
+                  rollbackInstant.get().getTimestamp() + "_" + rollbackInstant.get().getAction())
+              .build());
+    }
+
+    return Optional.empty();
   }
 
   private boolean doesCommitExistsAsOfInstant(Instant instant) {

--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiConversionTarget.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiConversionTarget.java
@@ -316,6 +316,35 @@ public class HudiConversionTarget implements ConversionTarget {
     return TableFormat.HUDI;
   }
 
+  @Override
+  public Optional<String> getTargetCommitIdentifier(String sourceIdentifier) {
+    if (!metaClient.isPresent()) {
+      return Optional.empty();
+    }
+    HoodieTimeline completedTimeline =
+        metaClient.get().getActiveTimeline().filterCompletedInstants();
+    for (HoodieInstant instant : completedTimeline.getInstants()) {
+      Option<byte[]> instantDetails =
+          metaClient.get().getActiveTimeline().getInstantDetails(instant);
+      if (!instantDetails.isPresent()) {
+        continue;
+      }
+      try {
+        HoodieCommitMetadata commitMetadata =
+            HoodieCommitMetadata.fromBytes(instantDetails.get(), HoodieCommitMetadata.class);
+        String metadataJson =
+            commitMetadata.getExtraMetadata().get(TableSyncMetadata.XTABLE_METADATA);
+        Optional<TableSyncMetadata> xTableMetadata = TableSyncMetadata.fromJson(metadataJson);
+        if (xTableMetadata.isPresent()
+            && xTableMetadata.get().getSourceIdentifier().equals(sourceIdentifier)) {
+          return Optional.of(sourceIdentifier);
+        }
+      } catch (IOException ignored) {
+      }
+    }
+    return Optional.empty();
+  }
+
   private HoodieTableMetaClient getMetaClient() {
     return metaClient.orElseThrow(
         () -> new IllegalStateException("beginSync must be called before calling this method"));

--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
@@ -157,6 +157,7 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
         .version(String.valueOf(currentSnapshot.snapshotId()))
         .table(irTable)
         .partitionedDataFiles(partitionedDataFiles)
+        .sourceIdentifier(String.valueOf(currentSnapshot.snapshotId()))
         .build();
   }
 
@@ -255,6 +256,11 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
       currentSnapshotId = currentSnapshot.parentId();
     }
     return true;
+  }
+
+  @Override
+  public String getCommitIdentifier(Snapshot commit) {
+    return String.valueOf(commit.snapshotId());
   }
 
   @Override

--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -37,6 +38,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -55,6 +57,7 @@ import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
+import org.apache.xtable.model.metadata.TableSyncMetadata;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.stat.PartitionValue;
@@ -256,6 +259,23 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
       currentSnapshotId = currentSnapshot.parentId();
     }
     return true;
+  }
+
+  /*
+   * Extract rollback snapshot by checking if the current snapshot
+   * matches any entry in the table's history.
+   */
+  @Override
+  public Optional<InternalSnapshot> getRollbackSnapshot(TableSyncMetadata lastSyncMetadata) {
+    Table iceTable = getSourceTable();
+    long currentSnapshotId = iceTable.currentSnapshot().snapshotId();
+    for (HistoryEntry historyEntry : iceTable.history()) {
+      if (historyEntry.snapshotId() == currentSnapshotId) {
+        return Optional.of(getCurrentSnapshot());
+      }
+    }
+
+    return Optional.empty();
   }
 
   @Override

--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionTarget.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionTarget.java
@@ -242,6 +242,19 @@ public class IcebergConversionTarget implements ConversionTarget {
     return TableFormat.ICEBERG;
   }
 
+  @Override
+  public Optional<String> getTargetCommitIdentifier(String sourceIdentifier) {
+    for (Snapshot snapshot : table.snapshots()) {
+      Optional<TableSyncMetadata> metadata =
+          TableSyncMetadata.fromJson(snapshot.summary().get(TableSyncMetadata.XTABLE_METADATA));
+      if (metadata.isPresent()
+          && String.valueOf(metadata.get().getSourceIdentifier()).equals(sourceIdentifier)) {
+        return Optional.of(String.valueOf(snapshot.snapshotId()));
+      }
+    }
+    return Optional.empty();
+  }
+
   private void rollbackCorruptCommits() {
     if (table == null) {
       // there is no existing table so exit early


### PR DESCRIPTION
## *Important Read*
- Aim to address #40 

## What is the purpose of the pull request

Previously, if a rollback/restore occurred in the source table, XTable would reflect it as file changes (added or deleted) in the target table. In this PR, we aim to improve this by issuing a rollback command in the target tables, ensuring more consistent histories between the source and target. This approach is also more efficient, as it allows us to restore directly to a specific version/snapshot instead of computing a large diff against the table’s current state.

This is the first part of this enhancement (1/3), focusing primarily on detecting whether a rollback/restore occurred in the source table and verifying if the corresponding commit exists in the target table.

## Brief change log

- *Add a source identifier in target transaction*
- *[Source] Detect rollback and get the rollbackSnapshot from source table*
- *[Target] Verify if the target table contains the corresponding rollback commit*

## Verify this pull request

This pull request is already covered by existing tests, all existing tests should pass
