### PR TITLE
[590] Add Iceberg Glue Catalog Sync implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>xtable-hudi-support</module>
         <module>xtable-core</module>
         <module>xtable-utilities</module>
+        <module>xtable-aws</module>
     </modules>
 
     <properties>
@@ -385,6 +386,11 @@
                 <artifactId>bundle</artifactId>
                 <version>${aws.version}</version>
                 <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>glue</artifactId>
+                <version>${aws.version}</version>
             </dependency>
 
             <!-- Protobuf -->

--- a/xtable-api/src/main/java/org/apache/xtable/model/storage/CatalogType.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/storage/CatalogType.java
@@ -25,4 +25,5 @@ package org.apache.xtable.model.storage;
  */
 public class CatalogType {
   public static final String STORAGE = "STORAGE";
+  public static final String GLUE = "GLUE";
 }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/CatalogConversionSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/CatalogConversionSource.java
@@ -18,6 +18,9 @@
  
 package org.apache.xtable.spi.extractor;
 
+import org.apache.hadoop.conf.Configuration;
+
+import org.apache.xtable.conversion.ExternalCatalogConfig;
 import org.apache.xtable.conversion.SourceTable;
 import org.apache.xtable.model.catalog.CatalogTableIdentifier;
 
@@ -32,4 +35,7 @@ public interface CatalogConversionSource {
 
   /** Returns the {@link org.apache.xtable.model.storage.CatalogType} for the catalog conversion */
   String getCatalogType();
+
+  /** Initializes the ConversionSource with provided configuration */
+  void init(ExternalCatalogConfig catalogConfig, Configuration configuration);
 }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSync.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSync.java
@@ -56,13 +56,15 @@ public class CatalogSync {
           try {
             results.add(syncCatalog(catalogSyncClient, tableIdentifier, table));
             log.info(
-                "Catalog sync is successful for table {} with format {} using catalogSync {}",
+                "Catalog sync is successful for table {} with base path {} and format {} using catalogSync {}",
+                tableIdentifier.getId(),
                 table.getBasePath(),
                 table.getTableFormat(),
                 catalogSyncClient.getClass().getName());
           } catch (Exception e) {
             log.error(
-                "Catalog sync failed for table {} with format {} using catalogSync {}",
+                "Catalog sync failed for table {} with base path {} and format {} using catalogSync {}",
+                tableIdentifier.getId(),
                 table.getBasePath(),
                 table.getTableFormat(),
                 catalogSyncClient.getClass().getName());
@@ -83,6 +85,12 @@ public class CatalogSync {
       CatalogSyncClient<TABLE> catalogSyncClient,
       CatalogTableIdentifier tableIdentifier,
       InternalTable table) {
+    log.info(
+        "Running catalog sync for table {} with base path {} and format {} using catalogSync {}",
+        tableIdentifier.getId(),
+        table.getBasePath(),
+        table.getTableFormat(),
+        catalogSyncClient.getClass().getName());
     if (!catalogSyncClient.hasDatabase(tableIdentifier)) {
       catalogSyncClient.createDatabase(tableIdentifier);
     }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSyncClient.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSyncClient.java
@@ -18,6 +18,9 @@
  
 package org.apache.xtable.spi.sync;
 
+import org.apache.hadoop.conf.Configuration;
+
+import org.apache.xtable.conversion.ExternalCatalogConfig;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.catalog.CatalogTableIdentifier;
 
@@ -71,4 +74,7 @@ public interface CatalogSyncClient<TABLE> extends AutoCloseable {
 
   /** Drops a table from the catalog. */
   void dropTable(InternalTable table, CatalogTableIdentifier tableIdentifier);
+
+  /** Initializes the client with provided configuration */
+  void init(ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration);
 }

--- a/xtable-aws/pom.xml
+++ b/xtable-aws/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.xtable</groupId>
+        <artifactId>xtable</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xtable-aws</artifactId>
+    <name>XTable AWS</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.xtable</groupId>
+            <artifactId>xtable-core_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Hadoop dependencies -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- AWS Glue dependencies -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>glue</artifactId>
+        </dependency>
+
+        <!-- Junit -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.xtable</groupId>
+            <artifactId>xtable-core_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/DefaultGlueClientFactory.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/DefaultGlueClientFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.apache.xtable.exception.ConfigurationException;
+import org.apache.xtable.reflection.ReflectionUtils;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
+
+/**
+ * Factory class for creating and configuring instances of {@link GlueClient} with settings provided
+ * by {@link GlueCatalogConfig}.
+ *
+ * <p>This factory is responsible for setting the AWS region and credentials for the Glue client. If
+ * a custom credentials provider class is specified in {@code GlueCatalogConfig}, it will use
+ * reflection to instantiate the provider; otherwise, it defaults to the standard AWS credentials
+ * provider.
+ */
+public class DefaultGlueClientFactory extends GlueClientFactory {
+
+  public DefaultGlueClientFactory(GlueCatalogConfig glueConfig) {
+    super(glueConfig);
+  }
+
+  public GlueClient getGlueClient() {
+    GlueClientBuilder builder = GlueClient.builder();
+    if (!StringUtils.isEmpty(glueConfig.getRegion())) {
+      builder.region(Region.of(glueConfig.getRegion()));
+    }
+
+    AwsCredentialsProvider credentialsProvider;
+    if (!StringUtils.isEmpty(glueConfig.getClientCredentialsProviderClass())) {
+      String className = glueConfig.getClientCredentialsProviderClass();
+      try {
+        credentialsProvider =
+            ReflectionUtils.createInstanceOfClassFromStaticMethod(
+                className,
+                "create",
+                new Class<?>[] {Map.class},
+                new Object[] {glueConfig.getClientCredentialsProviderConfigs()});
+      } catch (ConfigurationException e) {
+        // retry credentialsProvider creation without arguments if not a ClassNotFoundException
+        if (e.getCause() instanceof ClassNotFoundException) {
+          throw e;
+        }
+        credentialsProvider =
+            ReflectionUtils.createInstanceOfClassFromStaticMethod(className, "create");
+      }
+    } else {
+      credentialsProvider = DefaultCredentialsProvider.create();
+    }
+
+    builder.credentialsProvider(credentialsProvider);
+    return builder.build();
+  }
+}

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogConfig.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogConfig.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Configurations for setting up Glue client and running Glue catalog operations */
+@Getter
+@EqualsAndHashCode
+@ToString
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GlueCatalogConfig {
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  public static final String CLIENT_CREDENTIAL_PROVIDER_PROP_PREFIX =
+      "externalCatalog.glue.credentials.provider.";
+
+  @JsonProperty("externalCatalog.glue.catalogId")
+  private final String catalogId;
+
+  @JsonProperty("externalCatalog.glue.region")
+  private final String region;
+
+  @JsonProperty("externalCatalog.glue.credentialsProviderClass")
+  private final String clientCredentialsProviderClass;
+
+  /**
+   * In case a credentialsProviderClass is configured and require additional properties for
+   * instantiation, those properties should start with {@link
+   * #CLIENT_CREDENTIAL_PROVIDER_PROP_PREFIX}.
+   *
+   * <p>For ex: if credentialsProviderClass requires `accessKey` and `secretAccessKey`, they should
+   * be configured using below keys:
+   * <li>externalCatalog.glue.credentials.provider.accessKey
+   * <li>externalCatalog.glue.credentials.provider.secretAccessKey
+   */
+  private Map<String, String> clientCredentialsProviderConfigs;
+
+  /** Creates GlueCatalogConfig from given key-value map */
+  public static GlueCatalogConfig of(Map<String, String> properties) {
+    try {
+      GlueCatalogConfig cfg = OBJECT_MAPPER.convertValue(properties, GlueCatalogConfig.class);
+      cfg.clientCredentialsProviderConfigs =
+          propertiesWithPrefix(properties, CLIENT_CREDENTIAL_PROVIDER_PROP_PREFIX);
+      return cfg;
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Map<String, String> propertiesWithPrefix(
+      Map<String, String> properties, String prefix) {
+    if (properties == null || properties.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    return properties.entrySet().stream()
+        .filter(e -> e.getKey().startsWith(prefix))
+        .collect(Collectors.toMap(e -> e.getKey().replaceFirst(prefix, ""), Map.Entry::getValue));
+  }
+}

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogConversionSource.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogConversionSource.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import static org.apache.xtable.catalog.CatalogUtils.toHierarchicalTableIdentifier;
+
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.xtable.catalog.TableFormatUtils;
+import org.apache.xtable.conversion.ExternalCatalogConfig;
+import org.apache.xtable.conversion.SourceTable;
+import org.apache.xtable.exception.CatalogSyncException;
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.catalog.HierarchicalTableIdentifier;
+import org.apache.xtable.model.storage.CatalogType;
+import org.apache.xtable.spi.extractor.CatalogConversionSource;
+
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.GlueException;
+import software.amazon.awssdk.services.glue.model.Table;
+
+public class GlueCatalogConversionSource implements CatalogConversionSource {
+  private GlueClient glueClient;
+  private GlueCatalogConfig glueCatalogConfig;
+
+  // For loading the instance using ServiceLoader
+  public GlueCatalogConversionSource() {}
+
+  public GlueCatalogConversionSource(
+      ExternalCatalogConfig catalogConfig, Configuration configuration) {
+    _init(catalogConfig, configuration);
+  }
+
+  @VisibleForTesting
+  GlueCatalogConversionSource(GlueCatalogConfig glueCatalogConfig, GlueClient glueClient) {
+    this.glueCatalogConfig = glueCatalogConfig;
+    this.glueClient = glueClient;
+  }
+
+  @Override
+  public SourceTable getSourceTable(CatalogTableIdentifier tblIdentifier) {
+    HierarchicalTableIdentifier tableIdentifier = toHierarchicalTableIdentifier(tblIdentifier);
+    try {
+      GetTableResponse response =
+          glueClient.getTable(
+              GetTableRequest.builder()
+                  .catalogId(glueCatalogConfig.getCatalogId())
+                  .databaseName(tableIdentifier.getDatabaseName())
+                  .name(tableIdentifier.getTableName())
+                  .build());
+      Table table = response.table();
+      if (table == null) {
+        throw new IllegalStateException(
+            String.format("table: %s is null", tableIdentifier.getId()));
+      }
+
+      String tableFormat = TableFormatUtils.getTableFormat(table.parameters());
+      String tableLocation = table.storageDescriptor().location();
+      String dataPath =
+          TableFormatUtils.getTableDataLocation(tableFormat, tableLocation, table.parameters());
+
+      Properties tableProperties = new Properties();
+      tableProperties.putAll(table.parameters());
+      return SourceTable.builder()
+          .name(table.name())
+          .basePath(tableLocation)
+          .dataPath(dataPath)
+          .formatName(tableFormat)
+          .additionalProperties(tableProperties)
+          .build();
+    } catch (GlueException e) {
+      throw new CatalogSyncException("Failed to get table: " + tableIdentifier.getId(), e);
+    }
+  }
+
+  @Override
+  public String getCatalogType() {
+    return CatalogType.GLUE;
+  }
+
+  @Override
+  public void init(ExternalCatalogConfig catalogConfig, Configuration configuration) {
+    _init(catalogConfig, configuration);
+  }
+
+  private void _init(ExternalCatalogConfig catalogConfig, Configuration configuration) {
+    this.glueCatalogConfig = GlueCatalogConfig.of(catalogConfig.getCatalogProperties());
+    this.glueClient = new DefaultGlueClientFactory(glueCatalogConfig).getGlueClient();
+  }
+}

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogSyncClient.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogSyncClient.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import static org.apache.xtable.catalog.CatalogUtils.toHierarchicalTableIdentifier;
+
+import java.time.ZonedDateTime;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.xtable.catalog.CatalogTableBuilder;
+import org.apache.xtable.conversion.ExternalCatalogConfig;
+import org.apache.xtable.exception.CatalogSyncException;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.catalog.HierarchicalTableIdentifier;
+import org.apache.xtable.model.catalog.ThreePartHierarchicalTableIdentifier;
+import org.apache.xtable.model.storage.CatalogType;
+import org.apache.xtable.spi.sync.CatalogSyncClient;
+
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.DatabaseInput;
+import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
+
+/** AWS Glue implementation for CatalogSyncClient for registering InternalTable in Glue */
+@Log4j2
+public class GlueCatalogSyncClient implements CatalogSyncClient<Table> {
+
+  public static final String GLUE_EXTERNAL_TABLE_TYPE = "EXTERNAL_TABLE";
+  private static final String TEMP_SUFFIX = "_temp";
+
+  private ExternalCatalogConfig catalogConfig;
+  private GlueClient glueClient;
+  private GlueCatalogConfig glueCatalogConfig;
+  private Configuration configuration;
+  private CatalogTableBuilder<TableInput, Table> tableBuilder;
+
+  // For loading the instance using ServiceLoader
+  public GlueCatalogSyncClient() {}
+
+  public GlueCatalogSyncClient(
+      ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration) {
+    _init(catalogConfig, tableFormat, configuration);
+  }
+
+  @VisibleForTesting
+  GlueCatalogSyncClient(
+      ExternalCatalogConfig catalogConfig,
+      Configuration configuration,
+      GlueCatalogConfig glueCatalogConfig,
+      GlueClient glueClient,
+      CatalogTableBuilder tableBuilder) {
+    this.catalogConfig = catalogConfig;
+    this.configuration = new Configuration(configuration);
+    this.glueCatalogConfig = glueCatalogConfig;
+    this.glueClient = glueClient;
+    this.tableBuilder = tableBuilder;
+  }
+
+  @Override
+  public String getCatalogId() {
+    return catalogConfig.getCatalogId();
+  }
+
+  @Override
+  public String getCatalogType() {
+    return CatalogType.GLUE;
+  }
+
+  @Override
+  public String getStorageLocation(Table table) {
+    if (table == null || table.storageDescriptor() == null) {
+      return null;
+    }
+    return table.storageDescriptor().location();
+  }
+
+  @Override
+  public boolean hasDatabase(CatalogTableIdentifier tableIdentifier) {
+    String databaseName = toHierarchicalTableIdentifier(tableIdentifier).getDatabaseName();
+    try {
+      return glueClient
+              .getDatabase(
+                  GetDatabaseRequest.builder()
+                      .catalogId(glueCatalogConfig.getCatalogId())
+                      .name(databaseName)
+                      .build())
+              .database()
+          != null;
+    } catch (EntityNotFoundException e) {
+      return false;
+    } catch (Exception e) {
+      throw new CatalogSyncException("Failed to get database: " + databaseName, e);
+    }
+  }
+
+  @Override
+  public void createDatabase(CatalogTableIdentifier tableIdentifier) {
+    String databaseName = toHierarchicalTableIdentifier(tableIdentifier).getDatabaseName();
+    try {
+      glueClient.createDatabase(
+          CreateDatabaseRequest.builder()
+              .catalogId(glueCatalogConfig.getCatalogId())
+              .databaseInput(
+                  DatabaseInput.builder()
+                      .name(databaseName)
+                      .description("Created by " + this.getClass().getName())
+                      .build())
+              .build());
+    } catch (Exception e) {
+      throw new CatalogSyncException("Failed to create database: " + databaseName, e);
+    }
+  }
+
+  @Override
+  public Table getTable(CatalogTableIdentifier tableIdentifier) {
+    HierarchicalTableIdentifier tblIdentifier = toHierarchicalTableIdentifier(tableIdentifier);
+    try {
+      GetTableResponse response =
+          glueClient.getTable(
+              GetTableRequest.builder()
+                  .catalogId(glueCatalogConfig.getCatalogId())
+                  .databaseName(tblIdentifier.getDatabaseName())
+                  .name(tblIdentifier.getTableName())
+                  .build());
+      return response.table();
+    } catch (EntityNotFoundException e) {
+      return null;
+    } catch (Exception e) {
+      throw new CatalogSyncException("Failed to get table: " + tblIdentifier.getId(), e);
+    }
+  }
+
+  @Override
+  public void createTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    HierarchicalTableIdentifier tblIdentifier = toHierarchicalTableIdentifier(tableIdentifier);
+    TableInput tableInput = tableBuilder.getCreateTableRequest(table, tableIdentifier);
+    try {
+      glueClient.createTable(
+          CreateTableRequest.builder()
+              .catalogId(glueCatalogConfig.getCatalogId())
+              .databaseName(tblIdentifier.getDatabaseName())
+              .tableInput(tableInput)
+              .build());
+    } catch (Exception e) {
+      throw new CatalogSyncException("Failed to create table: " + tblIdentifier.getId(), e);
+    }
+  }
+
+  @Override
+  public void refreshTable(
+      InternalTable table, Table catalogTable, CatalogTableIdentifier tableIdentifier) {
+    HierarchicalTableIdentifier tblIdentifier = toHierarchicalTableIdentifier(tableIdentifier);
+    TableInput tableInput =
+        tableBuilder.getUpdateTableRequest(table, catalogTable, tableIdentifier);
+    try {
+      glueClient.updateTable(
+          UpdateTableRequest.builder()
+              .catalogId(glueCatalogConfig.getCatalogId())
+              .databaseName(tblIdentifier.getDatabaseName())
+              .skipArchive(true)
+              .tableInput(tableInput)
+              .build());
+    } catch (Exception e) {
+      throw new CatalogSyncException("Failed to refresh table: " + tblIdentifier.getId(), e);
+    }
+  }
+
+  @Override
+  public void createOrReplaceTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    // validate before dropping the table
+    validateTempTableCreation(table, tableIdentifier);
+    dropTable(table, tableIdentifier);
+    createTable(table, tableIdentifier);
+  }
+
+  @Override
+  public void dropTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    HierarchicalTableIdentifier tblIdentifier = toHierarchicalTableIdentifier(tableIdentifier);
+    try {
+      glueClient.deleteTable(
+          DeleteTableRequest.builder()
+              .catalogId(glueCatalogConfig.getCatalogId())
+              .databaseName(tblIdentifier.getDatabaseName())
+              .name(tblIdentifier.getTableName())
+              .build());
+    } catch (Exception e) {
+      throw new CatalogSyncException("Failed to drop table: " + tableIdentifier.getId(), e);
+    }
+  }
+
+  @Override
+  public void init(
+      ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration) {
+    _init(catalogConfig, tableFormat, configuration);
+  }
+
+  private void _init(
+      ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration) {
+    this.catalogConfig = catalogConfig;
+    this.glueCatalogConfig = GlueCatalogConfig.of(catalogConfig.getCatalogProperties());
+    this.glueClient = new DefaultGlueClientFactory(glueCatalogConfig).getGlueClient();
+    this.configuration = new Configuration(configuration);
+    this.tableBuilder = GlueCatalogTableBuilderFactory.getInstance(tableFormat, this.configuration);
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (glueClient != null) {
+      glueClient.close();
+    }
+  }
+
+  /**
+   * creates a temp table with new metadata and properties to ensure table creation succeeds before
+   * dropping the table and recreating it. This ensures that actual table is not dropped in case
+   * there are any issues
+   */
+  private void validateTempTableCreation(
+      InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    HierarchicalTableIdentifier tblIdentifier = toHierarchicalTableIdentifier(tableIdentifier);
+    String tempTableName =
+        tblIdentifier.getTableName() + TEMP_SUFFIX + ZonedDateTime.now().toEpochSecond();
+    ThreePartHierarchicalTableIdentifier tempTableIdentifier =
+        new ThreePartHierarchicalTableIdentifier(tblIdentifier.getDatabaseName(), tempTableName);
+    createTable(table, tempTableIdentifier);
+    dropTable(table, tempTableIdentifier);
+  }
+}

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogTableBuilderFactory.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogTableBuilderFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import org.apache.hadoop.conf.Configuration;
+
+import org.apache.xtable.catalog.CatalogTableBuilder;
+import org.apache.xtable.exception.NotSupportedException;
+import org.apache.xtable.glue.table.IcebergGlueCatalogTableBuilder;
+import org.apache.xtable.model.storage.TableFormat;
+
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+
+class GlueCatalogTableBuilderFactory {
+
+  static CatalogTableBuilder<TableInput, Table> getInstance(
+      String tableFormat, Configuration configuration) {
+    switch (tableFormat) {
+      case TableFormat.ICEBERG:
+        return new IcebergGlueCatalogTableBuilder(configuration);
+      default:
+        throw new NotSupportedException("Unsupported table format: " + tableFormat);
+    }
+  }
+}

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueClientFactory.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueClientFactory.java
@@ -16,27 +16,21 @@
  * limitations under the License.
  */
  
-package org.apache.xtable.model.exception;
+package org.apache.xtable.glue;
 
-import lombok.Getter;
+import software.amazon.awssdk.services.glue.GlueClient;
 
-@Getter
-public enum ErrorCode {
-  INVALID_CONFIGURATION(10001),
-  INVALID_PARTITION_SPEC(10002),
-  INVALID_PARTITION_VALUE(10003),
-  READ_EXCEPTION(10004),
-  UPDATE_EXCEPTION(10005),
-  INVALID_SCHEMA(10006),
-  UNSUPPORTED_SCHEMA_TYPE(10007),
-  UNSUPPORTED_FEATURE(10008),
-  PARSE_EXCEPTION(10009),
-  CATALOG_REFRESH_EXCEPTION(10010),
-  CATALOG_SYNC_GENERIC_EXCEPTION(10011);
+/**
+ * Abstract factory for creating {@link GlueClient} instances configured with {@link
+ * GlueCatalogConfig} settings.
+ */
+public abstract class GlueClientFactory {
 
-  private final int errorCode;
+  protected final GlueCatalogConfig glueConfig;
 
-  ErrorCode(int errorCode) {
-    this.errorCode = errorCode;
+  public GlueClientFactory(GlueCatalogConfig glueConfig) {
+    this.glueConfig = glueConfig;
   }
+
+  public abstract GlueClient getGlueClient();
 }

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueSchemaExtractor.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueSchemaExtractor.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import org.apache.xtable.exception.NotSupportedException;
+import org.apache.xtable.exception.SchemaExtractorException;
+import org.apache.xtable.model.schema.InternalField;
+import org.apache.xtable.model.schema.InternalSchema;
+
+import software.amazon.awssdk.services.glue.model.Column;
+import software.amazon.awssdk.services.glue.model.Table;
+
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GlueSchemaExtractor {
+  private static final GlueSchemaExtractor INSTANCE = new GlueSchemaExtractor();
+  private static final String FIELD_ID = "field.id";
+  private static final String FIELD_OPTIONAL = "field.optional";
+  private static final String FIELD_CURRENT = "field.current";
+  private static final int MAX_COLUMN_COMMENT_LENGTH = 255;
+
+  public static GlueSchemaExtractor getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Extract column list from InternalTable schema
+   *
+   * @param tableFormat tableFormat to handle format specific type conversion
+   * @param tableSchema InternalTable schema
+   * @return glue table column list
+   */
+  public List<Column> toColumns(String tableFormat, InternalSchema tableSchema) {
+    return toColumns(tableFormat, tableSchema, null);
+  }
+
+  public List<Column> toColumns(
+      String tableFormat, InternalSchema tableSchema, Table existingTable) {
+    List<Column> columns = Lists.newArrayList();
+    Set<String> addedNames = Sets.newHashSet();
+    for (InternalField field : tableSchema.getFields()) {
+      if (!addedNames.contains(field.getName())) {
+        columns.add(toColumn(field, tableFormat));
+        addedNames.add(field.getName());
+      }
+    }
+
+    // if there are columns in existing glueTable that are not part of tableSchema,
+    // include them by setting "field.current" property to false
+    List<Column> existingColumns =
+        existingTable != null && existingTable.storageDescriptor() != null
+            ? existingTable.storageDescriptor().columns()
+            : Collections.emptyList();
+    for (Column column : existingColumns) {
+      if (!addedNames.contains(column.name())) {
+        Map<String, String> columnParams = new HashMap<>();
+        if (column.hasParameters()) {
+          columnParams.putAll(column.parameters());
+        }
+        columnParams.put(getColumnProperty(tableFormat, FIELD_CURRENT), "false");
+        column = column.toBuilder().parameters(columnParams).build();
+        columns.add(column);
+        addedNames.add(column.name());
+      }
+    }
+    return columns;
+  }
+
+  /** create Glue column from InternalField */
+  @VisibleForTesting
+  protected Column toColumn(InternalField field, String tableFormat) {
+    int fieldId = field.getFieldId() != null ? field.getFieldId() : -1;
+    Column.Builder builder =
+        Column.builder()
+            .name(field.getName())
+            .type(toTypeString(field.getSchema(), tableFormat))
+            .parameters(
+                ImmutableMap.of(
+                    getColumnProperty(tableFormat, FIELD_ID),
+                    Integer.toString(fieldId),
+                    getColumnProperty(tableFormat, FIELD_OPTIONAL),
+                    Boolean.toString(field.getSchema().isNullable()),
+                    getColumnProperty(tableFormat, FIELD_CURRENT),
+                    "true"));
+
+    String comment = field.getSchema().getComment();
+    if (!StringUtils.isEmpty(comment)) {
+      // Glue has restriction on column comment to not exceed 255 chars
+      // https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html
+      if (comment.length() > MAX_COLUMN_COMMENT_LENGTH) {
+        log.warn(
+            "Column: {} comment has been truncated due to exceeding the maximum allowed length ({})",
+            field.getName(),
+            MAX_COLUMN_COMMENT_LENGTH);
+        comment = comment.substring(0, MAX_COLUMN_COMMENT_LENGTH);
+      }
+      builder.comment(comment);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Get glue compatible column type from InternalTable field schema
+   *
+   * @param tableFormat tableFormat to handle format specific type conversion
+   * @param fieldSchema InternalTable field schema
+   * @return glue column type
+   */
+  protected String toTypeString(InternalSchema fieldSchema, String tableFormat) {
+    switch (fieldSchema.getDataType()) {
+      case BOOLEAN:
+        return "boolean";
+      case INT:
+        return "int";
+      case LONG:
+        return "bigint";
+      case FLOAT:
+        return "float";
+      case DOUBLE:
+        return "double";
+      case DATE:
+        return "date";
+      case ENUM:
+      case STRING:
+        return "string";
+      case TIMESTAMP:
+      case TIMESTAMP_NTZ:
+        return "timestamp";
+      case FIXED:
+      case BYTES:
+        return "binary";
+      case DECIMAL:
+        Map<InternalSchema.MetadataKey, Object> metadata = fieldSchema.getMetadata();
+        if (metadata == null || metadata.isEmpty()) {
+          throw new NotSupportedException("Invalid decimal type, precision and scale is missing");
+        }
+        int precision =
+            (int)
+                metadata.computeIfAbsent(
+                    InternalSchema.MetadataKey.DECIMAL_PRECISION,
+                    k -> {
+                      throw new NotSupportedException("Invalid decimal type, precision is missing");
+                    });
+        int scale =
+            (int)
+                metadata.computeIfAbsent(
+                    InternalSchema.MetadataKey.DECIMAL_SCALE,
+                    k -> {
+                      throw new NotSupportedException("Invalid decimal type, scale is missing");
+                    });
+        return String.format("decimal(%s,%s)", precision, scale);
+      case RECORD:
+        final String nameToType =
+            fieldSchema.getFields().stream()
+                .map(
+                    f ->
+                        String.format(
+                            "%s:%s", f.getName(), toTypeString(f.getSchema(), tableFormat)))
+                .collect(Collectors.joining(","));
+        return String.format("struct<%s>", nameToType);
+      case LIST:
+        InternalField arrayElement =
+            fieldSchema.getFields().stream()
+                .filter(
+                    arrayField ->
+                        InternalField.Constants.ARRAY_ELEMENT_FIELD_NAME.equals(
+                            arrayField.getName()))
+                .findFirst()
+                .orElseThrow(() -> new SchemaExtractorException("Invalid array schema"));
+        return String.format("array<%s>", toTypeString(arrayElement.getSchema(), tableFormat));
+      case MAP:
+        InternalField key =
+            fieldSchema.getFields().stream()
+                .filter(
+                    mapField ->
+                        InternalField.Constants.MAP_KEY_FIELD_NAME.equals(mapField.getName()))
+                .findFirst()
+                .orElseThrow(() -> new SchemaExtractorException("Invalid map schema"));
+        InternalField value =
+            fieldSchema.getFields().stream()
+                .filter(
+                    mapField ->
+                        InternalField.Constants.MAP_VALUE_FIELD_NAME.equals(mapField.getName()))
+                .findFirst()
+                .orElseThrow(() -> new SchemaExtractorException("Invalid map schema"));
+        return String.format(
+            "map<%s,%s>",
+            toTypeString(key.getSchema(), tableFormat),
+            toTypeString(value.getSchema(), tableFormat));
+      default:
+        throw new NotSupportedException("Unsupported type: " + fieldSchema.getDataType());
+    }
+  }
+
+  @VisibleForTesting
+  protected static String getColumnProperty(String tableFormat, String property) {
+    return String.format("%s.%s", tableFormat.toLowerCase(Locale.ENGLISH), property);
+  }
+}

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/table/IcebergGlueCatalogTableBuilder.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/table/IcebergGlueCatalogTableBuilder.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue.table;
+
+import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
+import static org.apache.iceberg.BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.xtable.catalog.CatalogUtils.toHierarchicalTableIdentifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.hadoop.HadoopTables;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.xtable.catalog.CatalogTableBuilder;
+import org.apache.xtable.glue.GlueCatalogSyncClient;
+import org.apache.xtable.glue.GlueSchemaExtractor;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.catalog.HierarchicalTableIdentifier;
+import org.apache.xtable.model.storage.TableFormat;
+
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+
+/** Iceberg specific table operations for Glue catalog sync */
+public class IcebergGlueCatalogTableBuilder implements CatalogTableBuilder<TableInput, Table> {
+
+  private final GlueSchemaExtractor schemaExtractor;
+  private final HadoopTables hadoopTables;
+  private static final String tableFormat = TableFormat.ICEBERG;
+
+  public IcebergGlueCatalogTableBuilder(Configuration configuration) {
+    this.schemaExtractor = GlueSchemaExtractor.getInstance();
+    this.hadoopTables = new HadoopTables(configuration);
+  }
+
+  @VisibleForTesting
+  IcebergGlueCatalogTableBuilder(GlueSchemaExtractor schemaExtractor, HadoopTables hadoopTables) {
+    this.schemaExtractor = schemaExtractor;
+    this.hadoopTables = hadoopTables;
+  }
+
+  @Override
+  public TableInput getCreateTableRequest(
+      InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    HierarchicalTableIdentifier tblIdentifier = toHierarchicalTableIdentifier(tableIdentifier);
+    BaseTable fsTable = loadTableFromFs(table.getBasePath());
+    return TableInput.builder()
+        .name(tblIdentifier.getTableName())
+        .tableType(GlueCatalogSyncClient.GLUE_EXTERNAL_TABLE_TYPE)
+        .parameters(getTableParameters(fsTable))
+        .storageDescriptor(
+            StorageDescriptor.builder()
+                .location(table.getBasePath())
+                .columns(schemaExtractor.toColumns(tableFormat, table.getReadSchema()))
+                .build())
+        .build();
+  }
+
+  @Override
+  public TableInput getUpdateTableRequest(
+      InternalTable table, Table catalogTable, CatalogTableIdentifier tableIdentifier) {
+    HierarchicalTableIdentifier tblIdentifier = toHierarchicalTableIdentifier(tableIdentifier);
+    BaseTable icebergTable = loadTableFromFs(table.getBasePath());
+    Map<String, String> parameters = new HashMap<>(catalogTable.parameters());
+    parameters.put(PREVIOUS_METADATA_LOCATION_PROP, parameters.get(METADATA_LOCATION_PROP));
+    parameters.put(METADATA_LOCATION_PROP, getMetadataFileLocation(icebergTable));
+    parameters.putAll(icebergTable.properties());
+
+    return TableInput.builder()
+        .name(tblIdentifier.getTableName())
+        .tableType(GlueCatalogSyncClient.GLUE_EXTERNAL_TABLE_TYPE)
+        .parameters(parameters)
+        .storageDescriptor(
+            StorageDescriptor.builder()
+                .location(table.getBasePath())
+                .columns(
+                    schemaExtractor.toColumns(tableFormat, table.getReadSchema(), catalogTable))
+                .build())
+        .build();
+  }
+
+  @VisibleForTesting
+  Map<String, String> getTableParameters(BaseTable icebergTable) {
+    Map<String, String> parameters = new HashMap<>(icebergTable.properties());
+    parameters.put(TABLE_TYPE_PROP, tableFormat);
+    parameters.put(METADATA_LOCATION_PROP, getMetadataFileLocation(icebergTable));
+    return parameters;
+  }
+
+  private BaseTable loadTableFromFs(String tableBasePath) {
+    return (BaseTable) hadoopTables.load(tableBasePath);
+  }
+
+  private String getMetadataFileLocation(BaseTable table) {
+    return table.operations().current().metadataFileLocation();
+  }
+}

--- a/xtable-aws/src/main/resources/META-INF/services/org.apache.xtable.spi.extractor.CatalogConversionSource
+++ b/xtable-aws/src/main/resources/META-INF/services/org.apache.xtable.spi.extractor.CatalogConversionSource
@@ -1,0 +1,18 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+org.apache.xtable.glue.GlueCatalogConversionSource

--- a/xtable-aws/src/main/resources/META-INF/services/org.apache.xtable.spi.sync.CatalogSyncClient
+++ b/xtable-aws/src/main/resources/META-INF/services/org.apache.xtable.spi.sync.CatalogSyncClient
@@ -1,0 +1,18 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+org.apache.xtable.glue.GlueCatalogSyncClient

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/GlueCatalogSyncTestBase.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/GlueCatalogSyncTestBase.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import static org.apache.xtable.glue.GlueCatalogSyncClient.GLUE_EXTERNAL_TABLE_TYPE;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.mockito.Mock;
+
+import org.apache.xtable.conversion.ExternalCatalogConfig;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.catalog.ThreePartHierarchicalTableIdentifier;
+import org.apache.xtable.model.schema.InternalSchema;
+import org.apache.xtable.model.storage.CatalogType;
+import org.apache.xtable.model.storage.TableFormat;
+
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.DatabaseInput;
+import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GlueException;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
+
+public class GlueCatalogSyncTestBase {
+
+  @Mock protected GlueClient mockGlueClient;
+  @Mock protected GlueCatalogConfig mockGlueCatalogConfig;
+  @Mock protected GlueSchemaExtractor mockGlueSchemaExtractor;
+  protected final Configuration testConfiguration = new Configuration();
+
+  protected static final String TEST_GLUE_DATABASE = "glue_db";
+  protected static final String TEST_GLUE_TABLE = "glue_table";
+  protected static final String TEST_GLUE_CATALOG_ID = "aws-account-id";
+  protected static final String TEST_BASE_PATH = "base-path";
+  protected static final String TEST_CATALOG_NAME = "aws-glue-1";
+  protected static final String ICEBERG_METADATA_FILE_LOCATION = "base-path/metadata";
+  protected static final String ICEBERG_METADATA_FILE_LOCATION_v2 = "base-path/v2-metadata";
+  protected static final InternalTable TEST_ICEBERG_INTERNAL_TABLE =
+      InternalTable.builder()
+          .basePath(TEST_BASE_PATH)
+          .tableFormat(TableFormat.ICEBERG)
+          .readSchema(InternalSchema.builder().fields(Collections.emptyList()).build())
+          .build();
+  protected static final InternalTable TEST_HUDI_INTERNAL_TABLE =
+      InternalTable.builder()
+          .basePath(TEST_BASE_PATH)
+          .tableFormat(TableFormat.HUDI)
+          .readSchema(InternalSchema.builder().fields(Collections.emptyList()).build())
+          .build();
+  protected static final ThreePartHierarchicalTableIdentifier TEST_CATALOG_TABLE_IDENTIFIER =
+      new ThreePartHierarchicalTableIdentifier(TEST_GLUE_DATABASE, TEST_GLUE_TABLE);
+  protected static final ExternalCatalogConfig catalogConfig =
+      ExternalCatalogConfig.builder()
+          .catalogId(TEST_CATALOG_NAME)
+          .catalogType(CatalogType.GLUE)
+          .catalogSyncClientImpl(GlueCatalogSyncClient.class.getCanonicalName())
+          .catalogProperties(Collections.emptyMap())
+          .build();
+  protected static final TableInput TEST_TABLE_INPUT = TableInput.builder().build();
+  protected static final GlueException TEST_GLUE_EXCEPTION =
+      (GlueException) GlueException.builder().message("something went wrong").build();
+
+  protected GetDatabaseRequest getDbRequest(String dbName) {
+    return GetDatabaseRequest.builder().catalogId(TEST_GLUE_CATALOG_ID).name(dbName).build();
+  }
+
+  protected GetTableRequest getTableRequest(String dbName, String tableName) {
+    return GetTableRequest.builder()
+        .catalogId(TEST_GLUE_CATALOG_ID)
+        .databaseName(dbName)
+        .name(tableName)
+        .build();
+  }
+
+  protected CreateDatabaseRequest createDbRequest(String dbName) {
+    return CreateDatabaseRequest.builder()
+        .catalogId(TEST_GLUE_CATALOG_ID)
+        .databaseInput(
+            DatabaseInput.builder()
+                .name(dbName)
+                .description("Created by " + GlueCatalogSyncClient.class.getName())
+                .build())
+        .build();
+  }
+
+  protected TableInput getCreateOrUpdateTableInput(
+      String tableName, Map<String, String> params, InternalTable internalTable) {
+    return TableInput.builder()
+        .name(tableName)
+        .tableType(GLUE_EXTERNAL_TABLE_TYPE)
+        .parameters(params)
+        .storageDescriptor(
+            StorageDescriptor.builder()
+                .location(internalTable.getBasePath())
+                .columns(Collections.emptyList())
+                .build())
+        .build();
+  }
+
+  protected CreateTableRequest createTableRequest(String dbName, TableInput tableInput) {
+    return CreateTableRequest.builder()
+        .catalogId(TEST_GLUE_CATALOG_ID)
+        .databaseName(dbName)
+        .tableInput(tableInput)
+        .build();
+  }
+
+  protected UpdateTableRequest updateTableRequest(String dbName, TableInput tableInput) {
+    return UpdateTableRequest.builder()
+        .catalogId(TEST_GLUE_CATALOG_ID)
+        .databaseName(dbName)
+        .skipArchive(true)
+        .tableInput(tableInput)
+        .build();
+  }
+
+  protected DeleteTableRequest deleteTableRequest(String dbName, String tableName) {
+    return DeleteTableRequest.builder()
+        .catalogId(TEST_GLUE_CATALOG_ID)
+        .databaseName(dbName)
+        .name(tableName)
+        .build();
+  }
+
+  protected Table getGlueTable(String dbName, String tableName, String location) {
+    return Table.builder()
+        .databaseName(dbName)
+        .name(tableName)
+        .storageDescriptor(StorageDescriptor.builder().location(location).build())
+        .build();
+  }
+}

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueCatalogConfig.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueCatalogConfig.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class TestGlueCatalogConfig {
+  private static final String GLUE_CATALOG_ID_KEY = "externalCatalog.glue.catalogId";
+  private static final String GLUE_CATALOG_ID_VALUE = "aws-accountId";
+  private static final String GLUE_CATALOG_REGION_KEY = "externalCatalog.glue.region";
+  private static final String GLUE_CATALOG_REGION_VALUE = "aws-region";
+  private static final String GLUE_CATALOG_CREDENTIAL_PROVIDER_CLASS_KEY =
+      "externalCatalog.glue.credentialsProviderClass";
+  private static final String GLUE_CATALOG_CREDENTIAL_PROVIDER_CLASS_VALUE =
+      "credentialsProviderClass";
+  private static final String GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_ACCESS_KEY =
+      "externalCatalog.glue.credentials.provider.accessKey";
+  private static final String GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_ACCESS_KEY_VALUE = "accessKey";
+  private static final String GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_SECRET_ACCESS_KEY =
+      "externalCatalog.glue.credentials.provider.secretAccessKey";
+  private static final String GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_SECRET_ACCESS_KEY_VALUE =
+      "secretAccessKey";
+
+  @Test
+  void testGetGlueCatalogConfig_withNoPropertiesSet() {
+    Map<String, String> props = Collections.emptyMap();
+    GlueCatalogConfig catalogConfig = GlueCatalogConfig.of(props);
+    assertNull(catalogConfig.getCatalogId());
+    assertNull(catalogConfig.getRegion());
+    assertNull(catalogConfig.getClientCredentialsProviderClass());
+    assertNotNull(catalogConfig.getClientCredentialsProviderConfigs());
+    assertEquals(0, catalogConfig.getClientCredentialsProviderConfigs().size());
+  }
+
+  @Test
+  void testGetGlueCatalogConfig_withMissingProperties() {
+    Map<String, String> props =
+        createProps(
+            GLUE_CATALOG_ID_KEY,
+            GLUE_CATALOG_ID_VALUE,
+            GLUE_CATALOG_REGION_KEY,
+            GLUE_CATALOG_REGION_VALUE);
+    GlueCatalogConfig catalogConfig = GlueCatalogConfig.of(props);
+    assertEquals(GLUE_CATALOG_ID_VALUE, catalogConfig.getCatalogId());
+    assertEquals(GLUE_CATALOG_REGION_VALUE, catalogConfig.getRegion());
+    assertNull(catalogConfig.getClientCredentialsProviderClass());
+    assertNotNull(catalogConfig.getClientCredentialsProviderConfigs());
+    assertEquals(0, catalogConfig.getClientCredentialsProviderConfigs().size());
+  }
+
+  @Test
+  void testGetGlueCatalogConfig_withUnknownProperty() {
+    Map<String, String> props =
+        createProps(
+            GLUE_CATALOG_ID_KEY,
+            GLUE_CATALOG_ID_VALUE,
+            GLUE_CATALOG_REGION_KEY,
+            GLUE_CATALOG_REGION_VALUE,
+            "externalCatalog.glue.unknownProperty",
+            "unknown-property-value");
+    GlueCatalogConfig catalogConfig = assertDoesNotThrow(() -> GlueCatalogConfig.of(props));
+    assertEquals(GLUE_CATALOG_ID_VALUE, catalogConfig.getCatalogId());
+    assertEquals(GLUE_CATALOG_REGION_VALUE, catalogConfig.getRegion());
+    assertNull(catalogConfig.getClientCredentialsProviderClass());
+    assertNotNull(catalogConfig.getClientCredentialsProviderConfigs());
+    assertEquals(0, catalogConfig.getClientCredentialsProviderConfigs().size());
+  }
+
+  @Test
+  void testGetGlueCatalogConfig_withAllPropertiesSet() {
+    Map<String, String> props =
+        createProps(
+            GLUE_CATALOG_ID_KEY,
+            GLUE_CATALOG_ID_VALUE,
+            GLUE_CATALOG_REGION_KEY,
+            GLUE_CATALOG_REGION_VALUE,
+            GLUE_CATALOG_CREDENTIAL_PROVIDER_CLASS_KEY,
+            GLUE_CATALOG_CREDENTIAL_PROVIDER_CLASS_VALUE,
+            GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_ACCESS_KEY,
+            GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_ACCESS_KEY_VALUE,
+            GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_SECRET_ACCESS_KEY,
+            GLUE_CATALOG_CREDENTIAL_PROVIDER_PROP_SECRET_ACCESS_KEY_VALUE);
+    GlueCatalogConfig catalogConfig = GlueCatalogConfig.of(props);
+    assertEquals(GLUE_CATALOG_ID_VALUE, catalogConfig.getCatalogId());
+    assertEquals(GLUE_CATALOG_REGION_VALUE, catalogConfig.getRegion());
+    assertEquals(
+        GLUE_CATALOG_CREDENTIAL_PROVIDER_CLASS_VALUE,
+        catalogConfig.getClientCredentialsProviderClass());
+    assertNotNull(catalogConfig.getClientCredentialsProviderConfigs());
+    assertEquals(2, catalogConfig.getClientCredentialsProviderConfigs().size());
+  }
+
+  private Map<String, String> createProps(String... keyValues) {
+    Map<String, String> props = new HashMap<>();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      props.put(keyValues[i], keyValues[i + 1]);
+    }
+    return props;
+  }
+}

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueCatalogConversionSource.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueCatalogConversionSource.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceLoader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.apache.xtable.conversion.SourceTable;
+import org.apache.xtable.exception.CatalogSyncException;
+import org.apache.xtable.model.catalog.ThreePartHierarchicalTableIdentifier;
+import org.apache.xtable.model.storage.CatalogType;
+import org.apache.xtable.model.storage.TableFormat;
+import org.apache.xtable.spi.extractor.CatalogConversionSource;
+
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.GlueException;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+
+@ExtendWith(MockitoExtension.class)
+public class TestGlueCatalogConversionSource {
+
+  @Mock private GlueCatalogConfig mockCatalogConfig;
+  @Mock private GlueClient mockGlueClient;
+  private GlueCatalogConversionSource catalogConversionSource;
+  private static final String GLUE_DB = "glue_db";
+  private static final String GLUE_TABLE = "glue_tbl";
+  private static final String TABLE_BASE_PATH = "/var/data/table";
+  private static final String GLUE_CATALOG_ID = "aws-account-id";
+  private static final ThreePartHierarchicalTableIdentifier tableIdentifier =
+      new ThreePartHierarchicalTableIdentifier(GLUE_DB, GLUE_TABLE);
+  private static final GetTableRequest getTableRequest =
+      GetTableRequest.builder()
+          .catalogId(GLUE_CATALOG_ID)
+          .databaseName(GLUE_DB)
+          .name(GLUE_TABLE)
+          .build();
+
+  void setup() {
+    when(mockCatalogConfig.getCatalogId()).thenReturn(GLUE_CATALOG_ID);
+    catalogConversionSource = new GlueCatalogConversionSource(mockCatalogConfig, mockGlueClient);
+  }
+
+  @Test
+  void testGetSourceTable_errorGettingTableFromGlue() {
+    setup();
+
+    // error getting table from glue
+    when(mockGlueClient.getTable(getTableRequest))
+        .thenThrow(GlueException.builder().message("something went wrong").build());
+    CatalogSyncException exception =
+        assertThrows(
+            CatalogSyncException.class,
+            () -> catalogConversionSource.getSourceTable(tableIdentifier));
+    assertEquals(
+        String.format(
+            "Failed to get table: %s.%s",
+            tableIdentifier.getDatabaseName(), tableIdentifier.getTableName()),
+        exception.getMessage());
+
+    verify(mockGlueClient, times(1)).getTable(getTableRequest);
+  }
+
+  @Test
+  void testGetSourceTable_tableNotFoundInGlue() {
+    setup();
+
+    // table not found in glue
+    when(mockGlueClient.getTable(getTableRequest))
+        .thenThrow(EntityNotFoundException.builder().message("table not found").build());
+    CatalogSyncException exception =
+        assertThrows(
+            CatalogSyncException.class,
+            () -> catalogConversionSource.getSourceTable(tableIdentifier));
+    assertEquals(
+        String.format(
+            "Failed to get table: %s.%s",
+            tableIdentifier.getDatabaseName(), tableIdentifier.getTableName()),
+        exception.getMessage());
+
+    verify(mockGlueClient, times(1)).getTable(getTableRequest);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {"ICEBERG", "HUDI", "DELTA"})
+  void testGetSourceTable(String tableFormat) {
+    setup();
+
+    StorageDescriptor sd = StorageDescriptor.builder().location(TABLE_BASE_PATH).build();
+    Map<String, String> tableParams = new HashMap<>();
+    if (tableFormat.equals(TableFormat.ICEBERG)) {
+      tableParams.put("write.data.path", String.format("%s/iceberg", TABLE_BASE_PATH));
+      tableParams.put("table_type", tableFormat);
+    } else {
+      tableParams.put("spark.sql.sources.provider", tableFormat);
+    }
+
+    String dataPath =
+        tableFormat.equals(TableFormat.ICEBERG)
+            ? String.format("%s/iceberg", TABLE_BASE_PATH)
+            : TABLE_BASE_PATH;
+    SourceTable expected =
+        newSourceTable(GLUE_TABLE, TABLE_BASE_PATH, dataPath, tableFormat, tableParams);
+    when(mockGlueClient.getTable(getTableRequest))
+        .thenReturn(
+            GetTableResponse.builder()
+                .table(newGlueTable(GLUE_DB, GLUE_TABLE, tableParams, sd))
+                .build());
+    SourceTable output = catalogConversionSource.getSourceTable(tableIdentifier);
+    assertEquals(expected, output);
+
+    verify(mockGlueClient, times(1)).getTable(getTableRequest);
+  }
+
+  private Table newGlueTable(
+      String dbName, String tableName, Map<String, String> params, StorageDescriptor sd) {
+    return Table.builder()
+        .databaseName(dbName)
+        .name(tableName)
+        .parameters(params)
+        .storageDescriptor(sd)
+        .build();
+  }
+
+  private SourceTable newSourceTable(
+      String tblName,
+      String basePath,
+      String dataPath,
+      String tblFormat,
+      Map<String, String> params) {
+    Properties tblProperties = new Properties();
+    tblProperties.putAll(params);
+    return SourceTable.builder()
+        .name(tblName)
+        .basePath(basePath)
+        .dataPath(dataPath)
+        .formatName(tblFormat)
+        .additionalProperties(tblProperties)
+        .build();
+  }
+
+  @Test
+  void testLoadInstanceByServiceLoader() {
+    ServiceLoader<CatalogConversionSource> loader =
+        ServiceLoader.load(CatalogConversionSource.class);
+    CatalogConversionSource catalogConversionSource = null;
+
+    for (CatalogConversionSource instance : loader) {
+      if (instance.getCatalogType().equals(CatalogType.GLUE)) {
+        catalogConversionSource = instance;
+        break;
+      }
+    }
+    assertNotNull(catalogConversionSource);
+    assertEquals(
+        catalogConversionSource.getClass().getName(), GlueCatalogConversionSource.class.getName());
+  }
+}

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueCatalogSyncClient.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueCatalogSyncClient.java
@@ -1,0 +1,416 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.ServiceLoader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.apache.xtable.catalog.CatalogTableBuilder;
+import org.apache.xtable.exception.CatalogSyncException;
+import org.apache.xtable.model.catalog.ThreePartHierarchicalTableIdentifier;
+import org.apache.xtable.model.storage.CatalogType;
+import org.apache.xtable.spi.sync.CatalogSyncClient;
+
+import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.CreateDatabaseResponse;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.CreateTableResponse;
+import software.amazon.awssdk.services.glue.model.Database;
+import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.DeleteTableResponse;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabaseResponse;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
+import software.amazon.awssdk.services.glue.model.UpdateTableResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class TestGlueCatalogSyncClient extends GlueCatalogSyncTestBase {
+
+  @Mock private CatalogTableBuilder<TableInput, Table> mockTableBuilder;
+  private GlueCatalogSyncClient glueCatalogSyncClient;
+
+  private GlueCatalogSyncClient createGlueCatalogSyncClient() {
+    return new GlueCatalogSyncClient(
+        catalogConfig, testConfiguration, mockGlueCatalogConfig, mockGlueClient, mockTableBuilder);
+  }
+
+  void setupCommonMocks() {
+    glueCatalogSyncClient = createGlueCatalogSyncClient();
+    when(mockGlueCatalogConfig.getCatalogId()).thenReturn(TEST_GLUE_CATALOG_ID);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testHasDatabase(boolean isDbPresent) {
+    setupCommonMocks();
+    GetDatabaseRequest dbRequest = getDbRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName());
+    GetDatabaseResponse dbResponse =
+        GetDatabaseResponse.builder()
+            .database(
+                Database.builder().name(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName()).build())
+            .build();
+    if (isDbPresent) {
+      when(mockGlueClient.getDatabase(dbRequest)).thenReturn(dbResponse);
+    } else {
+      when(mockGlueClient.getDatabase(dbRequest))
+          .thenThrow(EntityNotFoundException.builder().message("db not found").build());
+    }
+    boolean output = glueCatalogSyncClient.hasDatabase(TEST_CATALOG_TABLE_IDENTIFIER);
+    if (isDbPresent) {
+      assertTrue(output);
+    } else {
+      assertFalse(output);
+    }
+    verify(mockGlueClient, times(1)).getDatabase(dbRequest);
+  }
+
+  @Test
+  void testHasDatabaseFailure() {
+    setupCommonMocks();
+    GetDatabaseRequest dbRequest = getDbRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName());
+    when(mockGlueClient.getDatabase(dbRequest)).thenThrow(TEST_GLUE_EXCEPTION);
+    CatalogSyncException exception =
+        assertThrows(
+            CatalogSyncException.class,
+            () -> glueCatalogSyncClient.hasDatabase(TEST_CATALOG_TABLE_IDENTIFIER));
+    assertEquals(
+        String.format("Failed to get database: %s", TEST_GLUE_DATABASE), exception.getMessage());
+    verify(mockGlueClient, times(1)).getDatabase(dbRequest);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testGetTable(boolean isTablePresent) {
+    setupCommonMocks();
+    GetTableRequest tableRequest =
+        getTableRequest(
+            TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(),
+            TEST_CATALOG_TABLE_IDENTIFIER.getTableName());
+    GetTableResponse tableResponse =
+        GetTableResponse.builder()
+            .table(
+                Table.builder()
+                    .databaseName(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName())
+                    .name(TEST_CATALOG_TABLE_IDENTIFIER.getTableName())
+                    .build())
+            .build();
+    if (isTablePresent) {
+      when(mockGlueClient.getTable(tableRequest)).thenReturn(tableResponse);
+    } else {
+      when(mockGlueClient.getTable(tableRequest))
+          .thenThrow(EntityNotFoundException.builder().message("table not found").build());
+    }
+    Table table = glueCatalogSyncClient.getTable(TEST_CATALOG_TABLE_IDENTIFIER);
+    if (isTablePresent) {
+      assertNotNull(table);
+      assertEquals(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), table.databaseName());
+      assertEquals(TEST_CATALOG_TABLE_IDENTIFIER.getTableName(), table.name());
+    } else {
+      assertNull(table);
+    }
+    verify(mockGlueClient, times(1)).getTable(tableRequest);
+  }
+
+  @Test
+  void testGetTableFailure() {
+    setupCommonMocks();
+    GetTableRequest tableRequest =
+        getTableRequest(
+            TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(),
+            TEST_CATALOG_TABLE_IDENTIFIER.getTableName());
+    when(mockGlueClient.getTable(tableRequest)).thenThrow(TEST_GLUE_EXCEPTION);
+    CatalogSyncException exception =
+        assertThrows(
+            CatalogSyncException.class,
+            () -> glueCatalogSyncClient.getTable(TEST_CATALOG_TABLE_IDENTIFIER));
+    assertEquals(
+        String.format("Failed to get table: %s.%s", TEST_GLUE_DATABASE, TEST_GLUE_TABLE),
+        exception.getMessage());
+    verify(mockGlueClient, times(1)).getTable(tableRequest);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testCreateDatabase(boolean shouldFail) {
+    setupCommonMocks();
+    CreateDatabaseRequest dbRequest =
+        createDbRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName());
+    if (shouldFail) {
+      when(mockGlueClient.createDatabase(dbRequest)).thenThrow(TEST_GLUE_EXCEPTION);
+      CatalogSyncException exception =
+          assertThrows(
+              CatalogSyncException.class,
+              () -> glueCatalogSyncClient.createDatabase(TEST_CATALOG_TABLE_IDENTIFIER));
+      assertEquals(
+          String.format("Failed to create database: %s", TEST_GLUE_DATABASE),
+          exception.getMessage());
+    } else {
+      when(mockGlueClient.createDatabase(dbRequest))
+          .thenReturn(CreateDatabaseResponse.builder().build());
+      glueCatalogSyncClient.createDatabase(TEST_CATALOG_TABLE_IDENTIFIER);
+    }
+    verify(mockGlueClient, times(1)).createDatabase(dbRequest);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testDropTable(boolean shouldFail) {
+    setupCommonMocks();
+    DeleteTableRequest deleteRequest =
+        deleteTableRequest(
+            TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(),
+            TEST_CATALOG_TABLE_IDENTIFIER.getTableName());
+    if (shouldFail) {
+      when(mockGlueClient.deleteTable(deleteRequest)).thenThrow(TEST_GLUE_EXCEPTION);
+      RuntimeException exception =
+          assertThrows(
+              RuntimeException.class,
+              () ->
+                  glueCatalogSyncClient.dropTable(
+                      TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER));
+      assertEquals(
+          String.format("Failed to drop table: %s.%s", TEST_GLUE_DATABASE, TEST_GLUE_TABLE),
+          exception.getMessage());
+    } else {
+      when(mockGlueClient.deleteTable(deleteRequest))
+          .thenReturn(DeleteTableResponse.builder().build());
+      glueCatalogSyncClient.dropTable(TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+    }
+    verify(mockGlueClient, times(1)).deleteTable(deleteRequest);
+  }
+
+  @Test
+  void testCreateTable_Success() {
+    setupCommonMocks();
+    CreateTableRequest createTableRequest =
+        createTableRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), TEST_TABLE_INPUT);
+    when(mockTableBuilder.getCreateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER))
+        .thenReturn(TEST_TABLE_INPUT);
+    when(mockGlueClient.createTable(createTableRequest))
+        .thenReturn(CreateTableResponse.builder().build());
+    glueCatalogSyncClient.createTable(TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+    verify(mockGlueClient, times(1)).createTable(createTableRequest);
+    verify(mockTableBuilder, times(1))
+        .getCreateTableRequest(TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+  }
+
+  @Test
+  void testCreateTable_ErrorGettingTableInput() {
+    glueCatalogSyncClient = createGlueCatalogSyncClient();
+
+    // error when getting iceberg table input
+    doThrow(new RuntimeException("something went wrong"))
+        .when(mockTableBuilder)
+        .getCreateTableRequest(TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            glueCatalogSyncClient.createTable(
+                TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER));
+    verify(mockTableBuilder, times(1))
+        .getCreateTableRequest(TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+    verify(mockGlueClient, never()).createTable(any(CreateTableRequest.class));
+  }
+
+  @Test
+  void testCreateTable_ErrorCreatingTable() {
+    setupCommonMocks();
+
+    // error when creating table
+    CreateTableRequest createTableRequest =
+        createTableRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), TEST_TABLE_INPUT);
+    when(mockTableBuilder.getCreateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER))
+        .thenReturn(TEST_TABLE_INPUT);
+    when(mockGlueClient.createTable(createTableRequest)).thenThrow(TEST_GLUE_EXCEPTION);
+    CatalogSyncException exception =
+        assertThrows(
+            CatalogSyncException.class,
+            () ->
+                glueCatalogSyncClient.createTable(
+                    TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER));
+    assertEquals(
+        String.format("Failed to create table: %s.%s", TEST_GLUE_DATABASE, TEST_GLUE_TABLE),
+        exception.getMessage());
+    verify(mockTableBuilder, times(1))
+        .getCreateTableRequest(TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+    verify(mockGlueClient, times(1)).createTable(createTableRequest);
+  }
+
+  @Test
+  void testRefreshTable_Success() {
+    setupCommonMocks();
+    UpdateTableRequest updateTableRequest =
+        updateTableRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), TEST_TABLE_INPUT);
+    Table glueTable = Table.builder().parameters(Collections.emptyMap()).build();
+    when(mockTableBuilder.getUpdateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER))
+        .thenReturn(TEST_TABLE_INPUT);
+    when(mockGlueClient.updateTable(updateTableRequest))
+        .thenReturn(UpdateTableResponse.builder().build());
+    glueCatalogSyncClient.refreshTable(
+        TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER);
+    verify(mockGlueClient, times(1)).updateTable(updateTableRequest);
+    verify(mockTableBuilder, times(1))
+        .getUpdateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER);
+  }
+
+  @Test
+  void testRefreshTable_ErrorCreatingTableInput() {
+    glueCatalogSyncClient = createGlueCatalogSyncClient();
+    Table glueTable = Table.builder().parameters(Collections.emptyMap()).build();
+
+    // error while refreshing table
+    doThrow(new RuntimeException("something went wrong"))
+        .when(mockTableBuilder)
+        .getUpdateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER);
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            glueCatalogSyncClient.refreshTable(
+                TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER));
+    verify(mockTableBuilder, times(1))
+        .getUpdateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER);
+    verify(mockGlueClient, never()).updateTable(any(UpdateTableRequest.class));
+  }
+
+  @Test
+  void testRefreshTable_ErrorRefreshingTable() {
+    setupCommonMocks();
+    Table glueTable = Table.builder().parameters(Collections.emptyMap()).build();
+
+    UpdateTableRequest updateTableRequest =
+        updateTableRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), TEST_TABLE_INPUT);
+    when(mockTableBuilder.getUpdateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER))
+        .thenReturn(TEST_TABLE_INPUT);
+
+    // error while refreshing table
+    when(mockGlueClient.updateTable(updateTableRequest)).thenThrow(TEST_GLUE_EXCEPTION);
+    CatalogSyncException exception =
+        assertThrows(
+            CatalogSyncException.class,
+            () ->
+                glueCatalogSyncClient.refreshTable(
+                    TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER));
+    assertEquals(
+        String.format("Failed to refresh table: %s.%s", TEST_GLUE_DATABASE, TEST_GLUE_TABLE),
+        exception.getMessage());
+    verify(mockTableBuilder, times(1))
+        .getUpdateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER);
+    verify(mockGlueClient, times(1)).updateTable(updateTableRequest);
+  }
+
+  @Test
+  void testCreateOrReplaceTable() {
+    setupCommonMocks();
+
+    ZonedDateTime fixedDateTime = ZonedDateTime.parse("2024-10-25T10:15:30.00Z");
+    try (MockedStatic<ZonedDateTime> mockZonedDateTime = mockStatic(ZonedDateTime.class)) {
+      mockZonedDateTime.when(ZonedDateTime::now).thenReturn(fixedDateTime);
+      String tempTableName =
+          TEST_CATALOG_TABLE_IDENTIFIER.getTableName()
+              + "_temp"
+              + ZonedDateTime.now().toEpochSecond();
+      ThreePartHierarchicalTableIdentifier tempTableIdentifier =
+          new ThreePartHierarchicalTableIdentifier(
+              TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), tempTableName);
+      TableInput tableInput = TableInput.builder().name(TEST_GLUE_TABLE).build();
+      TableInput tempTableInput = TableInput.builder().name(tempTableName).build();
+      CreateTableRequest origCreateTableRequest =
+          createTableRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), tableInput);
+      CreateTableRequest tempCreateTableRequest =
+          createTableRequest(TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(), tempTableInput);
+      DeleteTableRequest origDeleteTableRequest =
+          deleteTableRequest(
+              TEST_CATALOG_TABLE_IDENTIFIER.getDatabaseName(),
+              TEST_CATALOG_TABLE_IDENTIFIER.getTableName());
+      DeleteTableRequest tempDeleteTableRequest =
+          deleteTableRequest(
+              tempTableIdentifier.getDatabaseName(), tempTableIdentifier.getTableName());
+
+      when(mockTableBuilder.getCreateTableRequest(
+              TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER))
+          .thenReturn(tableInput);
+      when(mockTableBuilder.getCreateTableRequest(TEST_ICEBERG_INTERNAL_TABLE, tempTableIdentifier))
+          .thenReturn(tempTableInput);
+
+      glueCatalogSyncClient.createOrReplaceTable(
+          TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+
+      verify(mockGlueClient, times(1)).createTable(tempCreateTableRequest);
+      verify(mockGlueClient, times(1)).deleteTable(tempDeleteTableRequest);
+      verify(mockGlueClient, times(1)).createTable(origCreateTableRequest);
+      verify(mockGlueClient, times(1)).deleteTable(origDeleteTableRequest);
+
+      verify(mockTableBuilder, times(1))
+          .getCreateTableRequest(TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+      verify(mockTableBuilder, times(1))
+          .getCreateTableRequest(TEST_ICEBERG_INTERNAL_TABLE, tempTableIdentifier);
+    }
+  }
+
+  @Test
+  void testLoadInstanceByServiceLoader() {
+    ServiceLoader<CatalogSyncClient> loader = ServiceLoader.load(CatalogSyncClient.class);
+    CatalogSyncClient catalogSyncClient = null;
+
+    for (CatalogSyncClient instance : loader) {
+      if (instance.getCatalogType().equals(CatalogType.GLUE)) {
+        catalogSyncClient = instance;
+        break;
+      }
+    }
+    assertNotNull(catalogSyncClient);
+    assertEquals(catalogSyncClient.getClass().getName(), GlueCatalogSyncClient.class.getName());
+  }
+}

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueSchemaExtractor.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueSchemaExtractor.java
@@ -1,0 +1,686 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue;
+
+import static org.apache.xtable.glue.GlueSchemaExtractor.getColumnProperty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.xtable.catalog.TestSchemaExtractorBase;
+import org.apache.xtable.exception.NotSupportedException;
+import org.apache.xtable.model.schema.InternalField;
+import org.apache.xtable.model.schema.InternalSchema;
+import org.apache.xtable.model.schema.InternalType;
+import org.apache.xtable.model.storage.TableFormat;
+
+import software.amazon.awssdk.services.glue.model.Column;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+
+public class TestGlueSchemaExtractor extends TestSchemaExtractorBase {
+
+  private Column getCurrentGlueTableColumn(
+      String tableFormat, String colName, String colType, Integer fieldId, boolean isNullable) {
+    fieldId = fieldId != null ? fieldId : -1;
+    return getCurrentGlueTableColumn(tableFormat, colName, colType, null, fieldId, isNullable);
+  }
+
+  private Column getCurrentGlueTableColumn(
+      String tableFormat,
+      String colName,
+      String colType,
+      String comment,
+      Integer fieldId,
+      boolean isNullable) {
+    fieldId = fieldId != null ? fieldId : -1;
+    return Column.builder()
+        .name(colName)
+        .type(colType)
+        .comment(comment)
+        .parameters(
+            ImmutableMap.of(
+                getColumnProperty(tableFormat, "field.id"), Integer.toString(fieldId),
+                getColumnProperty(tableFormat, "field.optional"), Boolean.toString(isNullable),
+                getColumnProperty(tableFormat, "field.current"), "true"))
+        .build();
+  }
+
+  private Column getPreviousGlueTableColumn(String tableFormat, String colName, String colType) {
+    return Column.builder()
+        .name(colName)
+        .type(colType)
+        .parameters(ImmutableMap.of(getColumnProperty(tableFormat, "field.current"), "false"))
+        .build();
+  }
+
+  @Test
+  void testPrimitiveTypes_NoExistingTable() {
+    int precision = 10;
+    int scale = 5;
+    Map<InternalSchema.MetadataKey, Object> doubleMetadata = new HashMap<>();
+    doubleMetadata.put(InternalSchema.MetadataKey.DECIMAL_PRECISION, precision);
+    doubleMetadata.put(InternalSchema.MetadataKey.DECIMAL_SCALE, scale);
+    String tableFormat = TableFormat.ICEBERG;
+
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .name("record")
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "requiredBoolean", "boolean", InternalType.BOOLEAN, false, 1),
+                    getPrimitiveInternalField(
+                        "optionalBoolean", "boolean", InternalType.BOOLEAN, true, 2),
+                    getPrimitiveInternalField("requiredInt", "integer", InternalType.INT, false, 3),
+                    getPrimitiveInternalField("requiredLong", "long", InternalType.LONG, false, 4),
+                    getPrimitiveInternalField(
+                        "requiredDouble", "double", InternalType.DOUBLE, false, 5),
+                    getPrimitiveInternalField(
+                        "requiredFloat", "float", InternalType.FLOAT, false, 6),
+                    getPrimitiveInternalField(
+                        "requiredString", "string", InternalType.STRING, false, 7),
+                    getPrimitiveInternalField(
+                        "requiredBytes", "binary", InternalType.BYTES, false, 8),
+                    getPrimitiveInternalField("requiredDate", "date", InternalType.DATE, false, 9),
+                    getPrimitiveInternalField(
+                        "requiredDecimal",
+                        "decimal",
+                        InternalType.DECIMAL,
+                        false,
+                        10,
+                        doubleMetadata),
+                    getPrimitiveInternalField(
+                        "requiredTimestamp", "timestamp", InternalType.TIMESTAMP, false, 11),
+                    getPrimitiveInternalField(
+                        "requiredTimestampNTZ",
+                        "timestamp_ntz",
+                        InternalType.TIMESTAMP_NTZ,
+                        false,
+                        12)))
+            .build();
+
+    List<Column> expectedGlueColumns =
+        Arrays.asList(
+            getCurrentGlueTableColumn(tableFormat, "requiredBoolean", "boolean", 1, false),
+            getCurrentGlueTableColumn(tableFormat, "optionalBoolean", "boolean", 2, true),
+            getCurrentGlueTableColumn(tableFormat, "requiredInt", "int", 3, false),
+            getCurrentGlueTableColumn(tableFormat, "requiredLong", "bigint", 4, false),
+            getCurrentGlueTableColumn(tableFormat, "requiredDouble", "double", 5, false),
+            getCurrentGlueTableColumn(tableFormat, "requiredFloat", "float", 6, false),
+            getCurrentGlueTableColumn(tableFormat, "requiredString", "string", 7, false),
+            getCurrentGlueTableColumn(tableFormat, "requiredBytes", "binary", 8, false),
+            getCurrentGlueTableColumn(tableFormat, "requiredDate", "date", 9, false),
+            getCurrentGlueTableColumn(
+                tableFormat,
+                "requiredDecimal",
+                String.format("decimal(%s,%s)", precision, scale),
+                10,
+                false),
+            getCurrentGlueTableColumn(tableFormat, "requiredTimestamp", "timestamp", 11, false),
+            getCurrentGlueTableColumn(tableFormat, "requiredTimestampNTZ", "timestamp", 12, false));
+
+    assertEquals(
+        expectedGlueColumns,
+        GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema));
+  }
+
+  @Test
+  void testTimestamps_NoExistingTable() {
+    String tableFormat = TableFormat.ICEBERG;
+    Map<InternalSchema.MetadataKey, Object> millisTimestamp =
+        Collections.singletonMap(
+            InternalSchema.MetadataKey.TIMESTAMP_PRECISION, InternalSchema.MetadataValue.MILLIS);
+
+    Map<InternalSchema.MetadataKey, Object> microsTimestamp =
+        Collections.singletonMap(
+            InternalSchema.MetadataKey.TIMESTAMP_PRECISION, InternalSchema.MetadataValue.MICROS);
+
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .name("record")
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "requiredTimestampMillis",
+                        "timestamp",
+                        InternalType.TIMESTAMP,
+                        false,
+                        1,
+                        millisTimestamp),
+                    getPrimitiveInternalField(
+                        "requiredTimestampMicros",
+                        "timestamp",
+                        InternalType.TIMESTAMP,
+                        false,
+                        2,
+                        microsTimestamp),
+                    getPrimitiveInternalField(
+                        "requiredTimestampNTZMillis",
+                        "timestamp_ntz",
+                        InternalType.TIMESTAMP_NTZ,
+                        false,
+                        3,
+                        millisTimestamp),
+                    getPrimitiveInternalField(
+                        "requiredTimestampNTZMicros",
+                        "timestamp_ntz",
+                        InternalType.TIMESTAMP_NTZ,
+                        false,
+                        4,
+                        microsTimestamp)))
+            .build();
+
+    List<Column> expectedGlueColumns =
+        Arrays.asList(
+            getCurrentGlueTableColumn(
+                tableFormat, "requiredTimestampMillis", "timestamp", 1, false),
+            getCurrentGlueTableColumn(
+                tableFormat, "requiredTimestampMicros", "timestamp", 2, false),
+            getCurrentGlueTableColumn(
+                tableFormat, "requiredTimestampNTZMillis", "timestamp", 3, false),
+            getCurrentGlueTableColumn(
+                tableFormat, "requiredTimestampNTZMicros", "timestamp", 4, false));
+
+    assertEquals(
+        expectedGlueColumns,
+        GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema));
+  }
+
+  @Test
+  void testMaps_NoExistingTable() {
+    String tableFormat = TableFormat.ICEBERG;
+    InternalSchema recordMapElementSchema =
+        InternalSchema.builder()
+            .name("struct")
+            .isNullable(true)
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "requiredDouble",
+                        "double",
+                        InternalType.DOUBLE,
+                        false,
+                        1,
+                        "recordMap._one_field_value"),
+                    getPrimitiveInternalField(
+                        "optionalString",
+                        "string",
+                        InternalType.STRING,
+                        true,
+                        2,
+                        "recordMap._one_field_value")))
+            .dataType(InternalType.RECORD)
+            .build();
+
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .name("record")
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .fields(
+                Arrays.asList(
+                    InternalField.builder()
+                        .name("intMap")
+                        .fieldId(1)
+                        .schema(
+                            InternalSchema.builder()
+                                .name("map")
+                                .isNullable(false)
+                                .dataType(InternalType.MAP)
+                                .fields(
+                                    Arrays.asList(
+                                        getPrimitiveInternalField(
+                                            InternalField.Constants.MAP_KEY_FIELD_NAME,
+                                            "string",
+                                            InternalType.STRING,
+                                            false,
+                                            3,
+                                            "intMap"),
+                                        getPrimitiveInternalField(
+                                            InternalField.Constants.MAP_VALUE_FIELD_NAME,
+                                            "integer",
+                                            InternalType.INT,
+                                            false,
+                                            4,
+                                            "intMap")))
+                                .build())
+                        .build(),
+                    InternalField.builder()
+                        .name("recordMap")
+                        .fieldId(2)
+                        .schema(
+                            InternalSchema.builder()
+                                .name("map")
+                                .isNullable(true)
+                                .dataType(InternalType.MAP)
+                                .fields(
+                                    Arrays.asList(
+                                        getPrimitiveInternalField(
+                                            InternalField.Constants.MAP_KEY_FIELD_NAME,
+                                            "integer",
+                                            InternalType.INT,
+                                            false,
+                                            5,
+                                            "recordMap"),
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.MAP_VALUE_FIELD_NAME)
+                                            .fieldId(6)
+                                            .parentPath("recordMap")
+                                            .schema(recordMapElementSchema)
+                                            .build()))
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build()))
+            .build();
+
+    List<Column> expectedGlueColumns =
+        Arrays.asList(
+            getCurrentGlueTableColumn(tableFormat, "intMap", "map<string,int>", 1, false),
+            getCurrentGlueTableColumn(
+                tableFormat,
+                "recordMap",
+                "map<int,struct<requiredDouble:double,optionalString:string>>",
+                2,
+                true));
+
+    assertEquals(
+        expectedGlueColumns,
+        GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema));
+  }
+
+  @Test
+  void testLists_NoExistingTable() {
+    String tableFormat = TableFormat.ICEBERG;
+    InternalSchema recordListElementSchema =
+        InternalSchema.builder()
+            .name("struct")
+            .isNullable(true)
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "requiredDouble",
+                        "double",
+                        InternalType.DOUBLE,
+                        false,
+                        11,
+                        "recordMap._one_field_value"),
+                    getPrimitiveInternalField(
+                        "optionalString",
+                        "string",
+                        InternalType.STRING,
+                        true,
+                        12,
+                        "recordMap._one_field_value")))
+            .dataType(InternalType.RECORD)
+            .build();
+
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .name("record")
+            .isNullable(false)
+            .fields(
+                Arrays.asList(
+                    InternalField.builder()
+                        .name("intList")
+                        .fieldId(1)
+                        .schema(
+                            InternalSchema.builder()
+                                .name("list")
+                                .isNullable(false)
+                                .dataType(InternalType.LIST)
+                                .fields(
+                                    Collections.singletonList(
+                                        getPrimitiveInternalField(
+                                            InternalField.Constants.ARRAY_ELEMENT_FIELD_NAME,
+                                            "integer",
+                                            InternalType.INT,
+                                            false,
+                                            13,
+                                            "intList")))
+                                .build())
+                        .build(),
+                    InternalField.builder()
+                        .name("recordList")
+                        .fieldId(2)
+                        .schema(
+                            InternalSchema.builder()
+                                .name("list")
+                                .isNullable(true)
+                                .dataType(InternalType.LIST)
+                                .fields(
+                                    Collections.singletonList(
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.ARRAY_ELEMENT_FIELD_NAME)
+                                            .fieldId(14)
+                                            .parentPath("recordList")
+                                            .schema(recordListElementSchema)
+                                            .build()))
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build()))
+            .build();
+
+    List<Column> expectedGlueColumns =
+        Arrays.asList(
+            getCurrentGlueTableColumn(tableFormat, "intList", "array<int>", 1, false),
+            getCurrentGlueTableColumn(
+                tableFormat,
+                "recordList",
+                "array<struct<requiredDouble:double,optionalString:string>>",
+                2,
+                true));
+
+    assertEquals(
+        expectedGlueColumns,
+        GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema));
+  }
+
+  @Test
+  void testNestedRecords_NoExistingTable() {
+    String tableFormat = TableFormat.ICEBERG;
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .name("record")
+            .isNullable(false)
+            .fields(
+                Collections.singletonList(
+                    InternalField.builder()
+                        .name("nestedOne")
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .fieldId(1)
+                        .schema(
+                            InternalSchema.builder()
+                                .name("struct")
+                                .dataType(InternalType.RECORD)
+                                .isNullable(true)
+                                .fields(
+                                    Arrays.asList(
+                                        getPrimitiveInternalField(
+                                            "nestedOptionalInt",
+                                            "integer",
+                                            InternalType.INT,
+                                            true,
+                                            11,
+                                            "nestedOne"),
+                                        getPrimitiveInternalField(
+                                            "nestedRequiredDouble",
+                                            "double",
+                                            InternalType.DOUBLE,
+                                            false,
+                                            12,
+                                            "nestedOne"),
+                                        InternalField.builder()
+                                            .name("nestedTwo")
+                                            .parentPath("nestedOne")
+                                            .fieldId(13)
+                                            .schema(
+                                                InternalSchema.builder()
+                                                    .name("struct")
+                                                    .dataType(InternalType.RECORD)
+                                                    .isNullable(false)
+                                                    .fields(
+                                                        Collections.singletonList(
+                                                            getPrimitiveInternalField(
+                                                                "doublyNestedString",
+                                                                "string",
+                                                                InternalType.STRING,
+                                                                true,
+                                                                14,
+                                                                "nestedOne.nestedTwo")))
+                                                    .build())
+                                            .build()))
+                                .build())
+                        .build()))
+            .build();
+
+    List<Column> expectedGlueColumns =
+        Arrays.asList(
+            getCurrentGlueTableColumn(
+                tableFormat,
+                "nestedOne",
+                "struct<nestedOptionalInt:int,nestedRequiredDouble:double,nestedTwo:struct<doublyNestedString:string>>",
+                1,
+                true));
+    assertEquals(
+        expectedGlueColumns,
+        GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema));
+  }
+
+  @Test
+  void testToColumns_NoColumnsFromExistingTable() {
+    String tableFormat = TableFormat.ICEBERG;
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .name("record")
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "optionalBoolean", "boolean", InternalType.BOOLEAN, true, 2),
+                    getPrimitiveInternalField(
+                        "requiredInt", "integer", InternalType.INT, false, 3)))
+            .build();
+
+    List<Table> tableList =
+        Arrays.asList(
+            // table is null
+            null,
+            // storageDescriptor is null
+            Table.builder().build(),
+            // no columns present
+            Table.builder().storageDescriptor(StorageDescriptor.builder().build()).build());
+
+    List<Column> expectedGlueColumns =
+        Arrays.asList(
+            getCurrentGlueTableColumn(tableFormat, "optionalBoolean", "boolean", 2, true),
+            getCurrentGlueTableColumn(tableFormat, "requiredInt", "int", 3, false));
+
+    for (Table table : tableList) {
+      assertEquals(
+          expectedGlueColumns,
+          GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema, table));
+    }
+  }
+
+  @Test
+  void testToColumns_ValidExistingTable() {
+    String tableFormat = TableFormat.ICEBERG;
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .name("record")
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "optionalBoolean", "boolean", InternalType.BOOLEAN, true, 2),
+                    getPrimitiveInternalField(
+                        "requiredInt", "integer", InternalType.INT, false, 3)))
+            .build();
+
+    Table existingTable =
+        Table.builder()
+            .storageDescriptor(
+                StorageDescriptor.builder()
+                    .columns(
+                        ImmutableList.of(
+                            Column.builder().name("prev_x").type("string").build(),
+                            Column.builder().name("prev_y").type("string").build()))
+                    .build())
+            .build();
+
+    List<Column> expectedGlueColumns =
+        Arrays.asList(
+            getCurrentGlueTableColumn(tableFormat, "optionalBoolean", "boolean", 2, true),
+            getCurrentGlueTableColumn(tableFormat, "requiredInt", "int", 3, false),
+            getPreviousGlueTableColumn(tableFormat, "prev_x", "string"),
+            getPreviousGlueTableColumn(tableFormat, "prev_y", "string"));
+
+    assertEquals(
+        expectedGlueColumns,
+        GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema, existingTable));
+  }
+
+  @Test
+  void testUnsupportedType() {
+    String tableFormat = TableFormat.ICEBERG;
+    // Unknown "UNION" type
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .name("record")
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "optionalBoolean", "boolean", InternalType.BOOLEAN, true, 2),
+                    InternalField.builder()
+                        .name("unionField")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("unionSchema")
+                                .dataType(InternalType.UNION)
+                                .isNullable(true)
+                                .build())
+                        .fieldId(2)
+                        .build()))
+            .build();
+
+    NotSupportedException exception =
+        assertThrows(
+            NotSupportedException.class,
+            () -> GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema));
+    assertEquals("Unsupported type: InternalType.UNION(name=union)", exception.getMessage());
+
+    // Invalid decimal type (precision and scale metadata is missing)
+    InternalSchema internalSchema2 =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .name("record")
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "optionalBoolean", "boolean", InternalType.BOOLEAN, true, 1),
+                    getPrimitiveInternalField(
+                        "optionalDecimal", "decimal", InternalType.DECIMAL, true, 2)))
+            .build();
+
+    exception =
+        assertThrows(
+            NotSupportedException.class,
+            () -> GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema2));
+    assertEquals("Invalid decimal type, precision and scale is missing", exception.getMessage());
+
+    // Invalid decimal type (scale metadata is missing)
+    Map<InternalSchema.MetadataKey, Object> doubleMetadata = new HashMap<>();
+    doubleMetadata.put(InternalSchema.MetadataKey.DECIMAL_PRECISION, 10);
+    InternalSchema internalSchema3 =
+        InternalSchema.builder()
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .name("record")
+            .fields(
+                Arrays.asList(
+                    getPrimitiveInternalField(
+                        "optionalBoolean", "boolean", InternalType.BOOLEAN, true, 1),
+                    getPrimitiveInternalField(
+                        "optionalDecimal",
+                        "decimal",
+                        InternalType.DECIMAL,
+                        true,
+                        2,
+                        doubleMetadata)))
+            .build();
+
+    exception =
+        assertThrows(
+            NotSupportedException.class,
+            () -> GlueSchemaExtractor.getInstance().toColumns(tableFormat, internalSchema3));
+    assertEquals("Invalid decimal type, scale is missing", exception.getMessage());
+  }
+
+  @Test
+  void testColumnComment() {
+    String tableFormat = TableFormat.ICEBERG;
+    // comment exceeding 255 chars
+    String comment = String.join("", java.util.Collections.nCopies(260, "a"));
+    InternalField field =
+        getPrimitiveInternalField(
+            "booleanField",
+            "boolean",
+            InternalType.BOOLEAN,
+            comment,
+            false,
+            1,
+            null,
+            Collections.emptyMap());
+    comment = String.join("", java.util.Collections.nCopies(255, "a"));
+    Column column =
+        getCurrentGlueTableColumn(tableFormat, "booleanField", "boolean", comment, 1, false);
+    assertEquals(column, GlueSchemaExtractor.getInstance().toColumn(field, tableFormat));
+
+    // comment has 255 chars
+    field =
+        getPrimitiveInternalField(
+            "booleanField",
+            "boolean",
+            InternalType.BOOLEAN,
+            comment,
+            false,
+            1,
+            null,
+            Collections.emptyMap());
+    column = getCurrentGlueTableColumn(tableFormat, "booleanField", "boolean", comment, 1, false);
+    assertEquals(column, GlueSchemaExtractor.getInstance().toColumn(field, tableFormat));
+
+    // comment has less than 255 chars
+    comment = String.join("", java.util.Collections.nCopies(50, "a"));
+    field =
+        getPrimitiveInternalField(
+            "booleanField",
+            "boolean",
+            InternalType.BOOLEAN,
+            comment,
+            false,
+            1,
+            null,
+            Collections.emptyMap());
+    column = getCurrentGlueTableColumn(tableFormat, "booleanField", "boolean", comment, 1, false);
+    assertEquals(column, GlueSchemaExtractor.getInstance().toColumn(field, tableFormat));
+  }
+}

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/table/TestIcebergGlueCatalogTableBuilder.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/table/TestIcebergGlueCatalogTableBuilder.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue.table;
+
+import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
+import static org.apache.iceberg.BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.hadoop.HadoopTables;
+
+import org.apache.xtable.glue.GlueCatalogSyncTestBase;
+import org.apache.xtable.model.storage.TableFormat;
+
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+
+@ExtendWith(MockitoExtension.class)
+public class TestIcebergGlueCatalogTableBuilder extends GlueCatalogSyncTestBase {
+
+  @Mock private HadoopTables mockIcebergHadoopTables;
+  @Mock private BaseTable mockIcebergBaseTable;
+  @Mock private TableOperations mockIcebergTableOperations;
+  @Mock private TableMetadata mockIcebergTableMetadata;
+  private IcebergGlueCatalogTableBuilder icebergGlueCatalogTableBuilder;
+
+  private IcebergGlueCatalogTableBuilder createIcebergGlueCatalogSyncHelper() {
+    return new IcebergGlueCatalogTableBuilder(mockGlueSchemaExtractor, mockIcebergHadoopTables);
+  }
+
+  void setupCommonMocks() {
+    icebergGlueCatalogTableBuilder = createIcebergGlueCatalogSyncHelper();
+  }
+
+  void mockIcebergHadoopTables() {
+    when(mockIcebergHadoopTables.load(TEST_BASE_PATH)).thenReturn(mockIcebergBaseTable);
+    mockIcebergMetadataFileLocation();
+  }
+
+  void mockIcebergMetadataFileLocation() {
+    when(mockIcebergBaseTable.operations()).thenReturn(mockIcebergTableOperations);
+    when(mockIcebergTableOperations.current()).thenReturn(mockIcebergTableMetadata);
+    when(mockIcebergTableMetadata.metadataFileLocation())
+        .thenReturn(ICEBERG_METADATA_FILE_LOCATION);
+  }
+
+  @Test
+  void testGetCreateTableRequest() {
+    setupCommonMocks();
+    mockIcebergHadoopTables();
+    when(mockGlueSchemaExtractor.toColumns(
+            TableFormat.ICEBERG, TEST_ICEBERG_INTERNAL_TABLE.getReadSchema()))
+        .thenReturn(Collections.emptyList());
+
+    TableInput expected =
+        getCreateOrUpdateTableInput(
+            TEST_CATALOG_TABLE_IDENTIFIER.getTableName(),
+            icebergGlueCatalogTableBuilder.getTableParameters(mockIcebergBaseTable),
+            TEST_ICEBERG_INTERNAL_TABLE);
+    TableInput output =
+        icebergGlueCatalogTableBuilder.getCreateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+    assertEquals(expected, output);
+    verify(mockGlueSchemaExtractor, times(1))
+        .toColumns(TableFormat.ICEBERG, TEST_ICEBERG_INTERNAL_TABLE.getReadSchema());
+  }
+
+  @Test
+  void testGetUpdateTableRequest() {
+    setupCommonMocks();
+    mockIcebergHadoopTables();
+
+    Map<String, String> glueTableParams = new HashMap<>();
+    glueTableParams.put(METADATA_LOCATION_PROP, ICEBERG_METADATA_FILE_LOCATION);
+    Table glueTable = Table.builder().parameters(glueTableParams).build();
+
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(PREVIOUS_METADATA_LOCATION_PROP, glueTableParams.get(METADATA_LOCATION_PROP));
+    when(mockIcebergTableMetadata.metadataFileLocation())
+        .thenReturn(ICEBERG_METADATA_FILE_LOCATION_v2);
+    parameters.put(METADATA_LOCATION_PROP, ICEBERG_METADATA_FILE_LOCATION_v2);
+
+    when(mockGlueSchemaExtractor.toColumns(
+            TableFormat.ICEBERG, TEST_ICEBERG_INTERNAL_TABLE.getReadSchema(), glueTable))
+        .thenReturn(Collections.emptyList());
+
+    TableInput expected =
+        getCreateOrUpdateTableInput(
+            TEST_CATALOG_TABLE_IDENTIFIER.getTableName(), parameters, TEST_ICEBERG_INTERNAL_TABLE);
+    TableInput output =
+        icebergGlueCatalogTableBuilder.getUpdateTableRequest(
+            TEST_ICEBERG_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER);
+    assertEquals(expected, output);
+    verify(mockGlueSchemaExtractor, times(1))
+        .toColumns(TableFormat.ICEBERG, TEST_ICEBERG_INTERNAL_TABLE.getReadSchema(), glueTable);
+  }
+
+  @Test
+  void testGetTableParameters() {
+    icebergGlueCatalogTableBuilder = createIcebergGlueCatalogSyncHelper();
+    mockIcebergMetadataFileLocation();
+    Map<String, String> expected = new HashMap<>();
+    expected.put(TABLE_TYPE_PROP, TableFormat.ICEBERG);
+    expected.put(METADATA_LOCATION_PROP, ICEBERG_METADATA_FILE_LOCATION);
+    Map<String, String> tableParameters =
+        icebergGlueCatalogTableBuilder.getTableParameters(mockIcebergBaseTable);
+    assertEquals(expected, tableParameters);
+  }
+}

--- a/xtable-core/pom.xml
+++ b/xtable-core/pom.xml
@@ -144,6 +144,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
 
         <!-- Junit -->
         <dependency>

--- a/xtable-core/src/main/java/org/apache/xtable/catalog/CatalogConversionFactory.java
+++ b/xtable-core/src/main/java/org/apache/xtable/catalog/CatalogConversionFactory.java
@@ -51,10 +51,13 @@ public class CatalogConversionFactory {
   public static CatalogConversionSource createCatalogConversionSource(
       ExternalCatalogConfig sourceCatalogConfig, Configuration configuration) {
     if (!StringUtils.isEmpty(sourceCatalogConfig.getCatalogType())) {
-      return findInstance(
-          CatalogConversionSource.class,
-          sourceCatalogConfig.getCatalogType(),
-          CatalogConversionSource::getCatalogType);
+      CatalogConversionSource catalogConversionSource =
+          findInstanceByCatalogType(
+              CatalogConversionSource.class,
+              sourceCatalogConfig.getCatalogType(),
+              CatalogConversionSource::getCatalogType);
+      catalogConversionSource.init(sourceCatalogConfig, configuration);
+      return catalogConversionSource;
     }
     return ReflectionUtils.createInstanceOfClass(
         sourceCatalogConfig.getCatalogConversionSourceImpl(), sourceCatalogConfig, configuration);
@@ -70,10 +73,13 @@ public class CatalogConversionFactory {
   public <TABLE> CatalogSyncClient<TABLE> createCatalogSyncClient(
       ExternalCatalogConfig targetCatalogConfig, String tableFormat, Configuration configuration) {
     if (!StringUtils.isEmpty(targetCatalogConfig.getCatalogType())) {
-      return findInstance(
-          CatalogSyncClient.class,
-          targetCatalogConfig.getCatalogType(),
-          CatalogSyncClient::getCatalogType);
+      CatalogSyncClient catalogSyncClient =
+          findInstanceByCatalogType(
+              CatalogSyncClient.class,
+              targetCatalogConfig.getCatalogType(),
+              CatalogSyncClient::getCatalogType);
+      catalogSyncClient.init(targetCatalogConfig, tableFormat, configuration);
+      return catalogSyncClient;
     }
     return ReflectionUtils.createInstanceOfClass(
         targetCatalogConfig.getCatalogSyncClientImpl(),
@@ -82,7 +88,7 @@ public class CatalogConversionFactory {
         configuration);
   }
 
-  private static <T> T findInstance(
+  private static <T> T findInstanceByCatalogType(
       Class<T> serviceClass, String catalogType, Function<T, String> catalogTypeExtractor) {
     ServiceLoader<T> loader = ServiceLoader.load(serviceClass);
     for (T instance : loader) {

--- a/xtable-core/src/main/java/org/apache/xtable/catalog/CatalogTableBuilder.java
+++ b/xtable-core/src/main/java/org/apache/xtable/catalog/CatalogTableBuilder.java
@@ -16,27 +16,18 @@
  * limitations under the License.
  */
  
-package org.apache.xtable.model.exception;
+package org.apache.xtable.catalog;
 
-import lombok.Getter;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
 
-@Getter
-public enum ErrorCode {
-  INVALID_CONFIGURATION(10001),
-  INVALID_PARTITION_SPEC(10002),
-  INVALID_PARTITION_VALUE(10003),
-  READ_EXCEPTION(10004),
-  UPDATE_EXCEPTION(10005),
-  INVALID_SCHEMA(10006),
-  UNSUPPORTED_SCHEMA_TYPE(10007),
-  UNSUPPORTED_FEATURE(10008),
-  PARSE_EXCEPTION(10009),
-  CATALOG_REFRESH_EXCEPTION(10010),
-  CATALOG_SYNC_GENERIC_EXCEPTION(10011);
+/**
+ * The interface for creating/updating catalog table object, each catalog can have its own
+ * implementation that can be plugged in.
+ */
+public interface CatalogTableBuilder<REQUEST, TABLE> {
+  public REQUEST getCreateTableRequest(InternalTable table, CatalogTableIdentifier tableIdentifier);
 
-  private final int errorCode;
-
-  ErrorCode(int errorCode) {
-    this.errorCode = errorCode;
-  }
+  public REQUEST getUpdateTableRequest(
+      InternalTable table, TABLE catalogTable, CatalogTableIdentifier tableIdentifier);
 }

--- a/xtable-core/src/main/java/org/apache/xtable/catalog/CatalogUtils.java
+++ b/xtable-core/src/main/java/org/apache/xtable/catalog/CatalogUtils.java
@@ -16,27 +16,23 @@
  * limitations under the License.
  */
  
-package org.apache.xtable.model.exception;
+package org.apache.xtable.catalog;
 
-import lombok.Getter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@Getter
-public enum ErrorCode {
-  INVALID_CONFIGURATION(10001),
-  INVALID_PARTITION_SPEC(10002),
-  INVALID_PARTITION_VALUE(10003),
-  READ_EXCEPTION(10004),
-  UPDATE_EXCEPTION(10005),
-  INVALID_SCHEMA(10006),
-  UNSUPPORTED_SCHEMA_TYPE(10007),
-  UNSUPPORTED_FEATURE(10008),
-  PARSE_EXCEPTION(10009),
-  CATALOG_REFRESH_EXCEPTION(10010),
-  CATALOG_SYNC_GENERIC_EXCEPTION(10011);
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.catalog.HierarchicalTableIdentifier;
 
-  private final int errorCode;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CatalogUtils {
 
-  ErrorCode(int errorCode) {
-    this.errorCode = errorCode;
+  public static HierarchicalTableIdentifier toHierarchicalTableIdentifier(
+      CatalogTableIdentifier tableIdentifier) {
+    if (tableIdentifier instanceof HierarchicalTableIdentifier) {
+      return (HierarchicalTableIdentifier) tableIdentifier;
+    }
+    throw new IllegalArgumentException(
+        "Invalid tableIdentifier implementation: " + tableIdentifier.getClass().getName());
   }
 }

--- a/xtable-core/src/main/java/org/apache/xtable/catalog/Constants.java
+++ b/xtable-core/src/main/java/org/apache/xtable/catalog/Constants.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.catalog;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Constants {
+
+  /**
+   * This property should be used to specify the data source provider that Spark uses to read from
+   * or write to the data source. For ex: when working with a Delta table in Glue / HMS, this
+   * property typically points to "delta", and "hudi" in case of a Hudi table
+   */
+  public static final String PROP_SPARK_SQL_SOURCES_PROVIDER = "spark.sql.sources.provider";
+
+  /** This property should be used to specify the location of data in a storage system */
+  public static final String PROP_PATH = "path";
+
+  /**
+   * This property should be used to specify the serialization format in Hive SerDe properties, and
+   * it helps Hive understand how to read/write data for the table and is typically used in
+   * conjunction with the InputFormat and OutputFormat properties
+   */
+  public static final String PROP_SERIALIZATION_FORMAT = "serialization.format";
+
+  /**
+   * This property should be used to specify whether a table being synced to a catalog is an
+   * external table or not
+   */
+  public static final String PROP_EXTERNAL = "EXTERNAL";
+}

--- a/xtable-core/src/main/java/org/apache/xtable/catalog/TableFormatUtils.java
+++ b/xtable-core/src/main/java/org/apache/xtable/catalog/TableFormatUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.catalog;
+
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.xtable.catalog.Constants.PROP_SPARK_SQL_SOURCES_PROVIDER;
+
+import java.util.Locale;
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import org.apache.iceberg.TableProperties;
+
+import com.google.common.base.Strings;
+
+import org.apache.xtable.exception.NotSupportedException;
+import org.apache.xtable.model.storage.TableFormat;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TableFormatUtils {
+
+  public static String getTableDataLocation(
+      String tableFormat, String tableLocation, Map<String, String> properties) {
+    switch (tableFormat) {
+      case TableFormat.ICEBERG:
+        return getIcebergDataLocation(tableLocation, properties);
+      case TableFormat.DELTA:
+      case TableFormat.HUDI:
+        return tableLocation;
+      default:
+        throw new NotSupportedException("Unsupported table format: " + tableFormat);
+    }
+  }
+
+  /** Get iceberg table data files location */
+  private static String getIcebergDataLocation(
+      String tableLocation, Map<String, String> properties) {
+    String dataLocation = properties.get(TableProperties.WRITE_DATA_LOCATION);
+    if (dataLocation == null) {
+      dataLocation = properties.get(TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
+      if (dataLocation == null) {
+        dataLocation = properties.get(TableProperties.OBJECT_STORE_PATH);
+        if (dataLocation == null) {
+          dataLocation = String.format("%s/data", tableLocation);
+        }
+      }
+    }
+    return dataLocation;
+  }
+
+  /**
+   * Get table format from given table properties
+   *
+   * @param properties catalog table properties
+   * @return table format name
+   *     <li>In case of ICEBERG, table_type param will give the table format
+   *     <li>In case of DELTA, table_type or spark.sql.sources.provider param will give the table
+   *         format
+   *     <li>In case of HUDI, spark.sql.sources.provider param will give the table format
+   */
+  public static String getTableFormat(Map<String, String> properties) {
+    String tableFormat = properties.get(TABLE_TYPE_PROP);
+    if (Strings.isNullOrEmpty(tableFormat)) {
+      tableFormat = properties.get(PROP_SPARK_SQL_SOURCES_PROVIDER);
+    }
+    if (Strings.isNullOrEmpty(tableFormat)) {
+      throw new IllegalArgumentException("Invalid TableFormat: null or empty");
+    }
+    return tableFormat.toUpperCase(Locale.ENGLISH);
+  }
+}

--- a/xtable-core/src/main/java/org/apache/xtable/exception/CatalogSyncException.java
+++ b/xtable-core/src/main/java/org/apache/xtable/exception/CatalogSyncException.java
@@ -16,27 +16,22 @@
  * limitations under the License.
  */
  
-package org.apache.xtable.model.exception;
+package org.apache.xtable.exception;
 
-import lombok.Getter;
+import org.apache.xtable.model.exception.ErrorCode;
+import org.apache.xtable.model.exception.InternalException;
 
-@Getter
-public enum ErrorCode {
-  INVALID_CONFIGURATION(10001),
-  INVALID_PARTITION_SPEC(10002),
-  INVALID_PARTITION_VALUE(10003),
-  READ_EXCEPTION(10004),
-  UPDATE_EXCEPTION(10005),
-  INVALID_SCHEMA(10006),
-  UNSUPPORTED_SCHEMA_TYPE(10007),
-  UNSUPPORTED_FEATURE(10008),
-  PARSE_EXCEPTION(10009),
-  CATALOG_REFRESH_EXCEPTION(10010),
-  CATALOG_SYNC_GENERIC_EXCEPTION(10011);
+/**
+ * CatalogSyncException should be used for failures that occur while performing {@link
+ * org.apache.xtable.spi.sync.CatalogSyncClient} operations
+ */
+public class CatalogSyncException extends InternalException {
 
-  private final int errorCode;
+  public CatalogSyncException(ErrorCode errorCode, String message, Throwable e) {
+    super(errorCode, message, e);
+  }
 
-  ErrorCode(int errorCode) {
-    this.errorCode = errorCode;
+  public CatalogSyncException(String message, Throwable e) {
+    super(ErrorCode.CATALOG_SYNC_GENERIC_EXCEPTION, message, e);
   }
 }

--- a/xtable-core/src/test/java/org/apache/xtable/catalog/TestCatalogUtils.java
+++ b/xtable-core/src/test/java/org/apache/xtable/catalog/TestCatalogUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.catalog.HierarchicalTableIdentifier;
+import org.apache.xtable.model.catalog.ThreePartHierarchicalTableIdentifier;
+
+public class TestCatalogUtils {
+
+  @Test
+  void testCastToHierarchicalTableIdentifier() {
+    // Valid HierarchicalTableIdentifier objects
+    HierarchicalTableIdentifier catalogTableIdentifier1 =
+        ThreePartHierarchicalTableIdentifier.fromDotSeparatedIdentifier("db.table");
+    ThreePartHierarchicalTableIdentifier catalogTableIdentifier2 =
+        ThreePartHierarchicalTableIdentifier.fromDotSeparatedIdentifier("catalog.db.table");
+
+    // Invalid HierarchicalTableIdentifier object
+    CatalogTableIdentifier catalogTableIdentifier3 = new TestCatalogTableIdentifier();
+
+    HierarchicalTableIdentifier output;
+    output = CatalogUtils.toHierarchicalTableIdentifier(catalogTableIdentifier1);
+    assertEquals("db.table", output.getId());
+
+    output = CatalogUtils.toHierarchicalTableIdentifier(catalogTableIdentifier2);
+    assertEquals("catalog.db.table", output.getId());
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CatalogUtils.toHierarchicalTableIdentifier(catalogTableIdentifier3));
+    assertEquals(
+        "Invalid tableIdentifier implementation: org.apache.xtable.catalog.TestCatalogUtils$TestCatalogTableIdentifier",
+        exception.getMessage());
+  }
+
+  static class TestCatalogTableIdentifier implements CatalogTableIdentifier {
+    @Override
+    public String getId() {
+      return "test-catalog";
+    }
+  }
+}

--- a/xtable-core/src/test/java/org/apache/xtable/catalog/TestSchemaExtractorBase.java
+++ b/xtable-core/src/test/java/org/apache/xtable/catalog/TestSchemaExtractorBase.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.catalog;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.xtable.model.schema.InternalField;
+import org.apache.xtable.model.schema.InternalSchema;
+import org.apache.xtable.model.schema.InternalType;
+
+public class TestSchemaExtractorBase {
+  protected static InternalField getPrimitiveInternalField(
+      String fieldName, String schemaName, InternalType dataType, boolean isNullable, int fieldId) {
+    return getPrimitiveInternalField(
+        fieldName, schemaName, dataType, isNullable, fieldId, Collections.emptyMap());
+  }
+
+  protected static InternalField getPrimitiveInternalField(
+      String fieldName,
+      String schemaName,
+      InternalType dataType,
+      boolean isNullable,
+      int fieldId,
+      String parentPath) {
+    return getPrimitiveInternalField(
+        fieldName, schemaName, dataType, isNullable, fieldId, parentPath, Collections.emptyMap());
+  }
+
+  protected static InternalField getPrimitiveInternalField(
+      String fieldName,
+      String schemaName,
+      InternalType dataType,
+      boolean isNullable,
+      int fieldId,
+      Map<InternalSchema.MetadataKey, Object> metadata) {
+    return getPrimitiveInternalField(
+        fieldName, schemaName, dataType, isNullable, fieldId, null, metadata);
+  }
+
+  protected static InternalField getPrimitiveInternalField(
+      String fieldName,
+      String schemaName,
+      InternalType dataType,
+      boolean isNullable,
+      int fieldId,
+      String parentPath,
+      Map<InternalSchema.MetadataKey, Object> metadata) {
+    return getPrimitiveInternalField(
+        fieldName, schemaName, dataType, null, isNullable, fieldId, null, metadata);
+  }
+
+  protected static InternalField getPrimitiveInternalField(
+      String fieldName,
+      String schemaName,
+      InternalType dataType,
+      String comment,
+      boolean isNullable,
+      int fieldId,
+      String parentPath,
+      Map<InternalSchema.MetadataKey, Object> metadata) {
+    return InternalField.builder()
+        .name(fieldName)
+        .parentPath(parentPath)
+        .schema(
+            InternalSchema.builder()
+                .name(schemaName)
+                .dataType(dataType)
+                .isNullable(isNullable)
+                .metadata(metadata)
+                .comment(comment)
+                .build())
+        .fieldId(fieldId)
+        .build();
+  }
+}

--- a/xtable-core/src/test/java/org/apache/xtable/catalog/TestTableFormatUtils.java
+++ b/xtable-core/src/test/java/org/apache/xtable/catalog/TestTableFormatUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.catalog;
+
+import static org.apache.xtable.catalog.Constants.PROP_SPARK_SQL_SOURCES_PROVIDER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.iceberg.TableProperties;
+
+import org.apache.xtable.model.storage.TableFormat;
+
+class TestTableFormatUtils {
+
+  @Test
+  void testGetTableDataLocation_HudiDelta() {
+    // For Hudi and Delta, data location should be tableLocation
+    String tableLocation = "base-path";
+    assertEquals(
+        tableLocation,
+        TableFormatUtils.getTableDataLocation(
+            TableFormat.HUDI, tableLocation, Collections.emptyMap()));
+    assertEquals(
+        tableLocation,
+        TableFormatUtils.getTableDataLocation(
+            TableFormat.HUDI,
+            tableLocation,
+            Collections.singletonMap(TableProperties.WRITE_DATA_LOCATION, "base-path/data")));
+  }
+
+  @Test
+  void testGetTableDataLocation_Iceberg() {
+    // For Iceberg, data location will be WRITE_DATA_LOCATION / OBJECT_STORE_PATH param or
+    // "tableLocation/data"
+    String tableLocation = "base-path";
+
+    // no params is set
+    assertEquals(
+        tableLocation + "/data",
+        TableFormatUtils.getTableDataLocation(
+            TableFormat.ICEBERG, tableLocation, Collections.emptyMap()));
+
+    // WRITE_DATA_LOCATION param is set
+    String writeDataPath = "base-path/iceberg";
+    assertEquals(
+        writeDataPath,
+        TableFormatUtils.getTableDataLocation(
+            TableFormat.ICEBERG,
+            tableLocation,
+            Collections.singletonMap(TableProperties.WRITE_DATA_LOCATION, writeDataPath)));
+
+    // OBJECT_STORE_PATH param is set
+    String objectStorePath = "base-path/iceberg";
+    assertEquals(
+        objectStorePath,
+        TableFormatUtils.getTableDataLocation(
+            TableFormat.ICEBERG,
+            tableLocation,
+            Collections.singletonMap(TableProperties.OBJECT_STORE_PATH, objectStorePath)));
+  }
+
+  @Test
+  void testGetTableFormat() {
+    Map<String, String> params = new HashMap<>();
+
+    // exception thrown when table format is not present
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> TableFormatUtils.getTableFormat(params));
+    assertEquals("Invalid TableFormat: null or empty", exception.getMessage());
+
+    // "table_type" is set
+    params.put("table_type", TableFormat.ICEBERG);
+    assertEquals(TableFormat.ICEBERG, TableFormatUtils.getTableFormat(params));
+
+    params.clear();
+    // "spark.sql.sources.provider" is set
+    params.put(PROP_SPARK_SQL_SOURCES_PROVIDER, TableFormat.DELTA);
+    assertEquals(TableFormat.DELTA, TableFormatUtils.getTableFormat(params));
+  }
+}

--- a/xtable-core/src/test/java/org/apache/xtable/testutil/ITTestUtils.java
+++ b/xtable-core/src/test/java/org/apache/xtable/testutil/ITTestUtils.java
@@ -118,6 +118,10 @@ public class ITTestUtils {
     }
 
     @Override
+    public void init(
+        ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration) {}
+
+    @Override
     public void close() throws Exception {
       trackFunctionCall();
     }
@@ -151,5 +155,8 @@ public class ITTestUtils {
     public String getCatalogType() {
       return TEST_CATALOG_TYPE;
     }
+
+    @Override
+    public void init(ExternalCatalogConfig catalogConfig, Configuration configuration) {}
   }
 }

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -44,6 +44,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.xtable</groupId>
+            <artifactId>xtable-aws</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- command line arg parsing -->
         <dependency>
             <groupId>commons-cli</groupId>

--- a/xtable-utilities/src/main/java/org/apache/xtable/utilities/RunCatalogSync.java
+++ b/xtable-utilities/src/main/java/org/apache/xtable/utilities/RunCatalogSync.java
@@ -156,6 +156,7 @@ public class RunCatalogSync {
                 .basePath(sourceTable.getBasePath())
                 .namespace(sourceTable.getNamespace())
                 .formatName(targetCatalogTableIdentifier.getTableFormat())
+                .additionalProperties(sourceTable.getAdditionalProperties())
                 .build();
         targetTables.add(targetTable);
         if (!targetCatalogs.containsKey(targetTable)) {


### PR DESCRIPTION
https://github.com/apache/incubator-xtable/issues/590

## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Added support for syncing a source table to Glue catalog in Iceberg table format
 
## Brief change log

- Created a new module **xtable-aws**
- Added **GlueCatalogSyncClient** implementation for syncing **InternalTable** to Glue catalog in Iceberg table format
- Added **GlueCatalogConversionSource** implementation for creating **SourceTable** from Glue table identifier
- Added GlueSchemaExtractor for generating glue compatible schema from **InternalSchema**

## Verify this pull request

- Added unit tests
- Manually verified the change by running a job locally