### PR TITLE
Enable squash and merge in .asf.yaml for xtable

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,12 +27,10 @@ github:
     projects: true
     discussions: true
   enabled_merge_buttons:
-    # "squash and merge" replaces committer with noreply@github, and we don't want that
-    # See https://lists.apache.org/thread/vxxpt1x316kjryb4dptsbs95p66d9xrv
-    squash:  false
+    squash:  true
     # We prefer linear history, so creating merge commits is disabled in UI
     merge:   false
-    rebase:  true
+    rebase:  false
   protected_branches:
     main:
       required_pull_request_reviews:


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Other incubating projects have squash and merge enabled, trying it for XTable as well. 
https://github.com/apache/polaris/blob/main/.asf.yaml#L33 

## Brief change log

*(for example:)*
- *Enable squash and merge in .asf.yaml for xtable*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.