### PR TITLE
[608] Ensure column stats for decimal fields have proper scale set

### DIFF
--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaValueConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaValueConverter.java
@@ -21,6 +21,9 @@ package org.apache.xtable.delta;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -32,6 +35,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
 
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.schema.InternalType;
@@ -213,5 +218,110 @@ public class TestDeltaValueConverter {
         Arguments.of("+Infinity", floatSchema, Float.POSITIVE_INFINITY),
         Arguments.of(Double.NaN, doubleSchema, Double.NaN),
         Arguments.of(Double.POSITIVE_INFINITY, doubleSchema, Double.POSITIVE_INFINITY));
+  }
+
+  @ParameterizedTest
+  @MethodSource("decimalValues")
+  void parseDecimalValues(
+      Object deltaValue, InternalSchema fieldSchema, BigDecimal expectedOutput) {
+    assertEquals(
+        expectedOutput,
+        DeltaValueConverter.convertFromDeltaColumnStatValue(deltaValue, fieldSchema));
+  }
+
+  private static Stream<Arguments> decimalValues() {
+    return Stream.of(
+        Arguments.of(
+            -8.00,
+            InternalSchema.builder()
+                .name("decimal")
+                .dataType(InternalType.DECIMAL)
+                .metadata(
+                    ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                        .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                        .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 5)
+                        .build())
+                .build(),
+            new BigDecimal("-8.00", new MathContext(5, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY)),
+        Arguments.of(
+            -8.00f,
+            InternalSchema.builder()
+                .name("decimal")
+                .dataType(InternalType.DECIMAL)
+                .metadata(
+                    ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                        .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                        .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 5)
+                        .build())
+                .build(),
+            new BigDecimal("-8.00", new MathContext(5, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY)),
+        Arguments.of(
+            1000,
+            InternalSchema.builder()
+                .name("decimal")
+                .dataType(InternalType.DECIMAL)
+                .metadata(
+                    ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                        .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                        .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 6)
+                        .build())
+                .build(),
+            new BigDecimal("1000.00", new MathContext(6, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY)),
+        Arguments.of(
+            1000L,
+            InternalSchema.builder()
+                .name("decimal")
+                .dataType(InternalType.DECIMAL)
+                .metadata(
+                    ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                        .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                        .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 6)
+                        .build())
+                .build(),
+            new BigDecimal("1000.00", new MathContext(6, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY)),
+        Arguments.of(
+            "1000",
+            InternalSchema.builder()
+                .name("decimal")
+                .dataType(InternalType.DECIMAL)
+                .metadata(
+                    ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                        .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                        .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 6)
+                        .build())
+                .build(),
+            new BigDecimal("1000.00", new MathContext(6, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY)),
+        Arguments.of(
+            1234.56,
+            InternalSchema.builder()
+                .name("decimal")
+                .dataType(InternalType.DECIMAL)
+                .metadata(
+                    ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                        .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                        .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 6)
+                        .build())
+                .build(),
+            new BigDecimal("1234.56", new MathContext(6, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY)),
+        Arguments.of(
+            new BigDecimal("1234.56", new MathContext(6, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY),
+            InternalSchema.builder()
+                .name("decimal")
+                .dataType(InternalType.DECIMAL)
+                .metadata(
+                    ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                        .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                        .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 6)
+                        .build())
+                .build(),
+            new BigDecimal("1234.56", new MathContext(6, RoundingMode.UNNECESSARY))
+                .setScale(2, RoundingMode.UNNECESSARY)));
   }
 }

--- a/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiFileStatsExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiFileStatsExtractor.java
@@ -286,12 +286,8 @@ public class TestHudiFileStatsExtractor {
     assertEquals(1, decimalColumnStat.getNumNulls());
     assertEquals(2, decimalColumnStat.getNumValues());
     assertTrue(decimalColumnStat.getTotalSize() > 0);
-    assertEquals(
-        new BigDecimal("1234.56"),
-        ((BigDecimal) decimalColumnStat.getRange().getMinValue()).setScale(2));
-    assertEquals(
-        new BigDecimal("1234.56"),
-        ((BigDecimal) decimalColumnStat.getRange().getMaxValue()).setScale(2));
+    assertEquals(new BigDecimal("1234.56"), decimalColumnStat.getRange().getMinValue());
+    assertEquals(new BigDecimal("1234.56"), decimalColumnStat.getRange().getMaxValue());
   }
 
   private HoodieRecord<HoodieAvroPayload> buildRecord(GenericRecord record) {

--- a/xtable-core/src/test/java/org/apache/xtable/testutil/ColumnStatMapUtil.java
+++ b/xtable-core/src/test/java/org/apache/xtable/testutil/ColumnStatMapUtil.java
@@ -26,6 +26,8 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.schema.InternalType;
@@ -174,7 +176,16 @@ public class ColumnStatMapUtil {
   private static final InternalField DECIMAL_FIELD =
       InternalField.builder()
           .name("decimal_field")
-          .schema(InternalSchema.builder().name("decimal").dataType(InternalType.DECIMAL).build())
+          .schema(
+              InternalSchema.builder()
+                  .name("decimal")
+                  .dataType(InternalType.DECIMAL)
+                  .metadata(
+                      ImmutableMap.<InternalSchema.MetadataKey, Object>builder()
+                          .put(InternalSchema.MetadataKey.DECIMAL_SCALE, 2)
+                          .put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 5)
+                          .build())
+                  .build())
           .build();
 
   private static final InternalField FLOAT_FIELD =
@@ -312,7 +323,7 @@ public class ColumnStatMapUtil {
         ColumnStat.builder()
             .field(DECIMAL_FIELD)
             .numNulls(1)
-            .range(Range.vector(new BigDecimal("1.0"), new BigDecimal("2.0")))
+            .range(Range.vector(new BigDecimal("1.00"), new BigDecimal("2.00")))
             .numValues(50)
             .totalSize(123)
             .build();


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Addresses bug found in #608 

When converting the column stats to bytes in Iceberg, the `BigDecimal#unscaledValue` is called. If the value has the wrong scale, then the serialization and then deserialization will result in a different value.

## Brief change log

- Set the scale when reading back the column stats from the Hudi Metadata Table
- Set the scale when parsing the Delta Log stats

## Verify this pull request

- Fixed incorrect unit test setup for Hudi column stats extraction
- Added new tests for converting the column stats values for Delta Lake
