### PR TITLE
[551] Try enabling keep_files as false in GH action for downloads

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           personal_token: ${{ secrets.XTABLE_SITE_DEPLOY }}
           external_repository: apache/incubator-xtable-site
+          keep_files: false
           publish_branch: main
           publish_dir: ./website/build
           user_name: ${{ github.actor }}


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

The local version of the website is not getting deployed to https://xtable.incubator.apache.org/, setting the keep_files flag as false to see if it works.

## Brief change log

*(for example:)*
- *Setting the keep_files config to false to see if website docs upload works*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

The website builds locally using npm. 