### PR TITLE
[615] Add Iceberg stats when reading snapshot

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
@@ -145,7 +145,8 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
     Snapshot currentSnapshot = iceTable.currentSnapshot();
     InternalTable irTable = getTable(currentSnapshot);
 
-    TableScan scan = iceTable.newScan().useSnapshot(currentSnapshot.snapshotId());
+    TableScan scan =
+        iceTable.newScan().useSnapshot(currentSnapshot.snapshotId()).includeColumnStats();
     PartitionSpec partitionSpec = iceTable.spec();
     List<PartitionFileGroup> partitionedDataFiles;
     try (CloseableIterable<FileScanTask> files = scan.planFiles()) {


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

- Fixes a bug where the column stats were not populated when reading snapshots

## Brief change log

- Include column stats when reading the snapshot

## Verify this pull request

- Updated the unit tests to validate that the column stats are set for snapshots and when reading just the changes for that commit
