### PR TITLE
[678] Avoid skipping xtable-aws and xtable-hive-metastore in mvn deploy

### DIFF
--- a/xtable-aws/pom.xml
+++ b/xtable-aws/pom.xml
@@ -101,14 +101,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/xtable-hive-metastore/pom.xml
+++ b/xtable-hive-metastore/pom.xml
@@ -193,14 +193,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Found few problems in 0.3.0-rc1 staged artificats, abandoned the release as few modules were missing.

## Brief change log

*(for example:)*
- *Fixed pom.xml configuration for missing modules*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.