### PR TITLE
[590] Add Delta Glue Catalog Sync implementation

### DIFF
--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogTableBuilderFactory.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueCatalogTableBuilderFactory.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import org.apache.xtable.catalog.CatalogTableBuilder;
 import org.apache.xtable.exception.NotSupportedException;
+import org.apache.xtable.glue.table.DeltaGlueCatalogTableBuilder;
 import org.apache.xtable.glue.table.IcebergGlueCatalogTableBuilder;
 import org.apache.xtable.model.storage.TableFormat;
 
@@ -35,6 +36,8 @@ class GlueCatalogTableBuilderFactory {
     switch (tableFormat) {
       case TableFormat.ICEBERG:
         return new IcebergGlueCatalogTableBuilder(configuration);
+      case TableFormat.DELTA:
+        return new DeltaGlueCatalogTableBuilder();
       default:
         throw new NotSupportedException("Unsupported table format: " + tableFormat);
     }

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/table/DeltaGlueCatalogTableBuilder.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/table/DeltaGlueCatalogTableBuilder.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue.table;
+
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.xtable.catalog.CatalogUtils.toHierarchicalTableIdentifier;
+import static org.apache.xtable.catalog.Constants.PROP_EXTERNAL;
+import static org.apache.xtable.catalog.Constants.PROP_PATH;
+import static org.apache.xtable.catalog.Constants.PROP_SERIALIZATION_FORMAT;
+import static org.apache.xtable.catalog.Constants.PROP_SPARK_SQL_SOURCES_PROVIDER;
+import static org.apache.xtable.glue.GlueCatalogSyncClient.GLUE_EXTERNAL_TABLE_TYPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.xtable.catalog.CatalogTableBuilder;
+import org.apache.xtable.glue.GlueSchemaExtractor;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.catalog.HierarchicalTableIdentifier;
+import org.apache.xtable.model.storage.TableFormat;
+
+import software.amazon.awssdk.services.glue.model.Column;
+import software.amazon.awssdk.services.glue.model.SerDeInfo;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+
+/** Delta specific table operations for Glue catalog sync */
+public class DeltaGlueCatalogTableBuilder implements CatalogTableBuilder<TableInput, Table> {
+
+  private final GlueSchemaExtractor schemaExtractor;
+  private static final String tableFormat = TableFormat.DELTA;
+
+  public DeltaGlueCatalogTableBuilder() {
+    this.schemaExtractor = GlueSchemaExtractor.getInstance();
+  }
+
+  @Override
+  public TableInput getCreateTableRequest(
+      InternalTable table, CatalogTableIdentifier tblIdentifier) {
+    HierarchicalTableIdentifier tableIdentifier = toHierarchicalTableIdentifier(tblIdentifier);
+    Map<String, Column> columnsMap =
+        schemaExtractor.toColumns(tableFormat, table.getReadSchema()).stream()
+            .collect(Collectors.toMap(Column::name, c -> c));
+
+    return TableInput.builder()
+        .name(tableIdentifier.getTableName())
+        .tableType(GLUE_EXTERNAL_TABLE_TYPE)
+        .parameters(getTableParameters())
+        .storageDescriptor(
+            StorageDescriptor.builder()
+                .columns(schemaExtractor.getNonPartitionColumns(table, columnsMap))
+                .location(table.getBasePath())
+                .serdeInfo(SerDeInfo.builder().parameters(getSerDeParameters(table)).build())
+                .build())
+        .partitionKeys(schemaExtractor.getPartitionColumns(table, columnsMap))
+        .build();
+  }
+
+  @Override
+  public TableInput getUpdateTableRequest(
+      InternalTable table, Table catalogTable, CatalogTableIdentifier tblIdentifier) {
+    HierarchicalTableIdentifier tableIdentifier = toHierarchicalTableIdentifier(tblIdentifier);
+    Map<String, String> parameters = new HashMap<>(catalogTable.parameters());
+    Map<String, Column> columnsMap =
+        schemaExtractor.toColumns(tableFormat, table.getReadSchema(), catalogTable).stream()
+            .collect(Collectors.toMap(Column::name, c -> c));
+    return TableInput.builder()
+        .name(tableIdentifier.getTableName())
+        .tableType(GLUE_EXTERNAL_TABLE_TYPE)
+        .parameters(parameters)
+        .storageDescriptor(
+            catalogTable.storageDescriptor().toBuilder()
+                .columns(schemaExtractor.getNonPartitionColumns(table, columnsMap))
+                .build())
+        .partitionKeys(schemaExtractor.getPartitionColumns(table, columnsMap))
+        .build();
+  }
+
+  @VisibleForTesting
+  Map<String, String> getTableParameters() {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(TABLE_TYPE_PROP, tableFormat);
+    parameters.put(PROP_SPARK_SQL_SOURCES_PROVIDER, tableFormat);
+    parameters.put(PROP_EXTERNAL, "TRUE");
+    return parameters;
+  }
+
+  @VisibleForTesting
+  Map<String, String> getSerDeParameters(InternalTable table) {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(PROP_SERIALIZATION_FORMAT, "1");
+    parameters.put(PROP_PATH, table.getBasePath());
+    return parameters;
+  }
+}

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/table/TestDeltaGlueCatalogTableBuilder.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/table/TestDeltaGlueCatalogTableBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.glue.table;
+
+import static org.apache.xtable.glue.GlueCatalogSyncClient.GLUE_EXTERNAL_TABLE_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.apache.xtable.glue.GlueCatalogSyncTestBase;
+
+import software.amazon.awssdk.services.glue.model.Column;
+import software.amazon.awssdk.services.glue.model.SerDeInfo;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+
+@ExtendWith(MockitoExtension.class)
+public class TestDeltaGlueCatalogTableBuilder extends GlueCatalogSyncTestBase {
+
+  private DeltaGlueCatalogTableBuilder deltaGlueCatalogTableBuilder;
+
+  private DeltaGlueCatalogTableBuilder createDeltaGlueCatalogSyncHelper() {
+    return new DeltaGlueCatalogTableBuilder();
+  }
+
+  void setupCommonMocks() {
+    deltaGlueCatalogTableBuilder = createDeltaGlueCatalogSyncHelper();
+  }
+
+  @Test
+  void testGetCreateTableRequest() {
+    setupCommonMocks();
+
+    TableInput expected =
+        TableInput.builder()
+            .name(TEST_CATALOG_TABLE_IDENTIFIER.getTableName())
+            .tableType(GLUE_EXTERNAL_TABLE_TYPE)
+            .parameters(deltaGlueCatalogTableBuilder.getTableParameters())
+            .storageDescriptor(getTestStorageDescriptor(DELTA_GLUE_SCHEMA))
+            .partitionKeys(PARTITION_KEYS)
+            .build();
+
+    TableInput output =
+        deltaGlueCatalogTableBuilder.getCreateTableRequest(
+            TEST_DELTA_INTERNAL_TABLE, TEST_CATALOG_TABLE_IDENTIFIER);
+    assertEquals(expected, output);
+  }
+
+  @Test
+  void testGetUpdateTableInput() {
+    setupCommonMocks();
+    Table glueTable =
+        Table.builder()
+            .parameters(deltaGlueCatalogTableBuilder.getTableParameters())
+            .storageDescriptor(getTestStorageDescriptor(DELTA_GLUE_SCHEMA))
+            .partitionKeys(PARTITION_KEYS)
+            .build();
+
+    TableInput expected =
+        TableInput.builder()
+            .name(TEST_CATALOG_TABLE_IDENTIFIER.getTableName())
+            .tableType(GLUE_EXTERNAL_TABLE_TYPE)
+            .parameters(deltaGlueCatalogTableBuilder.getTableParameters())
+            .storageDescriptor(getTestStorageDescriptor(UPDATED_DELTA_GLUE_SCHEMA))
+            .partitionKeys(PARTITION_KEYS)
+            .build();
+
+    TableInput output =
+        deltaGlueCatalogTableBuilder.getUpdateTableRequest(
+            TEST_UPDATED_DELTA_INTERNAL_TABLE, glueTable, TEST_CATALOG_TABLE_IDENTIFIER);
+    assertEquals(expected, output);
+  }
+
+  private StorageDescriptor getTestStorageDescriptor(List<Column> columns) {
+    return StorageDescriptor.builder()
+        .columns(columns)
+        .location(TEST_BASE_PATH)
+        .serdeInfo(
+            SerDeInfo.builder()
+                .parameters(
+                    deltaGlueCatalogTableBuilder.getSerDeParameters(TEST_DELTA_INTERNAL_TABLE))
+                .build())
+        .build();
+  }
+}


### PR DESCRIPTION
https://github.com/apache/incubator-xtable/issues/590

## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Added support for syncing an InternalTable to Glue catalog in Delta table format

## Brief change log

Added **DeltaGlueCatalogTableBuilder** class to provide create / update table request for delta table format for syncing to Glue catalog

## Verify this pull request

- Added unit tests
- Manually verified the change by running a job locally