### PR TITLE
Use provided scope for hive dependencies in xtable-hive-metastore and glue in xtable-aws

### DIFF
--- a/xtable-aws/pom.xml
+++ b/xtable-aws/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>glue</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Junit -->

--- a/xtable-hive-metastore/pom.xml
+++ b/xtable-hive-metastore/pom.xml
@@ -54,18 +54,21 @@
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-hive-runtime</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Delta dependencies  -->
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-hive_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- HMS dependencies -->
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
+            <scope>provided</scope>
             <version>${hive.version}</version>
             <exclusions>
                 <exclusion>
@@ -93,6 +96,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
+            <scope>provided</scope>
             <version>${hive.version}</version>
             <exclusions>
                 <exclusion>
@@ -116,6 +120,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-common</artifactId>
+            <scope>provided</scope>
             <version>${hive.version}</version>
             <exclusions>
                 <exclusion>
@@ -127,6 +132,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
+            <scope>provided</scope>
             <version>${hive.version}</version>
             <classifier>core</classifier>
             <exclusions>


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request
Use provided scope for hive dependencies in xtable-hive-metastore and glue in xtable-aws as the bundling includes transitive dependencies which are not ASF compliant.   

## Brief change log

*(for example:)*
- *Use provided scope for hive dependencies as the bundling includes transitive dependencies which are not ASF compliant*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.