### PR TITLE
Delta source: add record count for DataFile

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/model/stat/FileStats.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/stat/FileStats.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.stat;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Captures a file level statistics.
+ *
+ * @since 0.2
+ */
+@Value
+@Builder(toBuilder = true)
+public class FileStats {
+  List<ColumnStat> columnStats;
+  long numRecords;
+}

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
@@ -35,6 +35,7 @@ import org.apache.xtable.exception.NotSupportedException;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.stat.ColumnStat;
+import org.apache.xtable.model.stat.FileStats;
 import org.apache.xtable.model.storage.FileFormat;
 import org.apache.xtable.model.storage.InternalDataFile;
 
@@ -56,13 +57,10 @@ public class DeltaActionsConverter {
       boolean includeColumnStats,
       DeltaPartitionExtractor partitionExtractor,
       DeltaStatsExtractor fileStatsExtractor) {
+    FileStats fileStats = fileStatsExtractor.getColumnStatsForFile(addFile, fields);
     List<ColumnStat> columnStats =
-        includeColumnStats
-            ? fileStatsExtractor.getColumnStatsForFile(addFile, fields)
-            : Collections.emptyList();
-    long recordCount =
-        columnStats.stream().map(ColumnStat::getNumValues).max(Long::compareTo).orElse(0L);
-    // TODO(https://github.com/apache/incubator-xtable/issues/102): removed record count.
+        includeColumnStats ? fileStats.getColumnStats() : Collections.emptyList();
+    long recordCount = fileStats.getNumRecords();
     return InternalDataFile.builder()
         .physicalPath(getFullPathToFile(deltaSnapshot, addFile.path()))
         .fileFormat(fileFormat)


### PR DESCRIPTION

## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Addresses https://github.com/apache/incubator-xtable/issues/102

## Brief change log

-  Update how to get the number of records from Delta source 
- Side effect, it also fixed the edge case when columnStats list is empty, the number of records becomes 0

## Verify this pull request

This change added tests and can be verified as follows:

- added a line of test
