### PR TITLE
Site content is not deployed due to missing .asf.yaml file

### DIFF
--- a/website/static/.asf.yaml
+++ b/website/static/.asf.yaml
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+publish:
+   whoami: main


### PR DESCRIPTION
## What is the purpose of the pull request
Restore the .asf.yaml file that was accidentally removed by https://github.com/apache/incubator-xtable/commit/493e1878dc94c3d8f29675132f03e3941e29b470 as a side-effect of changing the keep_files configuration.

## Brief change log
Add .asf.yaml  under static directory to appear at the root of https://github.com/apache/incubator-xtable

## Verify this pull request

Cannot be tested without committing to the repo.