### PR TITLE
Handle timestamp_ntz in delta and iceberg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <spotless.version>2.43.0</spotless.version>
         <apache.rat.version>0.16.1</apache.rat.version>
         <google.java.format.version>1.8</google.java.format.version>
-        <delta.standalone.version>0.5.0</delta.standalone.version>
+        <delta.standalone.version>3.3.0</delta.standalone.version>
         <delta.hive.version>3.0.0</delta.hive.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <target.dir.pattern>**/target/**</target.dir.pattern>

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionTarget.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionTarget.java
@@ -73,9 +73,9 @@ import org.apache.xtable.spi.sync.ConversionTarget;
 
 @Log4j2
 public class DeltaConversionTarget implements ConversionTarget {
-  private static final String MIN_READER_VERSION = String.valueOf(1);
+  private static final int MIN_READER_VERSION = 1;
   // gets access to generated columns.
-  private static final String MIN_WRITER_VERSION = String.valueOf(4);
+  private static final int MIN_WRITER_VERSION = 4;
 
   private DeltaLog deltaLog;
   private DeltaSchemaExtractor schemaExtractor;
@@ -329,8 +329,14 @@ public class DeltaConversionTarget implements ConversionTarget {
 
     private Map<String, String> getConfigurationsForDeltaSync() {
       Map<String, String> configMap = new HashMap<>();
-      configMap.put(DeltaConfigs.MIN_READER_VERSION().key(), MIN_READER_VERSION);
-      configMap.put(DeltaConfigs.MIN_WRITER_VERSION().key(), MIN_WRITER_VERSION);
+      configMap.put(
+          DeltaConfigs.MIN_READER_VERSION().key(),
+          String.valueOf(
+              Math.max(deltaLog.snapshot().protocol().minReaderVersion(), MIN_READER_VERSION)));
+      configMap.put(
+          DeltaConfigs.MIN_WRITER_VERSION().key(),
+          String.valueOf(
+              Math.max(deltaLog.snapshot().protocol().minWriterVersion(), MIN_WRITER_VERSION)));
       configMap.put(TableSyncMetadata.XTABLE_METADATA, metadata.toJson());
       // Sets retention for the Delta Log, does not impact underlying files in the table
       configMap.put(

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
@@ -56,6 +56,11 @@ import org.apache.xtable.schema.SchemaUtils;
 public class DeltaSchemaExtractor {
   private static final String DELTA_COLUMN_MAPPING_ID = "delta.columnMapping.id";
   private static final DeltaSchemaExtractor INSTANCE = new DeltaSchemaExtractor();
+  // Timestamps in Delta are microsecond precision by default
+  private static final Map<InternalSchema.MetadataKey, Object>
+      DEFAULT_TIMESTAMP_PRECISION_METADATA =
+          Collections.singletonMap(
+              InternalSchema.MetadataKey.TIMESTAMP_PRECISION, InternalSchema.MetadataValue.MICROS);
 
   public static DeltaSchemaExtractor getInstance() {
     return INSTANCE;
@@ -110,11 +115,11 @@ public class DeltaSchemaExtractor {
         break;
       case "timestamp":
         type = InternalType.TIMESTAMP;
-        // Timestamps in Delta are microsecond precision by default
-        metadata =
-            Collections.singletonMap(
-                InternalSchema.MetadataKey.TIMESTAMP_PRECISION,
-                InternalSchema.MetadataValue.MICROS);
+        metadata = DEFAULT_TIMESTAMP_PRECISION_METADATA;
+        break;
+      case "timestamp_ntz":
+        type = InternalType.TIMESTAMP_NTZ;
+        metadata = DEFAULT_TIMESTAMP_PRECISION_METADATA;
         break;
       case "struct":
         StructType structType = (StructType) dataType;

--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergSchemaExtractor.java
@@ -173,7 +173,6 @@ public class IcebergSchemaExtractor {
       case INT:
         return Types.IntegerType.get();
       case LONG:
-      case TIMESTAMP_NTZ: // TODO - revisit this
         return Types.LongType.get();
       case BYTES:
         return Types.BinaryType.get();
@@ -189,6 +188,8 @@ public class IcebergSchemaExtractor {
         return Types.DateType.get();
       case TIMESTAMP:
         return Types.TimestampType.withZone();
+      case TIMESTAMP_NTZ:
+        return Types.TimestampType.withoutZone();
       case DOUBLE:
         return Types.DoubleType.get();
       case DECIMAL:

--- a/xtable-core/src/main/java/org/apache/xtable/schema/SparkSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/schema/SparkSchemaExtractor.java
@@ -62,7 +62,6 @@ public class SparkSchemaExtractor {
       case INT:
         return DataTypes.IntegerType;
       case LONG:
-      case TIMESTAMP_NTZ:
         return DataTypes.LongType;
       case BYTES:
       case FIXED:
@@ -76,6 +75,8 @@ public class SparkSchemaExtractor {
         return DataTypes.DateType;
       case TIMESTAMP:
         return DataTypes.TimestampType;
+      case TIMESTAMP_NTZ:
+        return DataTypes.TimestampNTZType;
       case DOUBLE:
         return DataTypes.DoubleType;
       case DECIMAL:

--- a/xtable-core/src/test/java/org/apache/xtable/avro/TestAvroSchemaConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/avro/TestAvroSchemaConverter.java
@@ -576,7 +576,7 @@ public class TestAvroSchemaConverter {
                         .schema(
                             InternalSchema.builder()
                                 .name("long")
-                                .dataType(InternalType.TIMESTAMP_NTZ)
+                                .dataType(InternalType.LONG)
                                 .isNullable(false)
                                 .metadata(millisMetadata)
                                 .build())
@@ -586,7 +586,7 @@ public class TestAvroSchemaConverter {
                         .schema(
                             InternalSchema.builder()
                                 .name("long")
-                                .dataType(InternalType.TIMESTAMP_NTZ)
+                                .dataType(InternalType.LONG)
                                 .isNullable(false)
                                 .metadata(microsMetadata)
                                 .build())

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
@@ -322,13 +322,36 @@ public class TestDeltaSchemaExtractor {
                                 .metadata(metadata)
                                 .build())
                         .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build(),
+                    InternalField.builder()
+                        .name("requiredTimestampNtz")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("timestamp_ntz")
+                                .dataType(InternalType.TIMESTAMP_NTZ)
+                                .isNullable(false)
+                                .metadata(metadata)
+                                .build())
+                        .build(),
+                    InternalField.builder()
+                        .name("optionalTimestampNtz")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("timestamp_ntz")
+                                .dataType(InternalType.TIMESTAMP_NTZ)
+                                .isNullable(true)
+                                .metadata(metadata)
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
                         .build()))
             .build();
 
     StructType structRepresentationTimestamp =
         new StructType()
             .add("requiredTimestamp", DataTypes.TimestampType, false)
-            .add("optionalTimestamp", DataTypes.TimestampType, true);
+            .add("optionalTimestamp", DataTypes.TimestampType, true)
+            .add("requiredTimestampNtz", DataTypes.TimestampNTZType, false)
+            .add("optionalTimestampNtz", DataTypes.TimestampNTZType, true);
 
     Assertions.assertEquals(
         internalSchemaTimestamp,

--- a/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergSchemaExtractor.java
@@ -501,14 +501,18 @@ public class TestIcebergSchemaExtractor {
                 1, "requiredTimestampMillis", Types.TimestampType.withZone()),
             Types.NestedField.optional(
                 2, "optionalTimestampMillis", Types.TimestampType.withZone()),
-            Types.NestedField.required(3, "requiredTimestampNtzMillis", Types.LongType.get()),
-            Types.NestedField.optional(4, "optionalTimestampNtzMillis", Types.LongType.get()),
+            Types.NestedField.required(
+                3, "requiredTimestampNtzMillis", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(
+                4, "optionalTimestampNtzMillis", Types.TimestampType.withoutZone()),
             Types.NestedField.required(
                 5, "requiredTimestampMicros", Types.TimestampType.withZone()),
             Types.NestedField.optional(
                 6, "optionalTimestampMicros", Types.TimestampType.withZone()),
-            Types.NestedField.required(7, "requiredTimestampNtzMicros", Types.LongType.get()),
-            Types.NestedField.optional(8, "optionalTimestampNtzMicros", Types.LongType.get()));
+            Types.NestedField.required(
+                7, "requiredTimestampNtzMicros", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(
+                8, "optionalTimestampNtzMicros", Types.TimestampType.withoutZone()));
     assertTrue(expectedTargetSchema.sameSchema(SCHEMA_EXTRACTOR.toIceberg(irSchema)));
 
     Schema sourceSchema =

--- a/xtable-core/src/test/java/org/apache/xtable/schema/TestSparkSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/schema/TestSparkSchemaExtractor.java
@@ -385,8 +385,8 @@ public class TestSparkSchemaExtractor {
 
     StructType structRepresentationTimestampNtz =
         new StructType()
-            .add("requiredTimestampNtz", DataTypes.LongType, false)
-            .add("optionalTimestampNtz", DataTypes.LongType, true);
+            .add("requiredTimestampNtz", DataTypes.TimestampNTZType, false)
+            .add("optionalTimestampNtz", DataTypes.TimestampNTZType, true);
 
     Assertions.assertEquals(
         structRepresentationTimestamp,


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

1. Handle `timestamp_ntz` in delta target, ensured backwards compatibility by using the min and max writer version from `deltaLog.snapshot()`
2. Handle `timestamp_ntz` for iceberg target as well. 

## Brief change log

*(for example:)*
- *Handle timestamp_ntz in delta target*
- *Handle `timestamp_ntz` for iceberg target as well*

## Verify this pull request

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

*(example:)*

- *testTimestampNtz*