### PR TITLE
[590] Add RFC template for XTable 

### DIFF
--- a/rfc/template.md
+++ b/rfc/template.md
@@ -1,0 +1,55 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+# RFC-[number]: [Title]
+
+## Proposers
+
+- @<proposer1 github username>
+- @<proposer2 github username>
+
+## Approvers
+- @<approver1 github username>
+- @<approver2 github username>
+
+## Status
+
+GH Feature Request: <link to umbrella JIRA>
+
+> Please keep the status updated in `rfc/README.md`.
+
+## Abstract
+
+Describe the problem you are trying to solve and a brief description of why it’s needed.
+
+## Background
+Introduce any background context which is relevant or necessary to understand the feature and design choices.
+
+## Implementation
+Describe the new thing you want to do in appropriate detail, how it fits into the project architecture.<br>
+Provide a detailed description of how you intend to implement this feature, this may be fairly extensive and have large subsections of its own or it may be a few sentences.<br>
+Use judgement to decide on how detailed the description needs to be based on the scope of the change. If unclear, you can ask questions in dev@xtable.apache.org.
+
+## Rollout/Adoption Plan
+
+- Are there any breaking changes as part of this new feature/functionality?
+- What impact (if any) will there be on existing users?
+- If we are changing behavior how will we phase out the older behavior? When will we remove the existing behavior? 
+- If we need special migration tools, describe them here.
+
+## Test Plan
+
+Describe in few sentences how the RFC will be tested. How will we know that the implementation works as expected? How will we know nothing breaks?


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

The RFC template was reverted in previous commit, adding the template back. 
https://github.com/apache/incubator-xtable/pull/604 

## Brief change log

*(for example:)*
- *Add RFC template*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.