### PR TITLE
Add community sync page for XTable

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -109,5 +109,9 @@ npm run serve
 1. The homepage is a `.html` file located at `website/static/index.html`
 2. If you're making changes to the page, test it locally using `python 3 -m http.server` and visiting http://localhost:8000/ before pushing the changes.
 
+## Add community sync page 
+1. Create a `.md` file with all the content for Community page.
+2. Add community page to website homepage. 
+
 ## Maintainers
 [Apache XTable™ (Incubating) Community](https://incubator.apache.org/projects/xtable.html)

--- a/website/community/sync.md
+++ b/website/community/sync.md
@@ -1,0 +1,34 @@
+# Community
+
+We have set up the following regular syncs for community users and developers to meet, interact and exchange ideas. Meetings will be recorded and made available after every sync.
+
+
+## Bi-weekly Community Call
+Participate in our Community Calls by joining us on [Google Meet](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NXE5MGxnaGszOTgxN3FwMnRuZzRibzB2aW1fMjAyNTAxMjdUMTYwMDAwWiA2MWYzYmJjYzMwMzQzODhlNmZkMTlmNzEyNDU0NmEzMjQ5ZmMwYTFiZWMwZmVhYTNiNjNkZGQ1NTM2MzI2NTIwQGc&tmsrc=61f3bbcc3034388e6fd19f7124546a3249fc0a1bec0feaa3b63ddd5536326520%40group.calendar.google.com&scp=ALL) by adding the invite to your calendar.
+
+Here's a quick view of the upcoming community syncs:
+
+- 27th Jan 2025, 8:00 - 8:45AM PST
+- 10th Feb 2025, 8:00 - 8:45AM PST
+- 24th Feb 2025, 8:00 - 8:45AM PST
+
+## Join the Community on Slack
+We have a [Slack channel](https://join.slack.com/t/apachextablei-yoi8504/shared_invite/zt-2y9hqskhv-ZfSwoxzq~PTJlWGj0V1sQw) that you can join for help with any questions, issues, design choices, announcements, etc.
+
+
+## Recordings of the Community Calls
+Find date-wise recordings here.
+- [14th Jan 2025](https://drive.google.com/file/d/1eVRIWvf-Kn2UoYYctIyO-Iaetha8U_nH/view?usp=sharing)
+
+
+## Typical agenda
+Agenda Doc: https://docs.google.com/document/d/1mSthtQBVDDzi9bLn9sWDsPaJLJHCDoK_MxDsSphhlos/edit?usp=sharing
+
+
+## YouTube Channel
+https://www.youtube.com/@ApacheXTable/videos
+
+
+## Socials
+- [Linkedin](https://www.linkedin.com/company/apache-xtable/)
+- [X](https://twitter.com/apachextable)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -33,6 +33,14 @@ const config = {
           routeBasePath: 'releases',
         },
       ],
+      [
+        '@docusaurus/plugin-content-docs',
+        {
+          id: 'community',
+          path: 'community',
+          routeBasePath: 'community',
+        },
+      ]
     ],
 
   presets: [
@@ -78,6 +86,7 @@ const config = {
           },
           {to: 'blog', label: 'Blogs', position: 'left'},
           {to: 'releases/downloads', label: 'Downloads', position: 'left'},
+          {to: 'community/sync', label: 'Community', position: 'left'}
         ],
       },
       prism: {

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -33,6 +33,7 @@
       <nav role="navigation" class="nav-menu w-nav-menu">
         <a href="#" class="nav-link w-nav-link">Home</a>
         <a href="https://xtable.apache.org/docs/setup/" class="nav-link w-nav-link">Docs</a>
+        <a href="https://xtable.apache.org/community/sync" class="nav-link w-nav-link">Community</a>
         <a href="https://xtable.apache.org/blog" class="nav-link w-nav-link">Blogs</a><img src="images/break.svg" loading="lazy" alt="" class="image-10">
         <a href="https://xtable.apache.org/releases/downloads" class="nav-link w-nav-link">Downloads</a>
         <a href="https://github.com/apache/incubator-xtable" class="nav-icon-link1 w-inline-block"><img src="images/Github.svg" loading="lazy" alt=""></a>
@@ -50,6 +51,7 @@
       <nav role="navigation" class="nav-menu-copy w-nav-menu">
         <a href="#" class="nav-link-copy w-nav-link">Home</a>
         <a href="https://xtable.apache.org/docs/setup/" class="nav-link-copy w-nav-link">Docs</a>
+        <a href="https://xtable.apache.org/community/sync" class="nav-link-copy w-nav-link">Community</a>
         <a href="https://xtable.apache.org/blog" class="nav-link-copy w-nav-link">Blogs</a>
         <a href="https://xtable.apache.org/releases/downloads" class="nav-link-copy w-nav-link">Downloads</a>
         <a href="https://github.com/apache/incubator-xtable" class="nav-link-copy w-nav-link">GitHub</a>


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Add community sync page for Apache XTable(Incubating). Following Monday 8AM PST schedule based on response from 
dev channel. 
https://lists.apache.org/thread/30gtw1qnk0jyhv8xmhtoox662sj0mf86 
  
<img width="879" alt="image" src="https://github.com/user-attachments/assets/045721a9-0a4e-4583-8e7d-c03359f33561" />



## Brief change log

*(for example:)*
- *Add community sync page for Apache XTable(Incubating)*

## Verify this pull request

*(Please pick either of the following options)*

Verified the page loads locally and all links are valid.