### PR TITLE
[668] Support bucket partition transform for Iceberg Sources and Delta Targets

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/model/schema/InternalPartitionField.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/schema/InternalPartitionField.java
@@ -20,6 +20,7 @@ package org.apache.xtable.model.schema;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import lombok.Builder;
 import lombok.Value;
@@ -32,6 +33,7 @@ import lombok.Value;
 @Value
 @Builder
 public class InternalPartitionField {
+  public static final String NUM_BUCKETS = "NUM_BUCKETS";
   // Source field the partition is based on
   InternalField sourceField;
   /*
@@ -47,4 +49,6 @@ public class InternalPartitionField {
   @Builder.Default List<String> partitionFieldNames = Collections.emptyList();
   // An enum describing how the source data was transformed into the partition value
   PartitionTransformType transformType;
+  // Transform options such as number of buckets in the BUCKET transform type
+  @Builder.Default Map<String, Object> transformOptions = Collections.emptyMap();
 }

--- a/xtable-api/src/main/java/org/apache/xtable/model/schema/PartitionTransformType.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/schema/PartitionTransformType.java
@@ -30,7 +30,8 @@ public enum PartitionTransformType {
   MONTH,
   DAY,
   HOUR,
-  VALUE;
+  VALUE,
+  BUCKET;
 
   public boolean isTimeBased() {
     return this == YEAR || this == MONTH || this == DAY || this == HOUR;

--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiTableManager.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiTableManager.java
@@ -35,10 +35,12 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.TableNotFoundException;
 
+import org.apache.xtable.exception.PartitionSpecException;
 import org.apache.xtable.exception.UpdateException;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.schema.InternalField;
 import org.apache.xtable.model.schema.InternalPartitionField;
+import org.apache.xtable.model.schema.PartitionTransformType;
 import org.apache.xtable.model.storage.DataLayoutStrategy;
 
 /** A class used to initialize new Hudi tables and load the metadata of existing tables. */
@@ -124,6 +126,12 @@ public class HudiTableManager {
   @VisibleForTesting
   static String getKeyGeneratorClass(
       List<InternalPartitionField> partitionFields, List<InternalField> recordKeyFields) {
+    if (partitionFields.stream()
+        .anyMatch(
+            internalPartitionField ->
+                internalPartitionField.getTransformType() == PartitionTransformType.BUCKET)) {
+      throw new PartitionSpecException("Bucket partition is not yet supported by Hudi targets");
+    }
     boolean multipleRecordKeyFields = recordKeyFields.size() > 1;
     boolean multiplePartitionFields = partitionFields.size() > 1;
     String keyGeneratorClass;

--- a/xtable-core/src/test/java/org/apache/xtable/ITConversionController.java
+++ b/xtable-core/src/test/java/org/apache/xtable/ITConversionController.java
@@ -100,6 +100,7 @@ import org.apache.xtable.delta.DeltaConversionSourceProvider;
 import org.apache.xtable.hudi.HudiConversionSourceProvider;
 import org.apache.xtable.hudi.HudiTestUtil;
 import org.apache.xtable.iceberg.IcebergConversionSourceProvider;
+import org.apache.xtable.iceberg.TestIcebergDataHelper;
 import org.apache.xtable.model.storage.TableFormat;
 import org.apache.xtable.model.sync.SyncMode;
 
@@ -740,6 +741,34 @@ public class ITConversionController {
       // assert that proper settings are enabled for delta log
       DeltaLog deltaLog = DeltaLog.forTable(sparkSession, table.getBasePath());
       Assertions.assertTrue(deltaLog.enableExpiredLogCleanup(deltaLog.snapshot().metadata()));
+    }
+  }
+
+  @Test
+  void otherIcebergPartitionTypes() {
+    String tableName = getTableName();
+    ConversionController conversionController = new ConversionController(jsc.hadoopConfiguration());
+    List<String> targetTableFormats = Collections.singletonList(DELTA);
+
+    ConversionSourceProvider<?> conversionSourceProvider = getConversionSourceProvider(ICEBERG);
+    try (TestIcebergTable table =
+        new TestIcebergTable(
+            tableName,
+            tempDir,
+            jsc.hadoopConfiguration(),
+            "id",
+            Arrays.asList("level", "string_field"),
+            TestIcebergDataHelper.SchemaType.COMMON)) {
+      table.insertRows(100);
+
+      ConversionConfig conversionConfig =
+          getTableSyncConfig(
+              ICEBERG, SyncMode.FULL, tableName, table, targetTableFormats, null, null);
+      conversionController.sync(conversionConfig, conversionSourceProvider);
+      checkDatasetEquivalence(ICEBERG, table, targetTableFormats, 100);
+      // Query with filter to assert partition does not impact ability to query
+      checkDatasetEquivalenceWithFilter(
+          ICEBERG, table, targetTableFormats, "level == 'INFO' AND string_field > 'abc'");
     }
   }
 

--- a/xtable-core/src/test/java/org/apache/xtable/TestIcebergTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/TestIcebergTable.java
@@ -352,7 +352,7 @@ public class TestIcebergTable implements GenericTable<Record, String> {
     Path baseDataPath = Paths.get(icebergTable.location(), "data");
     String filePath;
     if (icebergDataHelper.getPartitionSpec().isPartitioned()) {
-      String partitionPath = getPartitionPath(partitionKey.get(0, String.class));
+      String partitionPath = ((PartitionKey) partitionKey).toPath();
       filePath =
           baseDataPath.resolve(partitionPath).resolve(UUID.randomUUID() + ".parquet").toString();
     } else {
@@ -433,15 +433,5 @@ public class TestIcebergTable implements GenericTable<Record, String> {
     return recordsByPartition.entrySet().stream()
         .map(entry -> writeAndGetDataFile(entry.getValue(), entry.getKey()))
         .collect(Collectors.toList());
-  }
-
-  private String getPartitionPath(Object partitionValue) {
-    Preconditions.checkArgument(
-        icebergDataHelper.getPartitionFieldNames().size() == 1,
-        "Only single partition field is supported for grouping records by partition");
-    Preconditions.checkArgument(
-        icebergDataHelper.getPartitionFieldNames().get(0).equals("level"),
-        "Only level partition field is supported for grouping records by partition");
-    return "level=" + partitionValue;
   }
 }

--- a/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergDataHelper.java
+++ b/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergDataHelper.java
@@ -126,7 +126,7 @@ public class TestIcebergDataHelper {
   String recordKeyField;
   List<String> partitionFieldNames;
 
-  public static enum SchemaType {
+  public enum SchemaType {
     BASIC,
     COMMON,
     COMMON_WITH_ADDITIONAL_COLUMNS,
@@ -201,6 +201,13 @@ public class TestIcebergDataHelper {
   public PartitionSpec getPartitionSpec() {
     if (partitionFieldNames.isEmpty()) {
       return PartitionSpec.unpartitioned();
+    }
+    if (partitionFieldNames.equals(Arrays.asList("level", "string_field"))) {
+      return PartitionSpec.builderFor(tableSchema)
+          .alwaysNull("bytes_field")
+          .identity("level")
+          .bucket("string_field", 10)
+          .build();
     }
     if (partitionFieldNames.size() > 1) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
## What is the purpose of the pull request

Addresses #668 
Adds support for handling Iceberg's Bucket partitioning when converting to Delta Lake. 

## Brief change log

- Skips handling of Void partition which will always return a null value
- Handle bucket partitioning by adding a new field in InternalPartitionField to track partitioning options like number of buckets
- Delta Lake support is added by using generated column to represent the partition similar to what we do for date based partitioning

## Verify this pull request

- Added unit tests for conversion cases
- Added integration test for Iceberg to Delta with bucket partitioning and void partition to test case reported
