### PR TITLE
Add additional properties when doing conversion for hudi

### DIFF
--- a/xtable-service/src/main/java/org/apache/xtable/service/ConversionService.java
+++ b/xtable-service/src/main/java/org/apache/xtable/service/ConversionService.java
@@ -19,6 +19,7 @@
 package org.apache.xtable.service;
 
 import static org.apache.xtable.conversion.ConversionUtils.convertToSourceTable;
+import static org.apache.xtable.hudi.HudiSourceConfig.PARTITION_FIELD_SPEC_CONFIG;
 import static org.apache.xtable.model.storage.TableFormat.DELTA;
 import static org.apache.xtable.model.storage.TableFormat.HUDI;
 import static org.apache.xtable.model.storage.TableFormat.ICEBERG;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -186,11 +188,19 @@ public class ConversionService {
    * @return a ConvertTableResponse containing details of the converted target tables
    */
   public ConvertTableResponse convertTable(ConvertTableRequest convertTableRequest) {
+
+    Properties sourceProperties = new Properties();
+    String partitionSpec = convertTableRequest.getConfigurations().getOrDefault("partition-spec", null);
+    if (partitionSpec != null) {
+      sourceProperties.put(PARTITION_FIELD_SPEC_CONFIG, partitionSpec);
+    }
+
     SourceTable sourceTable =
         SourceTable.builder()
             .name(convertTableRequest.getSourceTableName())
             .basePath(convertTableRequest.getSourceTablePath())
             .formatName(convertTableRequest.getSourceFormat())
+            .additionalProperties(sourceProperties)
             .build();
 
     List<TargetTable> targetTables = new ArrayList<>();
@@ -200,6 +210,7 @@ public class ConversionService {
               .name(convertTableRequest.getSourceTableName())
               .basePath(convertTableRequest.getSourceTablePath())
               .formatName(targetFormat)
+              .additionalProperties(sourceProperties)
               .build();
       targetTables.add(targetTable);
     }


### PR DESCRIPTION

## What is the purpose of the pull request
* Fix conversion when hudi is source/target format.

## Brief change log
* When testing conversion for Hudi, ran into a null pointer issue, as its required for hudi to set partition spec, as mentioned in the xtable docs https://xtable.apache.org/docs/how-to. When users are specifying hudi as either source or target they will need to provide `partition-spec` in the `configurations` map in the request.

```
 "configurations" : {"partition-spec" : "..."}
```

## Verify this pull request

Now when running with this change do not see the issue.

<img width="2580" alt="Screenshot 2025-05-12 at 9 01 19 AM" src="https://github.com/user-attachments/assets/77805cc5-684a-4fb8-9d08-b7aab321841a" />

