### PR TITLE
Iceberg and Delta target: sync schema field comments

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergSchemaSync.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergSchemaSync.java
@@ -21,6 +21,7 @@ package org.apache.xtable.iceberg;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -131,6 +132,12 @@ public class IcebergSchemaSync {
           updates.put(
               latestColumn.fieldId(), () -> updateSchema.requireColumn(latestColumn.name()));
         }
+      }
+      // update the comment of the column
+      if (!Objects.equals(currentColumn.doc(), latestColumn.doc())) {
+        updates.put(
+            latestColumn.fieldId(),
+            () -> updateSchema.updateColumnDoc(latestColumn.name(), latestColumn.doc()));
       }
       if (latestColumn.type().isStructType()) {
         updates.putAll(

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
@@ -56,6 +56,7 @@ public class TestDeltaSchemaExtractor {
                                 .name("boolean")
                                 .dataType(InternalType.BOOLEAN)
                                 .isNullable(false)
+                                .comment("requiredBooleanComment")
                                 .build())
                         .build(),
                     InternalField.builder()
@@ -226,7 +227,7 @@ public class TestDeltaSchemaExtractor {
 
     StructType structRepresentation =
         new StructType()
-            .add("requiredBoolean", DataTypes.BooleanType, false)
+            .add("requiredBoolean", DataTypes.BooleanType, false, "requiredBooleanComment")
             .add("optionalBoolean", DataTypes.BooleanType, true)
             .add("requiredInt", DataTypes.IntegerType, false)
             .add("optionalInt", DataTypes.IntegerType, true)
@@ -268,6 +269,7 @@ public class TestDeltaSchemaExtractor {
                                 .name("fixed")
                                 .dataType(InternalType.FIXED)
                                 .isNullable(false)
+                                .comment("comment")
                                 .build())
                         .build(),
                     InternalField.builder()
@@ -296,6 +298,7 @@ public class TestDeltaSchemaExtractor {
                                 .name("binary")
                                 .dataType(InternalType.BYTES)
                                 .isNullable(false)
+                                .comment("comment")
                                 .build())
                         .build(),
                     InternalField.builder()
@@ -311,7 +314,7 @@ public class TestDeltaSchemaExtractor {
             .build();
     StructType structRepresentation =
         new StructType()
-            .add("requiredFixed", DataTypes.BinaryType, false)
+            .add("requiredFixed", DataTypes.BinaryType, false, "comment")
             .add("optionalFixed", DataTypes.BinaryType, true);
 
     Assertions.assertEquals(
@@ -681,6 +684,7 @@ public class TestDeltaSchemaExtractor {
                                 .name("struct")
                                 .dataType(InternalType.RECORD)
                                 .isNullable(true)
+                                .comment("comment")
                                 .fields(
                                     Arrays.asList(
                                         InternalField.builder()
@@ -691,6 +695,7 @@ public class TestDeltaSchemaExtractor {
                                                     .name("integer")
                                                     .dataType(InternalType.INT)
                                                     .isNullable(true)
+                                                    .comment("nestedOptionalIntComment")
                                                     .build())
                                             .defaultValue(
                                                 InternalField.Constants.NULL_DEFAULT_VALUE)
@@ -740,13 +745,18 @@ public class TestDeltaSchemaExtractor {
             .add(
                 "nestedOne",
                 new StructType()
-                    .add("nestedOptionalInt", DataTypes.IntegerType, true)
+                    .add(
+                        "nestedOptionalInt",
+                        DataTypes.IntegerType,
+                        true,
+                        "nestedOptionalIntComment")
                     .add("nestedRequiredDouble", DataTypes.DoubleType, false)
                     .add(
                         "nestedTwo",
                         new StructType().add("doublyNestedString", DataTypes.StringType, true),
                         false),
-                true);
+                true,
+                "comment");
     Assertions.assertEquals(
         structRepresentation,
         DeltaSchemaExtractor.getInstance().fromInternalSchema(internalSchema));


### PR DESCRIPTION

## *Important Read*

Aim to address https://github.com/apache/incubator-xtable/issues/525

## What is the purpose of the pull request

It is expected to capture the comments and sync the comments of field when syncing schema. The PR makes the comments of schema fields are captured and synced correctly.

## Brief change log

- For Delta target, extract the comment from internal schema and add to Spark schema representative. 
- For Iceberg target, make sure any difference of comments is captured during syncSchema() and the schema is updated with new comments.

## Verify this pull request

This change added tests and can be verified as follows:

- *Added unit tests to test the comments in Iceberg schema sync test class*
- *Added comments in Delta schema extractor test class*
