### PR TITLE
Nested column partition support in HudiPartitionValuesExtractor when hive style partitioning is enabled

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiPartitionValuesExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiPartitionValuesExtractor.java
@@ -53,7 +53,7 @@ public class HudiPartitionValuesExtractor {
     List<PartitionValue> result = new ArrayList<>(totalNumberOfPartitions);
     String remainingPartitionPath = partitionPath;
     for (InternalPartitionField partitionField : partitionColumns) {
-      String sourceFieldName = partitionField.getSourceField().getName();
+      String sourceFieldName = partitionField.getSourceField().getPath();
       if (remainingPartitionPath.startsWith(sourceFieldName + "=")) {
         // Strip off hive style partitioning
         remainingPartitionPath = remainingPartitionPath.substring(sourceFieldName.length() + 1);


### PR DESCRIPTION

## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

XTable sync fails with number format exception when partitioning is done on a nested field and hive style partitioning is enabled - 
```java
java.lang.NumberFormatException: For input string: "root.partition.year=2024"
```

Partition column is represented as - 

```java
InternalPartitionField(
	sourceField=InternalField(
		name=year, 
		parentPath=root.partition, 
		schema=InternalSchema(
			name=int, 
			dataType=InternalType.INT(name=int)
		), 
		path=root.partition.year, 
		pathParts=[root, partition, year]
	), 
	transformType=VALUE
)
```
but we are using `sourceField.name` to resolve partition key-value when hive-style partitioning is enabled.
So, it is throwing number format exception when parsing partition value (`root.partition.year=2024` instead of `2024`)


## Brief change log

Updated `extractPartitionValues` in **HudiPartitionValuesExtractor** to use complete field path

## Verify this pull request

- Unit tests
- Ran hudi to iceberg conversion locally
<img width="688" height="374" alt="image" src="https://github.com/user-attachments/assets/29bf9c9f-ff58-483e-9cb1-a52cbfc4e6e9" />
