### PR TITLE
Extract Delta Lake deletion vectors

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/model/TableChange.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/TableChange.java
@@ -18,10 +18,15 @@
  
 package org.apache.xtable.model;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Value;
 
 import org.apache.xtable.model.storage.DataFilesDiff;
+import org.apache.xtable.model.storage.InternalDeletionVector;
 
 /**
  * Captures the changes in a single commit/instant from the source table.
@@ -29,11 +34,23 @@ import org.apache.xtable.model.storage.DataFilesDiff;
  * @since 0.1
  */
 @Value
-@Builder(toBuilder = true)
+@Builder(toBuilder = true, builderClassName = "Builder")
 public class TableChange {
   // Change in files at the specified instant
   DataFilesDiff filesDiff;
 
+  // A commit can add deletion vectors when some records are deleted. New deletion vectors can be
+  // added even if no new data files are added. However, as deletion vectors are always associated
+  // with a data file, they are implicitly removed when a corresponding data file is removed.
+  List<InternalDeletionVector> deletionVectorsAdded;
+
   /** The {@link InternalTable} at the commit time to which this table change belongs. */
   InternalTable tableAsOfChange;
+
+  public static class Builder {
+    public Builder deletionVectorsAdded(Collection<InternalDeletionVector> deletionVectorsAdded) {
+      this.deletionVectorsAdded = new ArrayList<>(deletionVectorsAdded);
+      return this;
+    }
+  }
 }

--- a/xtable-api/src/main/java/org/apache/xtable/model/storage/InternalDeletionVector.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/storage/InternalDeletionVector.java
@@ -42,34 +42,34 @@ public class InternalDeletionVector {
   long countRecordsDeleted;
 
   // physical path of the deletion vector file (absolute with scheme)
-  String deletionVectorFilePath;
+  String sourceDeletionVectorFilePath;
 
   // offset of deletion vector start in a deletion vector file
   int offset;
 
   /**
    * binary representation of the deletion vector. The consumer can use the {@link
-   * #deleteRecordIterator()} to extract the positional ordinals represented in the binary format.
+   * #ordinalsIterator()} to extract the ordinals represented in the binary format.
    */
   byte[] binaryRepresentation;
 
   /**
-   * Supplier for an iterator that returns the ordinal position of a record deleted by this deletion
-   * vector in the data file, identified by {@link #dataFilePath}.
+   * Supplier for an iterator that returns the ordinals of records deleted by this deletion vector
+   * in the linked data file, identified by {@link #dataFilePath}.
    *
    * <p>The {@link InternalDeletionVector} instance does not guarantee that a new or distinct result
    * will be returned each time the supplier is invoked. However, the supplier is expected to return
    * a new iterator for each call.
    */
   @Getter(AccessLevel.NONE)
-  Supplier<Iterator<Long>> deleteRecordSupplier;
+  Supplier<Iterator<Long>> ordinalsSupplier;
 
   /**
-   * @return An iterator that returns the ordinal position of a record deleted by this deletion.
-   *     There is no guarantee that a new or distinct iterator will be returned each time the
-   *     iterator is invoked.
+   * @return An iterator that returns the ordinals of records deleted by this deletion vector in the
+   *     linked data file. There is no guarantee that a new or distinct iterator will be returned
+   *     each time the iterator is invoked.
    */
-  public Iterator<Long> deleteRecordIterator() {
-    return deleteRecordSupplier.get();
+  public Iterator<Long> ordinalsIterator() {
+    return ordinalsSupplier.get();
   }
 }

--- a/xtable-api/src/main/java/org/apache/xtable/model/storage/InternalDeletionVector.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/storage/InternalDeletionVector.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.storage;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+@Builder(toBuilder = true, builderClassName = "Builder")
+@Accessors(fluent = true)
+@Value
+public class InternalDeletionVector {
+  // path (absolute with scheme) of data file to which this deletion vector belongs
+  @NonNull String dataFilePath;
+
+  // physical path of the deletion vector file (absolute with scheme)
+  String deletionVectorFilePath;
+
+  // offset of deletion vector start in the deletion vector file
+  int offset;
+
+  // length of the deletion vector in the deletion vector file
+  int length;
+
+  // count of records deleted by this deletion vector
+  long countRecordsDeleted;
+
+  @Getter(AccessLevel.NONE)
+  Supplier<Iterator<Long>> deleteRecordSupplier;
+
+  public Iterator<Long> deleteRecordIterator() {
+    return deleteRecordSupplier.get();
+  }
+
+  public static class Builder {
+    public Builder deleteRecordSupplier(Supplier<Iterator<Long>> recordsSupplier) {
+      this.deleteRecordSupplier = recordsSupplier;
+      return this;
+    }
+  }
+}

--- a/xtable-api/src/main/java/org/apache/xtable/model/storage/InternalDeletionVector.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/storage/InternalDeletionVector.java
@@ -35,29 +35,41 @@ public class InternalDeletionVector {
   // path (absolute with scheme) of data file to which this deletion vector belongs
   @NonNull String dataFilePath;
 
-  // physical path of the deletion vector file (absolute with scheme)
-  String deletionVectorFilePath;
-
-  // offset of deletion vector start in the deletion vector file
-  int offset;
-
-  // length of the deletion vector in the deletion vector file
-  int length;
+  // size of the deletion vector
+  int size;
 
   // count of records deleted by this deletion vector
   long countRecordsDeleted;
 
+  // physical path of the deletion vector file (absolute with scheme)
+  String deletionVectorFilePath;
+
+  // offset of deletion vector start in a deletion vector file
+  int offset;
+
+  /**
+   * binary representation of the deletion vector. The consumer can use the {@link
+   * #deleteRecordIterator()} to extract the positional ordinals represented in the binary format.
+   */
+  byte[] binaryRepresentation;
+
+  /**
+   * Supplier for an iterator that returns the ordinal position of a record deleted by this deletion
+   * vector in the data file, identified by {@link #dataFilePath}.
+   *
+   * <p>The {@link InternalDeletionVector} instance does not guarantee that a new or distinct result
+   * will be returned each time the supplier is invoked. However, the supplier is expected to return
+   * a new iterator for each call.
+   */
   @Getter(AccessLevel.NONE)
   Supplier<Iterator<Long>> deleteRecordSupplier;
 
+  /**
+   * @return An iterator that returns the ordinal position of a record deleted by this deletion.
+   *     There is no guarantee that a new or distinct iterator will be returned each time the
+   *     iterator is invoked.
+   */
   public Iterator<Long> deleteRecordIterator() {
     return deleteRecordSupplier.get();
-  }
-
-  public static class Builder {
-    public Builder deleteRecordSupplier(Supplier<Iterator<Long>> recordsSupplier) {
-      this.deleteRecordSupplier = recordsSupplier;
-      return this;
-    }
   }
 }

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
@@ -139,7 +139,7 @@ public class DeltaActionsConverter {
             .dataFilePath(dataFilePath)
             .deletionVectorFilePath(deletionVectorFilePath.toString())
             .countRecordsDeleted(deletionVector.cardinality())
-            .offset((Integer) deletionVector.offset().get())
+            .offset(getOffset(deletionVector))
             .length(deletionVector.sizeInBytes())
             .deleteRecordSupplier(() -> deletedRecordsIterator(snapshot, deletionVector))
             .build();
@@ -154,8 +154,12 @@ public class DeltaActionsConverter {
 
     Path deletionVectorFilePath = deleteVector.absolutePath(snapshot.deltaLog().dataPath());
     int size = deleteVector.sizeInBytes();
-    int offset = deleteVector.offset().isDefined() ? (int) deleteVector.offset().get() : 1;
+    int offset = getOffset(deleteVector);
     RoaringBitmapArray rbm = dvStore.read(deletionVectorFilePath, offset, size);
     return Arrays.stream(rbm.values()).iterator();
+  }
+
+  private static int getOffset(DeletionVectorDescriptor deleteVector) {
+    return deleteVector.offset().isDefined() ? (int) deleteVector.offset().get() : 1;
   }
 }

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
@@ -144,25 +144,25 @@ public class DeltaActionsConverter {
     if (deletionVector.isInline()) {
       deleteVectorBuilder
           .binaryRepresentation(deletionVector.inlineData())
-          .deleteRecordSupplier(() -> deletedRecordsIterator(deletionVector.inlineData()));
+          .ordinalsSupplier(() -> ordinalsIterator(deletionVector.inlineData()));
     } else {
       Path deletionVectorFilePath = deletionVector.absolutePath(snapshot.deltaLog().dataPath());
       deleteVectorBuilder
           .offset(getOffset(deletionVector))
-          .deletionVectorFilePath(deletionVectorFilePath.toString())
-          .deleteRecordSupplier(() -> deletedRecordsIterator(snapshot, deletionVector));
+          .sourceDeletionVectorFilePath(deletionVectorFilePath.toString())
+          .ordinalsSupplier(() -> ordinalsIterator(snapshot, deletionVector));
     }
 
     return deleteVectorBuilder.build();
   }
 
-  private Iterator<Long> deletedRecordsIterator(byte[] bytes) {
+  private Iterator<Long> ordinalsIterator(byte[] bytes) {
     RoaringBitmapArray rbm = RoaringBitmapArray.readFrom(bytes);
     long[] ordinals = rbm.values();
     return Arrays.stream(ordinals).iterator();
   }
 
-  private Iterator<Long> deletedRecordsIterator(
+  private Iterator<Long> ordinalsIterator(
       Snapshot snapshot, DeletionVectorDescriptor deleteVector) {
     Path deletionVectorFilePath = deleteVector.absolutePath(snapshot.deltaLog().dataPath());
     int offset = getOffset(deleteVector);

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -22,11 +22,9 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import lombok.Builder;
 import lombok.extern.log4j.Log4j2;
@@ -54,6 +52,7 @@ import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.storage.DataFilesDiff;
 import org.apache.xtable.model.storage.FileFormat;
 import org.apache.xtable.model.storage.InternalDataFile;
+import org.apache.xtable.model.storage.InternalDeletionVector;
 import org.apache.xtable.model.storage.PartitionFileGroup;
 import org.apache.xtable.spi.extractor.ConversionSource;
 import org.apache.xtable.spi.extractor.DataFileIterator;
@@ -112,8 +111,8 @@ public class DeltaConversionSource implements ConversionSource<Long> {
     // All 3 of the following data structures use data file's absolute path as the key
     Map<String, InternalDataFile> addedFiles = new HashMap<>();
     Map<String, InternalDataFile> removedFiles = new HashMap<>();
-    // Set of data file paths for which deletion vectors exists.
-    Set<String> deletionVectors = new HashSet<>();
+    // Map of data file paths for which deletion vectors exists.
+    Map<String, InternalDeletionVector> deletionVectors = new HashMap<>();
 
     for (Action action : actionsForVersion) {
       if (action instanceof AddFile) {
@@ -128,10 +127,10 @@ public class DeltaConversionSource implements ConversionSource<Long> {
                 DeltaPartitionExtractor.getInstance(),
                 DeltaStatsExtractor.getInstance());
         addedFiles.put(dataFile.getPhysicalPath(), dataFile);
-        String deleteVectorPath =
-            actionsConverter.extractDeletionVectorFile(snapshotAtVersion, (AddFile) action);
-        if (deleteVectorPath != null) {
-          deletionVectors.add(deleteVectorPath);
+        InternalDeletionVector deletionVector =
+            actionsConverter.extractDeletionVector(snapshotAtVersion, (AddFile) action);
+        if (deletionVector != null) {
+          deletionVectors.put(deletionVector.dataFilePath(), deletionVector);
         }
       } else if (action instanceof RemoveFile) {
         InternalDataFile dataFile =
@@ -150,7 +149,7 @@ public class DeltaConversionSource implements ConversionSource<Long> {
     // entry which is replaced by a new entry, AddFile with delete vector information. Since the
     // same data file is removed and added, we need to remove it from the added and removed file
     // maps which are used to track actual added and removed data files.
-    for (String deletionVector : deletionVectors) {
+    for (String deletionVector : deletionVectors.keySet()) {
       // validate that a Remove action is also added for the data file
       if (removedFiles.containsKey(deletionVector)) {
         addedFiles.remove(deletionVector);
@@ -167,7 +166,11 @@ public class DeltaConversionSource implements ConversionSource<Long> {
             .filesAdded(addedFiles.values())
             .filesRemoved(removedFiles.values())
             .build();
-    return TableChange.builder().tableAsOfChange(tableAtVersion).filesDiff(dataFilesDiff).build();
+    return TableChange.builder()
+        .tableAsOfChange(tableAtVersion)
+        .deletionVectorsAdded(deletionVectors.values())
+        .filesDiff(dataFilesDiff)
+        .build();
   }
 
   @Override

--- a/xtable-core/src/test/java/org/apache/xtable/TestSparkDeltaTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/TestSparkDeltaTable.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.functions;
 
 import org.apache.spark.sql.delta.DeltaLog;
+import org.apache.spark.sql.delta.actions.AddFile;
 
 import com.google.common.base.Preconditions;
 
@@ -212,9 +213,13 @@ public class TestSparkDeltaTable implements GenericTable<Row, Object>, Closeable
   }
 
   public List<String> getAllActiveFiles() {
-    return deltaLog.snapshot().allFiles().collectAsList().stream()
+    return getAllActiveFilesInfo().stream()
         .map(addFile -> addSlashToBasePath(basePath) + addFile.path())
         .collect(Collectors.toList());
+  }
+
+  public List<AddFile> getAllActiveFilesInfo() {
+    return deltaLog.snapshot().allFiles().collectAsList();
   }
 
   private String addSlashToBasePath(String basePath) {

--- a/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaDeleteVectorConvert.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaDeleteVectorConvert.java
@@ -300,7 +300,7 @@ public class ITDeltaDeleteVectorConvert {
       DeletionVectorDescriptor deletionVectorDescriptor =
           fileWithDeleteVector.getValue().deletionVector();
       assertEquals(deletionVectorDescriptor.cardinality(), deleteInfo.countRecordsDeleted());
-      assertEquals(deletionVectorDescriptor.sizeInBytes(), deleteInfo.length());
+      assertEquals(deletionVectorDescriptor.sizeInBytes(), deleteInfo.size());
       assertEquals(deletionVectorDescriptor.offset().get(), deleteInfo.offset());
 
       String deletionFilePath =

--- a/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaDeleteVectorConvert.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaDeleteVectorConvert.java
@@ -307,9 +307,9 @@ public class ITDeltaDeleteVectorConvert {
           deletionVectorDescriptor
               .absolutePath(new org.apache.hadoop.fs.Path(testSparkDeltaTable.getBasePath()))
               .toString();
-      assertEquals(deletionFilePath, deleteInfo.deletionVectorFilePath());
+      assertEquals(deletionFilePath, deleteInfo.sourceDeletionVectorFilePath());
 
-      Iterator<Long> iterator = deleteInfo.deleteRecordIterator();
+      Iterator<Long> iterator = deleteInfo.ordinalsIterator();
       List<Long> deletes = new ArrayList<>();
       iterator.forEachRemaining(deletes::add);
       assertEquals(deletes.size(), deleteInfo.countRecordsDeleted());

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
@@ -23,8 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
-import java.net.URISyntaxException;
-
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
@@ -41,7 +41,7 @@ import org.apache.xtable.model.storage.InternalDeletionVector;
 class TestDeltaActionsConverter {
 
   @Test
-  void extractDeletionVector() throws URISyntaxException {
+  void extractDeletionVector() {
     DeltaActionsConverter actionsConverter = DeltaActionsConverter.getInstance();
 
     int size = 123;

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
@@ -18,11 +18,19 @@
  
 package org.apache.xtable.delta;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.UUID;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -31,6 +39,8 @@ import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.actions.AddFile;
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor;
+import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray;
+import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArrayFormat;
 
 import scala.Option;
 
@@ -38,17 +48,20 @@ import org.apache.xtable.model.storage.InternalDeletionVector;
 
 class TestDeltaActionsConverter {
 
+  private final String basePath = "https://container.blob.core.windows.net/tablepath/";
+  private final int size = 372;
+  private final long time = 376;
+  private final boolean dataChange = true;
+  private final String stats = "";
+  private final int cardinality = 42;
+  private final int offset = 634;
+
   @Test
-  void extractDeletionVector() {
+  void extractMissingDeletionVector() {
     DeltaActionsConverter actionsConverter = DeltaActionsConverter.getInstance();
 
-    int size = 123;
-    long time = 234L;
-    boolean dataChange = true;
-    String stats = "";
-    String filePath = "https://container.blob.core.windows.net/tablepath/file_path";
+    String filePath = basePath + "file_path";
     Snapshot snapshot = Mockito.mock(Snapshot.class);
-    DeltaLog deltaLog = Mockito.mock(DeltaLog.class);
 
     DeletionVectorDescriptor deletionVector = null;
     AddFile addFileAction =
@@ -56,21 +69,125 @@ class TestDeltaActionsConverter {
     InternalDeletionVector internaldeletionVector =
         actionsConverter.extractDeletionVector(snapshot, addFileAction);
     assertNull(internaldeletionVector);
+  }
 
-    deletionVector =
+  @Test
+  void extractDeletionVectorInFileAbsolutePath() {
+    DeltaActionsConverter actionsConverter = spy(DeltaActionsConverter.getInstance());
+
+    String dataFilePath = "data_file";
+    String deleteFilePath = "https://container.blob.core.windows.net/tablepath/delete_file";
+    Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+    DeletionVectorDescriptor deletionVector =
         DeletionVectorDescriptor.onDiskWithAbsolutePath(
-            filePath, size, 42, Option.empty(), Option.empty());
+            deleteFilePath, size, cardinality, Option.apply(offset), Option.empty());
 
-    addFileAction =
-        new AddFile(filePath, null, size, time, dataChange, stats, null, deletionVector);
+    AddFile addFileAction =
+        new AddFile(dataFilePath, null, size, time, dataChange, stats, null, deletionVector);
 
+    Configuration conf = new Configuration();
+    DeltaLog deltaLog = Mockito.mock(DeltaLog.class);
     when(snapshot.deltaLog()).thenReturn(deltaLog);
-    when(deltaLog.dataPath())
-        .thenReturn(new Path("https://container.blob.core.windows.net/tablepath"));
-    internaldeletionVector = actionsConverter.extractDeletionVector(snapshot, addFileAction);
+    when(deltaLog.dataPath()).thenReturn(new Path(basePath));
+    when(deltaLog.newDeltaHadoopConf()).thenReturn(conf);
+
+    long[] ordinals = {45, 78, 98};
+    Mockito.doReturn(ordinals)
+        .when(actionsConverter)
+        .parseOrdinalFile(conf, new Path(deleteFilePath), size, offset);
+
+    InternalDeletionVector internaldeletionVector =
+        actionsConverter.extractDeletionVector(snapshot, addFileAction);
     assertNotNull(internaldeletionVector);
-    assertEquals(filePath, internaldeletionVector.dataFilePath());
-    assertEquals(42, internaldeletionVector.countRecordsDeleted());
-    assertEquals(size, internaldeletionVector.length());
+    assertEquals(basePath + dataFilePath, internaldeletionVector.dataFilePath());
+    assertEquals(deleteFilePath, internaldeletionVector.deletionVectorFilePath());
+    assertEquals(offset, internaldeletionVector.offset());
+    assertEquals(cardinality, internaldeletionVector.countRecordsDeleted());
+    assertEquals(size, internaldeletionVector.size());
+    assertNull(internaldeletionVector.binaryRepresentation());
+
+    Iterator<Long> iterator = internaldeletionVector.deleteRecordIterator();
+    Arrays.stream(ordinals).forEach(o -> assertEquals(o, iterator.next()));
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void extractDeletionVectorInFileRelativePath() {
+    DeltaActionsConverter actionsConverter = spy(DeltaActionsConverter.getInstance());
+
+    String dataFilePath = "data_file";
+    UUID deleteFileId = UUID.randomUUID();
+    String deleteFilePath = basePath + "deletion_vector_" + deleteFileId + ".bin";
+    Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+    DeletionVectorDescriptor deletionVector =
+        DeletionVectorDescriptor.onDiskWithRelativePath(
+            deleteFileId, "", size, cardinality, Option.apply(offset), Option.empty());
+
+    AddFile addFileAction =
+        new AddFile(dataFilePath, null, size, time, dataChange, stats, null, deletionVector);
+
+    Configuration conf = new Configuration();
+    DeltaLog deltaLog = Mockito.mock(DeltaLog.class);
+    when(snapshot.deltaLog()).thenReturn(deltaLog);
+    when(deltaLog.dataPath()).thenReturn(new Path(basePath));
+    when(deltaLog.newDeltaHadoopConf()).thenReturn(conf);
+
+    long[] ordinals = {45, 78, 98};
+    Mockito.doReturn(ordinals)
+        .when(actionsConverter)
+        .parseOrdinalFile(conf, new Path(deleteFilePath), size, offset);
+
+    InternalDeletionVector internaldeletionVector =
+        actionsConverter.extractDeletionVector(snapshot, addFileAction);
+    assertNotNull(internaldeletionVector);
+    assertEquals(basePath + dataFilePath, internaldeletionVector.dataFilePath());
+    assertEquals(deleteFilePath, internaldeletionVector.deletionVectorFilePath());
+    assertEquals(offset, internaldeletionVector.offset());
+    assertEquals(cardinality, internaldeletionVector.countRecordsDeleted());
+    assertEquals(size, internaldeletionVector.size());
+    assertNull(internaldeletionVector.binaryRepresentation());
+
+    Iterator<Long> iterator = internaldeletionVector.deleteRecordIterator();
+    Arrays.stream(ordinals).forEach(o -> assertEquals(o, iterator.next()));
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void extractInlineDeletionVector() {
+    DeltaActionsConverter actionsConverter = spy(DeltaActionsConverter.getInstance());
+
+    String dataFilePath = "data_file";
+    Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+    long[] ordinals = {45, 78, 98};
+    RoaringBitmapArray rbm = new RoaringBitmapArray();
+    Arrays.stream(ordinals).forEach(rbm::add);
+    byte[] bytes = rbm.serializeAsByteArray(RoaringBitmapArrayFormat.Portable());
+
+    DeletionVectorDescriptor deletionVector =
+        DeletionVectorDescriptor.inlineInLog(bytes, cardinality);
+
+    AddFile addFileAction =
+        new AddFile(dataFilePath, null, size, time, dataChange, stats, null, deletionVector);
+
+    DeltaLog deltaLog = Mockito.mock(DeltaLog.class);
+    when(snapshot.deltaLog()).thenReturn(deltaLog);
+    when(deltaLog.dataPath()).thenReturn(new Path(basePath));
+
+    InternalDeletionVector internaldeletionVector =
+        actionsConverter.extractDeletionVector(snapshot, addFileAction);
+    assertNotNull(internaldeletionVector);
+    assertEquals(basePath + dataFilePath, internaldeletionVector.dataFilePath());
+    assertArrayEquals(bytes, internaldeletionVector.binaryRepresentation());
+    assertEquals(cardinality, internaldeletionVector.countRecordsDeleted());
+    assertEquals(bytes.length, internaldeletionVector.size());
+    assertNull(internaldeletionVector.deletionVectorFilePath());
+    assertEquals(0, internaldeletionVector.offset());
+
+    Iterator<Long> iterator = internaldeletionVector.deleteRecordIterator();
+    Arrays.stream(ordinals).forEach(o -> assertEquals(o, iterator.next()));
+    assertFalse(iterator.hasNext());
   }
 }

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
@@ -101,13 +101,13 @@ class TestDeltaActionsConverter {
         actionsConverter.extractDeletionVector(snapshot, addFileAction);
     assertNotNull(internaldeletionVector);
     assertEquals(basePath + dataFilePath, internaldeletionVector.dataFilePath());
-    assertEquals(deleteFilePath, internaldeletionVector.deletionVectorFilePath());
+    assertEquals(deleteFilePath, internaldeletionVector.sourceDeletionVectorFilePath());
     assertEquals(offset, internaldeletionVector.offset());
     assertEquals(cardinality, internaldeletionVector.countRecordsDeleted());
     assertEquals(size, internaldeletionVector.size());
     assertNull(internaldeletionVector.binaryRepresentation());
 
-    Iterator<Long> iterator = internaldeletionVector.deleteRecordIterator();
+    Iterator<Long> iterator = internaldeletionVector.ordinalsIterator();
     Arrays.stream(ordinals).forEach(o -> assertEquals(o, iterator.next()));
     assertFalse(iterator.hasNext());
   }
@@ -143,13 +143,13 @@ class TestDeltaActionsConverter {
         actionsConverter.extractDeletionVector(snapshot, addFileAction);
     assertNotNull(internaldeletionVector);
     assertEquals(basePath + dataFilePath, internaldeletionVector.dataFilePath());
-    assertEquals(deleteFilePath, internaldeletionVector.deletionVectorFilePath());
+    assertEquals(deleteFilePath, internaldeletionVector.sourceDeletionVectorFilePath());
     assertEquals(offset, internaldeletionVector.offset());
     assertEquals(cardinality, internaldeletionVector.countRecordsDeleted());
     assertEquals(size, internaldeletionVector.size());
     assertNull(internaldeletionVector.binaryRepresentation());
 
-    Iterator<Long> iterator = internaldeletionVector.deleteRecordIterator();
+    Iterator<Long> iterator = internaldeletionVector.ordinalsIterator();
     Arrays.stream(ordinals).forEach(o -> assertEquals(o, iterator.next()));
     assertFalse(iterator.hasNext());
   }
@@ -183,10 +183,10 @@ class TestDeltaActionsConverter {
     assertArrayEquals(bytes, internaldeletionVector.binaryRepresentation());
     assertEquals(cardinality, internaldeletionVector.countRecordsDeleted());
     assertEquals(bytes.length, internaldeletionVector.size());
-    assertNull(internaldeletionVector.deletionVectorFilePath());
+    assertNull(internaldeletionVector.sourceDeletionVectorFilePath());
     assertEquals(0, internaldeletionVector.offset());
 
-    Iterator<Long> iterator = internaldeletionVector.deleteRecordIterator();
+    Iterator<Long> iterator = internaldeletionVector.ordinalsIterator();
     Arrays.stream(ordinals).forEach(o -> assertEquals(o, iterator.next()));
     assertFalse(iterator.hasNext());
   }


### PR DESCRIPTION
Fixes: #342, #343, and #345 

This change extracts deletion vectors represented as roaring bitmaps in delta lake files and converts them into the XTable intermediate representation.

Previously, XTable only detected tables changes that included adding or removing of data files. Now the detected table change also includes any deletion vectors files added in the commit.

Note that, in Delta Lake, the Deletion vectors are represented in a compressed binary format. However, once extracted by Xtable, the offset are currently extracted into a list of long offsets. This representation is not the most efficient for large datasets. Optimization is pending to prioritize end-to-end conversion completion.