### PR TITLE
[678] Introduce maturity-level in xtable-api and Refactor SyncStatusCode into separate class

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/annotations/Evolving.java
+++ b/xtable-api/src/main/java/org/apache/xtable/annotations/Evolving.java
@@ -16,20 +16,27 @@
  * limitations under the License.
  */
  
-package org.apache.xtable.model.sync;
+package org.apache.xtable.annotations;
 
-import org.apache.xtable.annotations.Stable;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Mode of a sync
- *
- * @since 0.1
+ * New APIs start out in this state. Although enough thought will be given to avoid breaking changes
+ * to the API in the future, sometimes it might need to change based on feedback.
  */
-@Stable
-public enum SyncMode {
-  // Full sync will create a checkpoint of ALL the files relevant at a certain point in time
-  FULL,
-  // Incremental will sync differential structures to bring the table state from and to points in
-  // the timeline
-  INCREMENTAL
-}
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+  ElementType.TYPE,
+  ElementType.FIELD,
+  ElementType.METHOD,
+  ElementType.PARAMETER,
+  ElementType.CONSTRUCTOR,
+  ElementType.LOCAL_VARIABLE,
+  ElementType.PACKAGE
+})
+public @interface Evolving {}

--- a/xtable-api/src/main/java/org/apache/xtable/annotations/Stable.java
+++ b/xtable-api/src/main/java/org/apache/xtable/annotations/Stable.java
@@ -16,20 +16,27 @@
  * limitations under the License.
  */
  
-package org.apache.xtable.model.sync;
+package org.apache.xtable.annotations;
 
-import org.apache.xtable.annotations.Stable;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Mode of a sync
- *
- * @since 0.1
+ * Enough applications/users have picked up the API and we deem it stable. We will strive to never
+ * break the stability of such APIs within a given major version release.
  */
-@Stable
-public enum SyncMode {
-  // Full sync will create a checkpoint of ALL the files relevant at a certain point in time
-  FULL,
-  // Incremental will sync differential structures to bring the table state from and to points in
-  // the timeline
-  INCREMENTAL
-}
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+  ElementType.TYPE,
+  ElementType.FIELD,
+  ElementType.METHOD,
+  ElementType.PARAMETER,
+  ElementType.CONSTRUCTOR,
+  ElementType.LOCAL_VARIABLE,
+  ElementType.PACKAGE
+})
+public @interface Stable {}

--- a/xtable-api/src/main/java/org/apache/xtable/model/sync/ErrorDetails.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/sync/ErrorDetails.java
@@ -18,18 +18,31 @@
  
 package org.apache.xtable.model.sync;
 
-import org.apache.xtable.annotations.Stable;
+import lombok.Builder;
+import lombok.Value;
 
-/**
- * Mode of a sync
- *
- * @since 0.1
- */
-@Stable
-public enum SyncMode {
-  // Full sync will create a checkpoint of ALL the files relevant at a certain point in time
-  FULL,
-  // Incremental will sync differential structures to bring the table state from and to points in
-  // the timeline
-  INCREMENTAL
+import org.apache.xtable.annotations.Evolving;
+
+@Value
+@Builder
+@Evolving
+public class ErrorDetails {
+  // error Message if any
+  String errorMessage;
+  // Readable description of the error
+  String errorDescription;
+  // Can the client retry for this type of error (Transient error=true, persistent error=false)
+  boolean canRetryOnFailure;
+
+  public static ErrorDetails create(Exception e, String errorDescription) {
+    if (e == null) {
+      return null;
+    }
+
+    return ErrorDetails.builder()
+        .errorMessage(e.getMessage())
+        .errorDescription(errorDescription)
+        .canRetryOnFailure(true)
+        .build();
+  }
 }

--- a/xtable-api/src/main/java/org/apache/xtable/model/sync/SyncResult.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/sync/SyncResult.java
@@ -20,10 +20,13 @@ package org.apache.xtable.model.sync;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 
 import lombok.Builder;
 import lombok.Value;
+
+import org.apache.xtable.annotations.Evolving;
 
 /**
  * Result of a sync operation
@@ -32,6 +35,7 @@ import lombok.Value;
  */
 @Value
 @Builder(toBuilder = true)
+@Evolving
 public class SyncResult {
   // Mode used for the sync
   SyncMode mode;
@@ -44,13 +48,7 @@ public class SyncResult {
   // The Sync Mode recommended for the next sync (Usually filled on an error)
   SyncMode recommendedSyncMode;
   // The sync status for each catalog.
-  List<CatalogSyncStatus> catalogSyncStatusList;
-
-  public enum SyncStatusCode {
-    SUCCESS,
-    ABORTED,
-    ERROR
-  }
+  @Builder.Default List<CatalogSyncStatus> catalogSyncStatusList = Collections.emptyList();
 
   /** Represents the status of a Sync operation. */
   @Value
@@ -74,16 +72,5 @@ public class SyncResult {
     SyncStatusCode statusCode;
     // errorDetails if any
     ErrorDetails errorDetails;
-  }
-
-  @Value
-  @Builder
-  public static class ErrorDetails {
-    // error Message if any
-    String errorMessage;
-    // Readable description of the error
-    String errorDescription;
-    // Can the client retry for this type of error (Transient error=true, persistent error=false)
-    boolean canRetryOnFailure;
   }
 }

--- a/xtable-api/src/main/java/org/apache/xtable/model/sync/SyncStatusCode.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/sync/SyncStatusCode.java
@@ -18,18 +18,18 @@
  
 package org.apache.xtable.model.sync;
 
-import org.apache.xtable.annotations.Stable;
+import org.apache.xtable.annotations.Evolving;
 
-/**
- * Mode of a sync
- *
- * @since 0.1
- */
-@Stable
-public enum SyncMode {
-  // Full sync will create a checkpoint of ALL the files relevant at a certain point in time
-  FULL,
-  // Incremental will sync differential structures to bring the table state from and to points in
-  // the timeline
-  INCREMENTAL
+/** Enum representing the status of a synchronization operation. */
+@Evolving
+public enum SyncStatusCode {
+
+  /** Indicates that the sync was successful. */
+  SUCCESS,
+
+  /** Indicates that the sync was aborted before completion. */
+  ABORTED,
+
+  /** Indicates that an error occurred during sync. */
+  ERROR
 }

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/CatalogConversionSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/CatalogConversionSource.java
@@ -20,6 +20,7 @@ package org.apache.xtable.spi.extractor;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.xtable.annotations.Evolving;
 import org.apache.xtable.conversion.ExternalCatalogConfig;
 import org.apache.xtable.conversion.SourceTable;
 import org.apache.xtable.model.catalog.CatalogTableIdentifier;
@@ -29,6 +30,7 @@ import org.apache.xtable.model.catalog.CatalogTableIdentifier;
  * catalog to SourceTable object {@link SourceTable}, can be used by downstream consumers for
  * syncing it to multiple {@link org.apache.xtable.conversion.TargetTable}
  */
+@Evolving
 public interface CatalogConversionSource {
   /** Returns the source table object present in the catalog. */
   SourceTable getSourceTable(CatalogTableIdentifier tableIdentifier);

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ConversionSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ConversionSource.java
@@ -21,6 +21,7 @@ package org.apache.xtable.spi.extractor;
 import java.io.Closeable;
 import java.time.Instant;
 
+import org.apache.xtable.annotations.Evolving;
 import org.apache.xtable.model.CommitsBacklog;
 import org.apache.xtable.model.InstantsForIncrementalSync;
 import org.apache.xtable.model.InternalSnapshot;
@@ -32,6 +33,7 @@ import org.apache.xtable.model.TableChange;
  * source system. The client uses {@link Instant} to represent the point in time a commit was made
  * to be as generic as possible across source table formats.
  */
+@Evolving
 public interface ConversionSource<COMMIT> extends Closeable {
   /**
    * Extracts the {@link InternalTable} definition as of the provided commit.

--- a/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ExtractFromSource.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/extractor/ExtractFromSource.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import org.apache.xtable.annotations.Stable;
 import org.apache.xtable.model.CommitsBacklog;
 import org.apache.xtable.model.IncrementalTableChanges;
 import org.apache.xtable.model.InstantsForIncrementalSync;
@@ -31,6 +32,7 @@ import org.apache.xtable.model.TableChange;
 
 @AllArgsConstructor(staticName = "of")
 @Getter
+@Stable
 public class ExtractFromSource<COMMIT> {
   private final ConversionSource<COMMIT> conversionSource;
 

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSync.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSync.java
@@ -34,8 +34,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.sync.ErrorDetails;
 import org.apache.xtable.model.sync.SyncResult;
 import org.apache.xtable.model.sync.SyncResult.CatalogSyncStatus;
+import org.apache.xtable.model.sync.SyncStatusCode;
 
 /** Provides the functionality to sync metadata from InternalTable to multiple target catalogs */
 @Log4j2
@@ -118,7 +120,7 @@ public class CatalogSync {
     }
     return CatalogSyncStatus.builder()
         .catalogId(catalogSyncClient.getCatalogId())
-        .statusCode(SyncResult.SyncStatusCode.SUCCESS)
+        .statusCode(SyncStatusCode.SUCCESS)
         .build();
   }
 
@@ -126,9 +128,9 @@ public class CatalogSync {
       String catalogId, String catalogImpl, Exception e) {
     return CatalogSyncStatus.builder()
         .catalogId(catalogId)
-        .statusCode(SyncResult.SyncStatusCode.ERROR)
+        .statusCode(SyncStatusCode.ERROR)
         .errorDetails(
-            SyncResult.ErrorDetails.builder()
+            ErrorDetails.builder()
                 .errorMessage(e.getMessage())
                 .errorDescription("catalogSync failed for " + catalogImpl)
                 .build())

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSyncClient.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSyncClient.java
@@ -20,6 +20,7 @@ package org.apache.xtable.spi.sync;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.xtable.annotations.Evolving;
 import org.apache.xtable.conversion.ExternalCatalogConfig;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.catalog.CatalogTableIdentifier;
@@ -30,6 +31,7 @@ import org.apache.xtable.model.catalog.CatalogTableIdentifier;
  *
  * @param <TABLE>
  */
+@Evolving
 public interface CatalogSyncClient<TABLE> extends AutoCloseable {
   /**
    * Returns the user-defined unique identifier for the catalog, allows user to sync table to

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/ConversionTarget.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/ConversionTarget.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.xtable.annotations.Stable;
 import org.apache.xtable.conversion.TargetTable;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.metadata.TableSyncMetadata;
@@ -32,6 +33,7 @@ import org.apache.xtable.model.storage.InternalFilesDiff;
 import org.apache.xtable.model.storage.PartitionFileGroup;
 
 /** A client that provides the major functionality for syncing changes to a target system. */
+@Stable
 public interface ConversionTarget {
 
   /**

--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/TableFormatSync.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/TableFormatSync.java
@@ -33,13 +33,16 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
+import org.apache.xtable.annotations.Stable;
 import org.apache.xtable.model.IncrementalTableChanges;
 import org.apache.xtable.model.InternalSnapshot;
 import org.apache.xtable.model.InternalTable;
 import org.apache.xtable.model.TableChange;
 import org.apache.xtable.model.metadata.TableSyncMetadata;
+import org.apache.xtable.model.sync.ErrorDetails;
 import org.apache.xtable.model.sync.SyncMode;
 import org.apache.xtable.model.sync.SyncResult;
+import org.apache.xtable.model.sync.SyncStatusCode;
 
 /** Provides the functionality to sync from the InternalTable format to the target format. */
 @Log4j2
@@ -58,6 +61,7 @@ public class TableFormatSync {
    * @param snapshot the snapshot to sync
    * @return the result of the sync process
    */
+  @Stable
   public Map<String, SyncResult> syncSnapshot(
       Collection<ConversionTarget> conversionTargets, InternalSnapshot snapshot) {
     Instant startTime = Instant.now();
@@ -91,6 +95,7 @@ public class TableFormatSync {
    * @param changes the changes from the source table format that need to be applied
    * @return the results of trying to sync each change
    */
+  @Stable
   public Map<String, List<SyncResult>> syncChanges(
       Map<ConversionTarget, TableSyncMetadata> conversionTargetWithMetadata,
       IncrementalTableChanges changes) {
@@ -192,9 +197,9 @@ public class TableFormatSync {
         .mode(mode)
         .tableFormatSyncStatus(
             SyncResult.SyncStatus.builder()
-                .statusCode(SyncResult.SyncStatusCode.ERROR)
+                .statusCode(SyncStatusCode.ERROR)
                 .errorDetails(
-                    SyncResult.ErrorDetails.builder()
+                    ErrorDetails.builder()
                         .errorMessage(e.getMessage())
                         .errorDescription("Failed to sync " + mode.name())
                         .canRetryOnFailure(true)

--- a/xtable-api/src/test/java/org/apache/xtable/spi/sync/TestCatalogSync.java
+++ b/xtable-api/src/test/java/org/apache/xtable/spi/sync/TestCatalogSync.java
@@ -47,6 +47,7 @@ import org.apache.xtable.model.schema.InternalPartitionField;
 import org.apache.xtable.model.schema.InternalSchema;
 import org.apache.xtable.model.schema.PartitionTransformType;
 import org.apache.xtable.model.sync.SyncResult;
+import org.apache.xtable.model.sync.SyncStatusCode;
 
 @ExtendWith(MockitoExtension.class)
 public class TestCatalogSync<TABLE> {
@@ -110,14 +111,14 @@ public class TestCatalogSync<TABLE> {
             .getCatalogSyncStatusList();
     List<SyncResult.CatalogSyncStatus> errorStatus =
         results.stream()
-            .filter(status -> status.getStatusCode().equals(SyncResult.SyncStatusCode.ERROR))
+            .filter(status -> status.getStatusCode().equals(SyncStatusCode.ERROR))
             .collect(Collectors.toList());
-    assertEquals(SyncResult.SyncStatusCode.ERROR, errorStatus.get(0).getStatusCode());
+    assertEquals(SyncStatusCode.ERROR, errorStatus.get(0).getStatusCode());
     assertEquals(
         3,
         results.stream()
             .map(SyncResult.CatalogSyncStatus::getStatusCode)
-            .filter(statusCode -> statusCode.equals(SyncResult.SyncStatusCode.SUCCESS))
+            .filter(statusCode -> statusCode.equals(SyncStatusCode.SUCCESS))
             .count());
 
     verify(mockClient1, times(1)).createDatabase(tableIdentifier1);

--- a/xtable-api/src/test/java/org/apache/xtable/spi/sync/TestTableFormatSync.java
+++ b/xtable-api/src/test/java/org/apache/xtable/spi/sync/TestTableFormatSync.java
@@ -52,8 +52,10 @@ import org.apache.xtable.model.storage.InternalDataFile;
 import org.apache.xtable.model.storage.InternalFilesDiff;
 import org.apache.xtable.model.storage.PartitionFileGroup;
 import org.apache.xtable.model.storage.TableFormat;
+import org.apache.xtable.model.sync.ErrorDetails;
 import org.apache.xtable.model.sync.SyncMode;
 import org.apache.xtable.model.sync.SyncResult;
+import org.apache.xtable.model.sync.SyncStatusCode;
 
 public class TestTableFormatSync {
   private final ConversionTarget mockConversionTarget1 = mock(ConversionTarget.class);
@@ -99,9 +101,9 @@ public class TestTableFormatSync {
     assertSyncResultTimes(failureResult, start);
     assertEquals(
         SyncResult.SyncStatus.builder()
-            .statusCode(SyncResult.SyncStatusCode.ERROR)
+            .statusCode(SyncStatusCode.ERROR)
             .errorDetails(
-                SyncResult.ErrorDetails.builder()
+                ErrorDetails.builder()
                     .errorMessage("Failure")
                     .errorDescription("Failed to sync FULL")
                     .canRetryOnFailure(true)
@@ -197,9 +199,9 @@ public class TestTableFormatSync {
     assertSyncResultTimes(partialSuccessResults.get(1), start);
     assertEquals(
         SyncResult.SyncStatus.builder()
-            .statusCode(SyncResult.SyncStatusCode.ERROR)
+            .statusCode(SyncStatusCode.ERROR)
             .errorDetails(
-                SyncResult.ErrorDetails.builder()
+                ErrorDetails.builder()
                     .errorMessage("Failure")
                     .errorDescription("Failed to sync INCREMENTAL")
                     .canRetryOnFailure(true)

--- a/xtable-core/src/main/java/org/apache/xtable/conversion/ConversionController.java
+++ b/xtable-core/src/main/java/org/apache/xtable/conversion/ConversionController.java
@@ -48,6 +48,7 @@ import org.apache.xtable.model.catalog.CatalogTableIdentifier;
 import org.apache.xtable.model.metadata.TableSyncMetadata;
 import org.apache.xtable.model.sync.SyncMode;
 import org.apache.xtable.model.sync.SyncResult;
+import org.apache.xtable.model.sync.SyncStatusCode;
 import org.apache.xtable.spi.extractor.ConversionSource;
 import org.apache.xtable.spi.extractor.ExtractFromSource;
 import org.apache.xtable.spi.sync.CatalogSync;
@@ -207,13 +208,11 @@ public class ConversionController {
     Map<String, SyncResult> syncResultsMerged =
         new HashMap<>(syncResultForIncrementalSync.getLastSyncResult());
     syncResultsMerged.putAll(syncResultForSnapshotSync.getLastSyncResult());
-    String successfulSyncs =
-        getFormatsWithStatusCode(syncResultsMerged, SyncResult.SyncStatusCode.SUCCESS);
+    String successfulSyncs = getFormatsWithStatusCode(syncResultsMerged, SyncStatusCode.SUCCESS);
     if (!successfulSyncs.isEmpty()) {
       log.info("Sync is successful for the following formats {}", successfulSyncs);
     }
-    String failedSyncs =
-        getFormatsWithStatusCode(syncResultsMerged, SyncResult.SyncStatusCode.ERROR);
+    String failedSyncs = getFormatsWithStatusCode(syncResultsMerged, SyncStatusCode.ERROR);
     if (!failedSyncs.isEmpty()) {
       log.error("Sync failed for the following formats {}", failedSyncs);
     }
@@ -243,7 +242,7 @@ public class ConversionController {
   }
 
   private static String getFormatsWithStatusCode(
-      Map<String, SyncResult> syncResultsMerged, SyncResult.SyncStatusCode statusCode) {
+      Map<String, SyncResult> syncResultsMerged, SyncStatusCode statusCode) {
     return syncResultsMerged.entrySet().stream()
         .filter(entry -> entry.getValue().getTableFormatSyncStatus().getStatusCode() == statusCode)
         .map(Map.Entry::getKey)

--- a/xtable-hudi-support/xtable-hudi-support-extensions/src/main/java/org/apache/xtable/hudi/sync/XTableSyncTool.java
+++ b/xtable-hudi-support/xtable-hudi-support-extensions/src/main/java/org/apache/xtable/hudi/sync/XTableSyncTool.java
@@ -45,6 +45,7 @@ import org.apache.xtable.hudi.HudiConversionSourceProvider;
 import org.apache.xtable.model.schema.PartitionTransformType;
 import org.apache.xtable.model.sync.SyncMode;
 import org.apache.xtable.model.sync.SyncResult;
+import org.apache.xtable.model.sync.SyncStatusCode;
 
 /**
  * A HoodieSyncTool for syncing a Hudi table to other formats (Delta and Iceberg) with
@@ -107,7 +108,7 @@ public class XTableSyncTool extends HoodieSyncTool {
             .filter(
                 entry ->
                     entry.getValue().getTableFormatSyncStatus().getStatusCode()
-                        != SyncResult.SyncStatusCode.SUCCESS)
+                        != SyncStatusCode.SUCCESS)
             .map(Map.Entry::getKey)
             .collect(Collectors.joining(","));
     if (!failingFormats.isEmpty()) {


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Refactoring classes for SyncStatusCode and ErrorDetails into separate classes for the PolicySync interfaces and methods. 
https://github.com/apache/incubator-xtable/pull/644/files 

## Brief change log

*(for example:)*
- *Refactor classes for SyncStatusCode and ErrorDetails*
- *Introduce maturity level for xtable-api module*

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

*(example:)*

- *xtable-api/src/test/java/org/apache/xtable/spi/sync/TestCatalogSync.java*
- *xtable-api/src/test/java/org/apache/xtable/spi/sync/TestTableFormatSync.java*