### PR TITLE
Handle timestamp_ntz in delta conversion target

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionTarget.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionTarget.java
@@ -66,9 +66,9 @@ import org.apache.xtable.model.storage.TableFormat;
 import org.apache.xtable.spi.sync.ConversionTarget;
 
 public class DeltaConversionTarget implements ConversionTarget {
-  private static final String MIN_READER_VERSION = String.valueOf(1);
+  private static final String MIN_READER_VERSION = String.valueOf(3);
   // gets access to generated columns.
-  private static final String MIN_WRITER_VERSION = String.valueOf(4);
+  private static final String MIN_WRITER_VERSION = String.valueOf(7);
 
   private DeltaLog deltaLog;
   private DeltaSchemaExtractor schemaExtractor;

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
@@ -61,6 +61,11 @@ public class DeltaSchemaExtractor {
   private static final String DELTA_COLUMN_MAPPING_ID = "delta.columnMapping.id";
   private static final String COMMENT = "comment";
   private static final DeltaSchemaExtractor INSTANCE = new DeltaSchemaExtractor();
+  // Timestamps in Delta are microsecond precision by default
+  private static final Map<InternalSchema.MetadataKey, Object>
+      DEFAULT_TIMESTAMP_PRECISION_METADATA =
+          Collections.singletonMap(
+              InternalSchema.MetadataKey.TIMESTAMP_PRECISION, InternalSchema.MetadataValue.MICROS);
 
   public static DeltaSchemaExtractor getInstance() {
     return INSTANCE;
@@ -88,7 +93,6 @@ public class DeltaSchemaExtractor {
       case INT:
         return DataTypes.IntegerType;
       case LONG:
-      case TIMESTAMP_NTZ:
         return DataTypes.LongType;
       case BYTES:
       case FIXED:
@@ -102,6 +106,8 @@ public class DeltaSchemaExtractor {
         return DataTypes.DateType;
       case TIMESTAMP:
         return DataTypes.TimestampType;
+      case TIMESTAMP_NTZ:
+        return DataTypes.TimestampNTZType;
       case DOUBLE:
         return DataTypes.DoubleType;
       case DECIMAL:
@@ -206,11 +212,11 @@ public class DeltaSchemaExtractor {
         break;
       case "timestamp":
         type = InternalType.TIMESTAMP;
-        // Timestamps in Delta are microsecond precision by default
-        metadata =
-            Collections.singletonMap(
-                InternalSchema.MetadataKey.TIMESTAMP_PRECISION,
-                InternalSchema.MetadataValue.MICROS);
+        metadata = DEFAULT_TIMESTAMP_PRECISION_METADATA;
+        break;
+      case "timestamp_ntz":
+        type = InternalType.TIMESTAMP_NTZ;
+        metadata = DEFAULT_TIMESTAMP_PRECISION_METADATA;
         break;
       case "struct":
         StructType structType = (StructType) dataType;

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
@@ -395,8 +395,8 @@ public class TestDeltaSchemaExtractor {
 
     StructType structRepresentationTimestampNtz =
         new StructType()
-            .add("requiredTimestampNtz", DataTypes.LongType, false)
-            .add("optionalTimestampNtz", DataTypes.LongType, true);
+            .add("requiredTimestampNtz", DataTypes.TimestampNTZType, false)
+            .add("optionalTimestampNtz", DataTypes.TimestampNTZType, true);
 
     Assertions.assertEquals(
         structRepresentationTimestamp,


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Handle timestamp_ntz in delta target, this needs to be done in a better way by finding this function in delta codebase. 
https://docs.delta.io/2.0.0/versioning.html 
`When creating a table, Delta Lake chooses the minimum required protocol version based on table characteristics such as the schema or table properties
`
## Brief change log

*(for example:)*
- * Handle timestamp_ntz in delta target*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end.*
- *Added TestConversionController to verify the change.*
- *Manually verified the change by running a job locally.*
