### PR TITLE
[643] Add interface and models for synchronizing ACL policies

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalAccessControlPolicySnapshot.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalAccessControlPolicySnapshot.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.catalog.policy;
+
+import java.time.Instant;
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Value;
+
+/** A snapshot of all access control data at a given point in time. */
+@Value
+@Builder
+public class InternalAccessControlPolicySnapshot {
+  /**
+   * A unique identifier representing this snapshot's version.
+   *
+   * <p>This could be a UUID, timestamp string, or any value that guarantees uniqueness across
+   * snapshots.
+   */
+  String versionId;
+
+  /**
+   * The moment in time when this snapshot was created.
+   *
+   * <p>Useful for maintaining an audit trail or comparing how policies have changed over time.
+   */
+  Instant timestamp;
+
+  /**
+   * A map of user names to {@link InternalUser} objects, capturing individual users' details such
+   * as assigned roles, auditing metadata, etc.
+   */
+  Map<String, InternalUser> usersByName;
+
+  /**
+   * A map of group names to {@link InternalUserGroup} objects, representing logical groupings of
+   * users for easier role management.
+   */
+  Map<String, InternalUserGroup> groupsByName;
+
+  /**
+   * A map of role names to {@link InternalRole} objects, defining the privileges and security rules
+   * each role entails.
+   */
+  Map<String, InternalRole> rolesByName;
+
+  /**
+   * A map of additional properties or metadata related to this snapshot. This map provides
+   * flexibility for storing information without modifying the main schema of the snapshot.
+   */
+  Map<String, String> properties;
+}

--- a/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalChangeLogInfo.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalChangeLogInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.catalog.policy;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Contains change-log information for roles, users, or user groups, enabling traceability of who
+ * created or last modified them.
+ *
+ * <p>This class is useful for governance and compliance scenarios, where an audit trail is
+ * necessary. It can be extended to include additional fields such as reasonForChange or
+ * changeDescription.
+ */
+@Value
+@Builder
+public class InternalChangeLogInfo {
+  /** The username or identifier of the entity that created this record. */
+  String createdBy;
+
+  /** The username or identifier of the entity that last modified this record. */
+  String lastModifiedBy;
+
+  /** The timestamp when this record was created. */
+  Instant createdAt;
+
+  /** The timestamp when this record was last modified. */
+  Instant lastModifiedAt;
+}

--- a/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalPrivilege.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalPrivilege.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.catalog.policy;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Represents a single privilege assignment for a securable object.
+ *
+ * <p>This defines the kind of operation (e.g., SELECT, CREATE, MODIFY) and whether it is allowed or
+ * denied. Some catalogs may only accept ALLOW rules and treat all other operations as denied by
+ * default.
+ */
+@Value
+@Builder
+public class InternalPrivilege {
+  /**
+   * The type of privilege, such as SELECT, CREATE, or MODIFY. Each implementation can define its
+   * own set of enums.
+   */
+  String privilegeType;
+
+  /**
+   * The decision, typically ALLOW or DENY. Some catalogs may not support DENY explicitly,
+   * defaulting to ALLOW.
+   */
+  String privilegeDecision;
+}

--- a/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalRole.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalRole.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.catalog.policy;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Represents a role within the catalog.
+ *
+ * <p>A role can be granted access to multiple securable objects, each with its own set of
+ * privileges. Audit info is stored to track the role's creation and modifications, and a properties
+ * map can hold additional metadata.
+ */
+@Value
+@Builder
+public class InternalRole {
+  /** The unique name or identifier for the role. */
+  String name;
+
+  /** The list of securable objects this role can access. */
+  List<InternalSecurableObject> securableObjects;
+
+  /** Contains information about how and when this role was created and last modified. */
+  InternalChangeLogInfo changeLogInfo;
+
+  /**
+   * A map to store additional metadata or properties related to this role. For example, this might
+   * include a description, usage instructions, or any catalog-specific fields.
+   */
+  Map<String, String> properties;
+}

--- a/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalSecurableObject.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalSecurableObject.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.catalog.policy;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Represents a securable object in the catalog, which can be managed by access control.
+ *
+ * <p>Examples of securable objects include catalogs, schemas, tables, views, or any other data
+ * objects that require fine-grained privilege management. Each securable object can have one or
+ * more privileges assigned to it.
+ */
+@Value
+@Builder
+public class InternalSecurableObject {
+  /**
+   * The type of securable object, such as TABLE, VIEW, FUNCTION, etc. Each implementation can
+   * define its own set of enums.
+   */
+  String securableObjectType;
+  /** The set of privileges assigned to this object. */
+  List<InternalPrivilege> privileges;
+}

--- a/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalUser.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalUser.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.catalog.policy;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Represents an individual user within the catalog.
+ *
+ * <p>A user may be assigned multiple roles, and can also belong to a specific user group. Audit
+ * information is stored to allow tracking of who created or last modified the user.
+ */
+@Value
+@Builder
+public class InternalUser {
+  /** The unique name or identifier for the user. */
+  String name;
+
+  /** The list of roles assigned to this user. */
+  List<InternalRole> roles;
+}

--- a/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalUserGroup.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/catalog/policy/InternalUserGroup.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.model.catalog.policy;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Represents a user group within the catalog.
+ *
+ * <p>Groups can have multiple roles assigned, and also include audit information to track creation
+ * and modifications.
+ */
+@Value
+@Builder
+public class InternalUserGroup {
+  /** The unique name or identifier for the user group. */
+  String name;
+
+  /** The list of roles assigned to this group. */
+  List<InternalRole> roles;
+
+  /** Contains information about how and when this group was created and last modified. */
+  InternalChangeLogInfo changeLogInfo;
+}

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogAccessControlPolicySyncClient.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogAccessControlPolicySyncClient.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.spi.sync;
+
+import org.apache.xtable.model.catalog.policy.InternalAccessControlPolicySnapshot;
+import org.apache.xtable.model.sync.SyncResult;
+
+/**
+ * Defines the contract for synchronizing access control policies between a specific catalog and the
+ * internal canonical model.
+ *
+ * <p>Implementations of this interface are responsible for:
+ *
+ * <ul>
+ *   <li>Fetching the catalog’s native policy definitions and converting them into the canonical
+ *       model.
+ *   <li>Converting the canonical model back into the catalog’s format and updating the catalog
+ *       accordingly.
+ * </ul>
+ */
+public interface CatalogAccessControlPolicySyncClient {
+  /**
+   * Fetches the current policies from the catalog, converting them into the internal canonical
+   * model.
+   *
+   * <p>This method allows you to pull in the catalog’s native policy definitions (e.g., roles,
+   * privileges, user/groups) and map them into a {@link InternalAccessControlPolicySnapshot} so
+   * that they can be managed or merged with your centralized policy framework.
+   *
+   * @return A {@code CatalogAccessControlPolicySnapshot} containing the catalog’s current policies.
+   */
+  InternalAccessControlPolicySnapshot fetchPolicies();
+
+  /**
+   * Pushes the canonical policy snapshot into the target catalog, converting it into the catalog’s
+   * native policy definitions and applying any necessary updates.
+   *
+   * <p>This method typically performs the following steps:
+   *
+   * <ol>
+   *   <li>Transforms the given {@code InternalAccessControlPolicySnapshot} into the catalog’s
+   *       native format (roles, privileges, etc.).
+   *   <li>Applies the resulting policy definitions to the catalog, potentially overwriting or
+   *       merging existing policies.
+   *   <li>Returns a {@link SyncResult} detailing the success or failure of the operation.
+   * </ol>
+   *
+   * @param snapshot The access control policy snapshot to be synchronized with the catalog.
+   */
+  void pushPolicies(InternalAccessControlPolicySnapshot snapshot);
+}


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Adds interface and models for synchronizing ACL policies between source and target catalogs.

## Brief change log

*(for example:)*
- *Add models for role, user, user-group, privilege and securable-object*
- *Add InternalAccessControlPolicySnapshot to represent the policy snapshot for a catalog*
- *Add interface CatalogAccessControlPolicySyncClient*

## Verify this pull request

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end.*
- *Added TestConversionController to verify the change.*
- *Manually verified the change by running a job locally.*
