### PR TITLE
[660] Fix bug in Iceberg isIncrementalSyncSafeFrom

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
@@ -247,7 +247,7 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
     long timeInMillis = instant.toEpochMilli();
     Table iceTable = getSourceTable();
     boolean doesInstantOfAgeExists = false;
-    Long targetSnapshotId = null;
+    long targetSnapshotId = -1L;
     for (Snapshot snapshot : iceTable.snapshots()) {
       if (snapshot.timestampMillis() <= timeInMillis) {
         doesInstantOfAgeExists = true;
@@ -261,8 +261,8 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
     }
     // Go from latest snapshot until targetSnapshotId through parent reference.
     // nothing has to be null in this chain to guarantee safety of incremental sync.
-    Long currentSnapshotId = iceTable.currentSnapshot().snapshotId();
-    while (currentSnapshotId != null && currentSnapshotId != targetSnapshotId) {
+    long currentSnapshotId = iceTable.currentSnapshot().snapshotId();
+    while (currentSnapshotId != targetSnapshotId) {
       Snapshot currentSnapshot = iceTable.snapshot(currentSnapshotId);
       if (currentSnapshot == null) {
         // The snapshot is expired.

--- a/xtable-core/src/test/java/org/apache/xtable/TestIcebergTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/TestIcebergTable.java
@@ -307,7 +307,7 @@ public class TestIcebergTable implements GenericTable<Record, String> {
     return String.format("%s > 'aaa'", icebergDataHelper.getRecordKeyField());
   }
 
-  public Long getLastCommitTimestamp() {
+  public long getLastCommitTimestamp() {
     return getLatestSnapshot().timestampMillis();
   }
 


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Fixes #660 by fixing the comparison logic. The existing logic is using `!=` on non-primitives leading to a bug.

## Brief change log

- Use primitive longs instead of boxed longs to avoid basic comparison bug
- Add tests that will fail without the fix to prove out the case the user is facing

## Verify this pull request

- Augmented the existing tests to ensure that the positive case is asserted after snapshots are expired since that is a valid case for incremental sync. Previously this would fail due to the bug.
