### PR TITLE
Remove parameters from Glue partition columns

### DIFF
--- a/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSync.java
+++ b/xtable-api/src/main/java/org/apache/xtable/spi/sync/CatalogSync.java
@@ -69,7 +69,8 @@ public class CatalogSync {
                 tableIdentifier.getId(),
                 table.getBasePath(),
                 table.getTableFormat(),
-                catalogSyncClient.getClass().getName());
+                catalogSyncClient.getClass().getName(),
+                e);
             results.add(
                 getCatalogSyncFailureStatus(
                     catalogSyncClient.getCatalogId(), catalogSyncClient.getClass().getName(), e));

--- a/xtable-aws/src/main/java/org/apache/xtable/glue/GlueSchemaExtractor.java
+++ b/xtable-aws/src/main/java/org/apache/xtable/glue/GlueSchemaExtractor.java
@@ -250,8 +250,13 @@ public class GlueSchemaExtractor {
      */
     return getPartitionKeys(table).stream()
         .map(
-            pKey ->
-                columnsMap.getOrDefault(pKey, Column.builder().name(pKey).type("string").build()))
+            pKey -> {
+              Column column = columnsMap.get(pKey);
+              return Column.builder()
+                  .name(pKey)
+                  .type(column != null ? column.type() : "string")
+                  .build();
+            })
         .collect(Collectors.toList());
   }
 

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/GlueCatalogSyncTestBase.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/GlueCatalogSyncTestBase.java
@@ -96,7 +96,7 @@ public class GlueCatalogSyncTestBase {
                   getInternalField("booleanField", "boolean", InternalType.BOOLEAN)))
           .build();
   protected static final List<Column> PARTITION_KEYS =
-      Collections.singletonList(getColumn(TableFormat.DELTA, "partitionField", "string"));
+      Collections.singletonList(getColumn("partitionField", "string"));
   protected static final List<Column> DELTA_GLUE_SCHEMA =
       Arrays.asList(
           getColumn(TableFormat.DELTA, "intField", "int"),

--- a/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueSchemaExtractor.java
+++ b/xtable-aws/src/test/java/org/apache/xtable/glue/TestGlueSchemaExtractor.java
@@ -92,7 +92,7 @@ public class TestGlueSchemaExtractor extends TestSchemaExtractorBase {
           .partitionFieldNames(Collections.singletonList("dateOfBirth"))
           .build();
 
-  private static Column getColumn(String name, String type) {
+  public static Column getColumn(String name, String type) {
     return Column.builder().name(name).type(type).build();
   }
 


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Glue does not support partition column having any parameters when registering a table, otherwise would result in 
`Caused by: software.amazon.awssdk.services.glue.model.InvalidInputException: Parameters not supported for partition columns`, so not setting parameters for partition columns
## Brief change log

*(for example:)*
- *Fixed JSON parsing error when persisting state*
- *Added unit tests for schema evolution*

## Verify this pull request

- Unit tests