### PR TITLE
Improved all tests in TestHudiInstantUtils by parameterising and adding more test cases

### DIFF
--- a/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiInstantUtils.java
+++ b/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiInstantUtils.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
 package org.apache.xtable.hudi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.Instant;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -38,18 +37,25 @@ public class TestHudiInstantUtils {
 
   private static Stream<Arguments> instantTimeParseTestCases() {
     return Stream.of(
-            // Original test cases
-            Arguments.of("20230120044331843", Instant.parse("2023-01-20T04:43:31.843Z")),
-            Arguments.of("20230120044331", Instant.parse("2023-01-20T04:43:31.999Z")),
+        // Original test cases
+        Arguments.of("20230120044331843", Instant.parse("2023-01-20T04:43:31.843Z")),
+        Arguments.of("20230120044331", Instant.parse("2023-01-20T04:43:31.999Z")),
 
-            // Additional test cases
-            Arguments.of("19700101000000000", Instant.parse("1970-01-01T00:00:00.000Z")), // Unix epoch
-            Arguments.of("19700101000000", Instant.parse("1970-01-01T00:00:00.999Z")),    // Unix epoch without millis
-            Arguments.of("20251224235959123", Instant.parse("2025-12-24T23:59:59.123Z")), // Future date with millis
-            Arguments.of("20251224235959", Instant.parse("2025-12-24T23:59:59.999Z")),    // Future date without millis
-            Arguments.of("20200229235959123", Instant.parse("2020-02-29T23:59:59.123Z")), // Leap year
-            Arguments.of("20200229235959", Instant.parse("2020-02-29T23:59:59.999Z"))     // Leap year without millis
-    );
+        // Additional test cases
+        Arguments.of("19700101000000000", Instant.parse("1970-01-01T00:00:00.000Z")), // Unix epoch
+        Arguments.of(
+            "19700101000000",
+            Instant.parse("1970-01-01T00:00:00.999Z")), // Unix epoch without millis
+        Arguments.of(
+            "20251224235959123",
+            Instant.parse("2025-12-24T23:59:59.123Z")), // Future date with millis
+        Arguments.of(
+            "20251224235959",
+            Instant.parse("2025-12-24T23:59:59.999Z")), // Future date without millis
+        Arguments.of("20200229235959123", Instant.parse("2020-02-29T23:59:59.123Z")), // Leap year
+        Arguments.of(
+            "20200229235959", Instant.parse("2020-02-29T23:59:59.999Z")) // Leap year without millis
+        );
   }
 
   @ParameterizedTest
@@ -60,17 +66,22 @@ public class TestHudiInstantUtils {
 
   private static Stream<Arguments> instantToCommitTestCases() {
     return Stream.of(
-            // Original test cases
-            Arguments.of(Instant.parse("2023-01-20T04:43:31.843Z"), "20230120044331843"),
-            Arguments.of(Instant.parse("2023-01-20T04:43:31Z"), "20230120044331000"),
+        // Original test cases
+        Arguments.of(Instant.parse("2023-01-20T04:43:31.843Z"), "20230120044331843"),
+        Arguments.of(Instant.parse("2023-01-20T04:43:31Z"), "20230120044331000"),
 
-            // Additional test cases
-            Arguments.of(Instant.parse("1970-01-01T00:00:00Z"), "19700101000000000"),     // Unix epoch
-            Arguments.of(Instant.parse("1970-01-01T00:00:00.123Z"), "19700101000000123"), // Unix epoch with millis
-            Arguments.of(Instant.parse("2025-12-24T23:59:59Z"), "20251224235959000"),     // Future date
-            Arguments.of(Instant.parse("2025-12-24T23:59:59.999Z"), "20251224235959999"), // Future date with max millis
-            Arguments.of(Instant.parse("2020-02-29T23:59:59Z"), "20200229235959000"),     // Leap year
-            Arguments.of(Instant.parse("2021-12-31T23:59:59.555Z"), "20211231235959555")  // Year end with millis
-    );
+        // Additional test cases
+        Arguments.of(Instant.parse("1970-01-01T00:00:00Z"), "19700101000000000"), // Unix epoch
+        Arguments.of(
+            Instant.parse("1970-01-01T00:00:00.123Z"),
+            "19700101000000123"), // Unix epoch with millis
+        Arguments.of(Instant.parse("2025-12-24T23:59:59Z"), "20251224235959000"), // Future date
+        Arguments.of(
+            Instant.parse("2025-12-24T23:59:59.999Z"),
+            "20251224235959999"), // Future date with max millis
+        Arguments.of(Instant.parse("2020-02-29T23:59:59Z"), "20200229235959000"), // Leap year
+        Arguments.of(
+            Instant.parse("2021-12-31T23:59:59.555Z"), "20211231235959555") // Year end with millis
+        );
   }
 }

--- a/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiInstantUtils.java
+++ b/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiInstantUtils.java
@@ -15,34 +15,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.xtable.hudi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestHudiInstantUtils {
 
-  @Test
-  public void testParseCommitTimeToInstant() {
-    assertEquals(
-        Instant.parse("2023-01-20T04:43:31.843Z"),
-        HudiInstantUtils.parseFromInstantTime("20230120044331843"));
-    assertEquals(
-        Instant.parse("2023-01-20T04:43:31.999Z"),
-        HudiInstantUtils.parseFromInstantTime("20230120044331"));
+  @ParameterizedTest
+  @MethodSource("instantTimeParseTestCases")
+  public void testParseCommitTimeToInstant(String commitTime, Instant expectedInstant) {
+    assertEquals(expectedInstant, HudiInstantUtils.parseFromInstantTime(commitTime));
   }
 
-  @Test
-  public void testInstantToCommit() {
-    assertEquals(
-        "20230120044331843",
-        HudiInstantUtils.convertInstantToCommit(Instant.parse("2023-01-20T04:43:31.843Z")));
-    assertEquals(
-        "20230120044331000",
-        HudiInstantUtils.convertInstantToCommit(Instant.parse("2023-01-20T04:43:31Z")));
+  private static Stream<Arguments> instantTimeParseTestCases() {
+    return Stream.of(
+            // Original test cases
+            Arguments.of("20230120044331843", Instant.parse("2023-01-20T04:43:31.843Z")),
+            Arguments.of("20230120044331", Instant.parse("2023-01-20T04:43:31.999Z")),
+
+            // Additional test cases
+            Arguments.of("19700101000000000", Instant.parse("1970-01-01T00:00:00.000Z")), // Unix epoch
+            Arguments.of("19700101000000", Instant.parse("1970-01-01T00:00:00.999Z")),    // Unix epoch without millis
+            Arguments.of("20251224235959123", Instant.parse("2025-12-24T23:59:59.123Z")), // Future date with millis
+            Arguments.of("20251224235959", Instant.parse("2025-12-24T23:59:59.999Z")),    // Future date without millis
+            Arguments.of("20200229235959123", Instant.parse("2020-02-29T23:59:59.123Z")), // Leap year
+            Arguments.of("20200229235959", Instant.parse("2020-02-29T23:59:59.999Z"))     // Leap year without millis
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("instantToCommitTestCases")
+  public void testInstantToCommit(Instant instant, String expectedCommitTime) {
+    assertEquals(expectedCommitTime, HudiInstantUtils.convertInstantToCommit(instant));
+  }
+
+  private static Stream<Arguments> instantToCommitTestCases() {
+    return Stream.of(
+            // Original test cases
+            Arguments.of(Instant.parse("2023-01-20T04:43:31.843Z"), "20230120044331843"),
+            Arguments.of(Instant.parse("2023-01-20T04:43:31Z"), "20230120044331000"),
+
+            // Additional test cases
+            Arguments.of(Instant.parse("1970-01-01T00:00:00Z"), "19700101000000000"),     // Unix epoch
+            Arguments.of(Instant.parse("1970-01-01T00:00:00.123Z"), "19700101000000123"), // Unix epoch with millis
+            Arguments.of(Instant.parse("2025-12-24T23:59:59Z"), "20251224235959000"),     // Future date
+            Arguments.of(Instant.parse("2025-12-24T23:59:59.999Z"), "20251224235959999"), // Future date with max millis
+            Arguments.of(Instant.parse("2020-02-29T23:59:59Z"), "20200229235959000"),     // Leap year
+            Arguments.of(Instant.parse("2021-12-31T23:59:59.555Z"), "20211231235959555")  // Year end with millis
+    );
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

This pull request improves both the tests in `TestHudiInstantUtils` by refactoring them into parameterised unit tests and also adding more test cases to enhance testing logic. 

Elaboration: 
* The same method calls (parseFromInstantTime & convertInstantToCommit) are repeated with different inputs, making the test harder to maintain and extend.
* When a test fails, JUnit only shows which type of assertion failed, but not which specific input caused the failure.
* Adding new test cases requires copying and pasting another Assertions.assertEquals(...) statement instead of simply adding new data.

## Brief change log
- *Parameterised tests: `testParseCommitTimeToInstant` & `testInstantToCommit`*
- *Added more test cases as value sets to above parameterised tests*

## Verify this pull request
Below are the before and after unit test run reports: 
Below changes:  
<img width="365" alt="Screenshot 2025-04-24 at 11 08 53 AM" src="https://github.com/user-attachments/assets/d4b8e193-2fae-4360-b52c-628cce577f3c" />

After changes: 
<img width="462" alt="Screenshot 2025-04-24 at 11 09 18 AM" src="https://github.com/user-attachments/assets/7f82be7d-5b56-4d7f-8b76-a12a05e28d6a" />
