### PR TITLE
[Draft] Paimon Source Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ hs_err_pid*
 # Ignore java-version and idea files.
 .java-version
 .idea
+.vscode
 
 # Ignore Gradle project-specific cache directory
 .gradle

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <spark.version.prefix>3.4</spark.version.prefix>
         <iceberg.version>1.4.2</iceberg.version>
         <delta.version>2.4.0</delta.version>
+        <paimon.version>1.2.0</paimon.version>
         <jackson.version>2.18.2</jackson.version>
         <spotless.version>2.43.0</spotless.version>
         <apache.rat.version>0.16.1</apache.rat.version>
@@ -330,6 +331,13 @@
                 <groupId>io.delta</groupId>
                 <artifactId>delta-hive_${scala.binary.version}</artifactId>
                 <version>${delta.hive.version}</version>
+            </dependency>
+
+            <!-- Paimon -->
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-bundle</artifactId>
+                <version>${paimon.version}</version>
             </dependency>
 
             <!-- Spark -->

--- a/xtable-api/src/main/java/org/apache/xtable/model/storage/TableFormat.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/storage/TableFormat.java
@@ -27,8 +27,9 @@ public class TableFormat {
   public static final String HUDI = "HUDI";
   public static final String ICEBERG = "ICEBERG";
   public static final String DELTA = "DELTA";
+  public static final String PAIMON = "PAIMON";
 
   public static String[] values() {
-    return new String[] {"HUDI", "ICEBERG", "DELTA"};
+    return new String[] {"HUDI", "ICEBERG", "DELTA", "PAIMON"};
   }
 }

--- a/xtable-core/pom.xml
+++ b/xtable-core/pom.xml
@@ -110,6 +110,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Paimon dependencies -->
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-bundle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-spark-${spark.version.prefix}</artifactId>
+            <version>${paimon.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Hadoop dependencies -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -204,6 +216,14 @@
                 </executions>
                 <configuration>
                     <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonConversionSource.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.paimon;
+
+import static org.apache.xtable.model.storage.DataLayoutStrategy.HIVE_STYLE_PARTITION;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.apache.xtable.exception.ReadException;
+import org.apache.xtable.model.*;
+import org.apache.xtable.model.schema.InternalPartitionField;
+import org.apache.xtable.model.schema.InternalSchema;
+import org.apache.xtable.model.storage.DataLayoutStrategy;
+import org.apache.xtable.model.storage.InternalDataFile;
+import org.apache.xtable.model.storage.PartitionFileGroup;
+import org.apache.xtable.model.storage.TableFormat;
+import org.apache.xtable.spi.extractor.ConversionSource;
+
+@Log4j2
+public class PaimonConversionSource implements ConversionSource<Snapshot> {
+
+  private final FileStoreTable paimonTable;
+  private final SchemaManager schemaManager;
+  private final SnapshotManager snapshotManager;
+
+  private final PaimonDataFileExtractor dataFileExtractor = PaimonDataFileExtractor.getInstance();
+  private final PaimonSchemaExtractor schemaExtractor = PaimonSchemaExtractor.getInstance();
+  private final PaimonPartitionExtractor partitionSpecExtractor =
+      PaimonPartitionExtractor.getInstance();
+
+  public PaimonConversionSource(FileStoreTable paimonTable) {
+    this.paimonTable = paimonTable;
+    this.schemaManager = paimonTable.schemaManager();
+    this.snapshotManager = paimonTable.snapshotManager();
+  }
+
+  @Override
+  public InternalTable getTable(Snapshot snapshot) {
+    TableSchema paimonSchema = schemaManager.schema(snapshot.schemaId());
+    InternalSchema internalSchema = schemaExtractor.toInternalSchema(paimonSchema);
+
+    List<String> partitionKeys = paimonTable.partitionKeys();
+    List<InternalPartitionField> partitioningFields =
+        partitionSpecExtractor.toInternalPartitionFields(partitionKeys, internalSchema);
+
+    DataLayoutStrategy dataLayoutStrategy =
+        partitioningFields.isEmpty() ? DataLayoutStrategy.FLAT : HIVE_STYLE_PARTITION;
+
+    return InternalTable.builder()
+        .name(paimonTable.name())
+        .tableFormat(TableFormat.PAIMON)
+        .readSchema(internalSchema)
+        .layoutStrategy(dataLayoutStrategy)
+        .basePath(paimonTable.location().toString())
+        .partitioningFields(partitioningFields)
+        .latestCommitTime(Instant.ofEpochMilli(snapshot.timeMillis()))
+        .latestMetadataPath(snapshotManager.snapshotPath(snapshot.id()).toString())
+        .build();
+  }
+
+  @Override
+  public InternalTable getCurrentTable() {
+    SnapshotManager snapshotManager = paimonTable.snapshotManager();
+    Snapshot snapshot = snapshotManager.latestSnapshot();
+    if (snapshot == null) {
+      throw new ReadException("No snapshots found for table " + paimonTable.name());
+    }
+    return getTable(snapshot);
+  }
+
+  @Override
+  public InternalSnapshot getCurrentSnapshot() {
+    SnapshotManager snapshotManager = paimonTable.snapshotManager();
+    Snapshot snapshot = snapshotManager.latestSnapshot();
+    if (snapshot == null) {
+      throw new ReadException("No snapshots found for table " + paimonTable.name());
+    }
+
+    InternalTable internalTable = getTable(snapshot);
+    List<InternalDataFile> internalDataFiles =
+        dataFileExtractor.toInternalDataFiles(paimonTable, snapshot);
+
+    return InternalSnapshot.builder()
+        .table(internalTable)
+        .version(Long.toString(snapshot.timeMillis()))
+        .partitionedDataFiles(PartitionFileGroup.fromFiles(internalDataFiles))
+        // TODO : Implement pending commits extraction, required for incremental sync
+        .sourceIdentifier(getCommitIdentifier(snapshot))
+        .build();
+  }
+
+  @Override
+  public TableChange getTableChangeForCommit(Snapshot snapshot) {
+    throw new UnsupportedOperationException("Incremental Sync is not supported yet.");
+  }
+
+  @Override
+  public CommitsBacklog<Snapshot> getCommitsBacklog(
+      InstantsForIncrementalSync instantsForIncrementalSync) {
+    throw new UnsupportedOperationException("Incremental Sync is not supported yet.");
+  }
+
+  @Override
+  public boolean isIncrementalSyncSafeFrom(Instant instant) {
+    return false; // Incremental sync is not supported yet
+  }
+
+  @Override
+  public String getCommitIdentifier(Snapshot snapshot) {
+    return Long.toString(snapshot.commitIdentifier());
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonConversionSourceProvider.java
+++ b/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonConversionSourceProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.paimon;
+
+import java.io.IOException;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+
+import org.apache.xtable.conversion.ConversionSourceProvider;
+import org.apache.xtable.conversion.SourceTable;
+import org.apache.xtable.spi.extractor.ConversionSource;
+
+public class PaimonConversionSourceProvider extends ConversionSourceProvider<Snapshot> {
+  @Override
+  public ConversionSource<Snapshot> getConversionSourceInstance(SourceTable sourceTableConfig) {
+    try {
+      Options catalogOptions = new Options();
+      CatalogContext context = CatalogContext.create(catalogOptions, hadoopConf);
+
+      Path path = new Path(sourceTableConfig.getDataPath());
+      FileIO fileIO = FileIO.get(path, context);
+      FileStoreTable paimonTable = FileStoreTableFactory.create(fileIO, path);
+
+      return new PaimonConversionSource(paimonTable);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonDataFileExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonDataFileExtractor.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.paimon;
+
+import java.util.*;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+
+import org.apache.xtable.model.stat.ColumnStat;
+import org.apache.xtable.model.storage.InternalDataFile;
+
+public class PaimonDataFileExtractor {
+
+  private final PaimonPartitionExtractor partitionExtractor =
+      PaimonPartitionExtractor.getInstance();
+
+  private static final PaimonDataFileExtractor INSTANCE = new PaimonDataFileExtractor();
+
+  public static PaimonDataFileExtractor getInstance() {
+    return INSTANCE;
+  }
+
+  public List<InternalDataFile> toInternalDataFiles(FileStoreTable table, Snapshot snapshot) {
+    List<InternalDataFile> result = new ArrayList<>();
+    Iterator<ManifestEntry> iterator = newSnapshotReader(table, snapshot).readFileIterator();
+    while (iterator.hasNext()) {
+      result.add(toInternalDataFile(table, iterator.next()));
+    }
+    return result;
+  }
+
+  private InternalDataFile toInternalDataFile(FileStoreTable table, ManifestEntry entry) {
+    return InternalDataFile.builder()
+        .physicalPath(toFullPhysicalPath(table, entry))
+        .fileSizeBytes(entry.file().fileSize())
+        .lastModified(entry.file().creationTimeEpochMillis())
+        .recordCount(entry.file().rowCount())
+        .partitionValues(partitionExtractor.toPartitionValues(table, entry.partition()))
+        .columnStats(toColumnStats(entry.file()))
+        .build();
+  }
+
+  private String toFullPhysicalPath(FileStoreTable table, ManifestEntry entry) {
+    String basePath = table.location().toString();
+    String bucketPath = "bucket-" + entry.bucket();
+    String filePath = entry.file().fileName();
+
+    Optional<String> partitionPath = partitionExtractor.toPartitionPath(table, entry.partition());
+    if (partitionPath.isPresent()) {
+      return String.join("/", basePath, partitionPath.get(), bucketPath, filePath);
+    } else {
+      return String.join("/", basePath, bucketPath, filePath);
+    }
+  }
+
+  private List<ColumnStat> toColumnStats(DataFileMeta file) {
+    // TODO: Implement logic to extract column stats from the file meta
+    return Collections.emptyList();
+  }
+
+  private SnapshotReader newSnapshotReader(FileStoreTable table, Snapshot snapshot) {
+    // If the table has primary keys, we read only the top level files
+    // which means we can only consider fully compacted files.
+    if (!table.schema().primaryKeys().isEmpty()) {
+      return table
+          .newSnapshotReader()
+          .withLevel(table.coreOptions().numLevels() - 1)
+          .withSnapshot(snapshot);
+    } else {
+      return table.newSnapshotReader().withSnapshot(snapshot);
+    }
+  }
+}

--- a/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonPartitionExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonPartitionExtractor.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.paimon;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.InternalRowPartitionComputer;
+
+import org.apache.xtable.model.schema.InternalField;
+import org.apache.xtable.model.schema.InternalPartitionField;
+import org.apache.xtable.model.schema.InternalSchema;
+import org.apache.xtable.model.schema.PartitionTransformType;
+import org.apache.xtable.model.stat.PartitionValue;
+import org.apache.xtable.model.stat.Range;
+
+/** Extracts partition spec for Paimon as identity transforms on partition keys. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaimonPartitionExtractor {
+
+  private final PaimonSchemaExtractor paimonSchemaExtractor = PaimonSchemaExtractor.getInstance();
+
+  private static final PaimonPartitionExtractor INSTANCE = new PaimonPartitionExtractor();
+
+  public static PaimonPartitionExtractor getInstance() {
+    return INSTANCE;
+  }
+
+  public List<InternalPartitionField> toInternalPartitionFields(
+      List<String> partitionKeys, InternalSchema schema) {
+    if (partitionKeys == null || partitionKeys.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return partitionKeys.stream()
+        .map(key -> toPartitionField(key, schema))
+        .collect(Collectors.toList());
+  }
+
+  public List<PartitionValue> toPartitionValues(FileStoreTable table, BinaryRow partition) {
+    InternalRowPartitionComputer partitionComputer = newPartitionComputer(table);
+    InternalSchema internalSchema = paimonSchemaExtractor.toInternalSchema(table.schema());
+
+    List<PartitionValue> partitionValues = new ArrayList<>();
+    for (Map.Entry<String, String> entry :
+        partitionComputer.generatePartValues(partition).entrySet()) {
+      PartitionValue partitionValue =
+          PartitionValue.builder()
+              .partitionField(toPartitionField(entry.getKey(), internalSchema))
+              .range(Range.scalar(entry.getValue()))
+              .build();
+      partitionValues.add(partitionValue);
+    }
+    return partitionValues;
+  }
+
+  public Optional<String> toPartitionPath(FileStoreTable table, BinaryRow partition) {
+    InternalRowPartitionComputer partitionComputer = newPartitionComputer(table);
+    return partitionComputer.generatePartValues(partition).entrySet().stream()
+        .map(e -> e.getKey() + "=" + e.getValue())
+        .reduce((a, b) -> a + "/" + b);
+  }
+
+  private InternalPartitionField toPartitionField(String key, InternalSchema schema) {
+    InternalField sourceField =
+        findField(schema, key)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Partition key not found in schema: " + key));
+    return InternalPartitionField.builder()
+        .sourceField(sourceField)
+        .transformType(PartitionTransformType.VALUE)
+        .build();
+  }
+
+  private Optional<InternalField> findField(InternalSchema schema, String path) {
+    return schema.getAllFields().stream().filter(f -> f.getPath().equals(path)).findFirst();
+  }
+
+  private InternalRowPartitionComputer newPartitionComputer(FileStoreTable table) {
+    return new InternalRowPartitionComputer(
+        table.coreOptions().partitionDefaultName(),
+        table.store().partitionType(),
+        table.partitionKeys().toArray(new String[0]),
+        table.coreOptions().legacyPartitionName());
+  }
+}

--- a/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/paimon/PaimonSchemaExtractor.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.paimon;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.*;
+
+import org.apache.xtable.exception.NotSupportedException;
+import org.apache.xtable.model.schema.InternalField;
+import org.apache.xtable.model.schema.InternalSchema;
+import org.apache.xtable.model.schema.InternalType;
+import org.apache.xtable.schema.SchemaUtils;
+
+/** Converts Paimon RowType to XTable InternalSchema. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaimonSchemaExtractor {
+  private static final PaimonSchemaExtractor INSTANCE = new PaimonSchemaExtractor();
+
+  public static PaimonSchemaExtractor getInstance() {
+    return INSTANCE;
+  }
+
+  public InternalSchema toInternalSchema(TableSchema paimonSchema) {
+    RowType rowType = paimonSchema.logicalRowType();
+    List<InternalField> fields = toInternalFields(rowType);
+    return InternalSchema.builder()
+        .name("record")
+        .dataType(InternalType.RECORD)
+        .fields(fields)
+        .recordKeyFields(primaryKeyFields(paimonSchema, fields))
+        .build();
+  }
+
+  private List<InternalField> primaryKeyFields(
+      TableSchema paimonSchema, List<InternalField> internalFields) {
+    List<String> keys = paimonSchema.primaryKeys();
+    return internalFields.stream()
+        .filter(f -> keys.contains(f.getName()))
+        .collect(Collectors.toList());
+  }
+
+  private List<InternalField> toInternalFields(RowType rowType) {
+    List<InternalField> fields = new ArrayList<>(rowType.getFieldCount());
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      DataField dataField = rowType.getFields().get(i);
+      InternalField internalField =
+          InternalField.builder()
+              .name(dataField.name())
+              .fieldId(dataField.id())
+              .parentPath(null)
+              .schema(
+                  fromPaimonType(dataField.type(), dataField.name(), dataField.type().isNullable()))
+              .defaultValue(
+                  dataField.type().isNullable() ? InternalField.Constants.NULL_DEFAULT_VALUE : null)
+              .build();
+      fields.add(internalField);
+    }
+    return fields;
+  }
+
+  private InternalSchema fromPaimonType(DataType type, String fieldPath, boolean nullable) {
+    InternalType internalType;
+    List<InternalField> fields = null;
+    Map<InternalSchema.MetadataKey, Object> metadata = null;
+    if (type instanceof CharType || type instanceof VarCharType) {
+      internalType = InternalType.STRING;
+    } else if (type instanceof BooleanType) {
+      internalType = InternalType.BOOLEAN;
+    } else if (type instanceof TinyIntType
+        || type instanceof SmallIntType
+        || type instanceof IntType) {
+      internalType = InternalType.INT;
+    } else if (type instanceof BigIntType) {
+      internalType = InternalType.LONG;
+    } else if (type instanceof FloatType) {
+      internalType = InternalType.FLOAT;
+    } else if (type instanceof DoubleType) {
+      internalType = InternalType.DOUBLE;
+    } else if (type instanceof BinaryType || type instanceof VarBinaryType) {
+      internalType = InternalType.BYTES;
+    } else if (type instanceof DateType) {
+      internalType = InternalType.DATE;
+    } else if (type instanceof TimestampType || type instanceof LocalZonedTimestampType) {
+      internalType = InternalType.TIMESTAMP;
+      metadata =
+          Collections.singletonMap(
+              InternalSchema.MetadataKey.TIMESTAMP_PRECISION, InternalSchema.MetadataValue.MICROS);
+    } else if (type instanceof DecimalType) {
+      DecimalType d = (DecimalType) type;
+      metadata = new HashMap<>(2, 1.0f);
+      metadata.put(InternalSchema.MetadataKey.DECIMAL_PRECISION, d.getPrecision());
+      metadata.put(InternalSchema.MetadataKey.DECIMAL_SCALE, d.getScale());
+      internalType = InternalType.DECIMAL;
+    } else if (type instanceof RowType) {
+      RowType rt = (RowType) type;
+      List<InternalField> nested = new ArrayList<>(rt.getFieldCount());
+      for (DataField df : rt.getFields()) {
+        nested.add(
+            InternalField.builder()
+                .name(df.name())
+                .fieldId(df.id())
+                .parentPath(fieldPath)
+                .schema(
+                    fromPaimonType(
+                        df.type(),
+                        SchemaUtils.getFullyQualifiedPath(fieldPath, df.name()),
+                        df.type().isNullable()))
+                .defaultValue(
+                    df.type().isNullable() ? InternalField.Constants.NULL_DEFAULT_VALUE : null)
+                .build());
+      }
+      fields = nested;
+      internalType = InternalType.RECORD;
+    } else if (type instanceof ArrayType) {
+      ArrayType at = (ArrayType) type;
+      InternalSchema elementSchema =
+          fromPaimonType(
+              at.getElementType(),
+              SchemaUtils.getFullyQualifiedPath(
+                  fieldPath, InternalField.Constants.ARRAY_ELEMENT_FIELD_NAME),
+              at.getElementType().isNullable());
+      InternalField elementField =
+          InternalField.builder()
+              .name(InternalField.Constants.ARRAY_ELEMENT_FIELD_NAME)
+              .parentPath(fieldPath)
+              .schema(elementSchema)
+              .build();
+      fields = Collections.singletonList(elementField);
+      internalType = InternalType.LIST;
+    } else if (type instanceof MapType) {
+      MapType mt = (MapType) type;
+      InternalSchema keySchema =
+          fromPaimonType(
+              mt.getKeyType(),
+              SchemaUtils.getFullyQualifiedPath(
+                  fieldPath, InternalField.Constants.MAP_KEY_FIELD_NAME),
+              false);
+      InternalField keyField =
+          InternalField.builder()
+              .name(InternalField.Constants.MAP_KEY_FIELD_NAME)
+              .parentPath(fieldPath)
+              .schema(keySchema)
+              .build();
+      InternalSchema valueSchema =
+          fromPaimonType(
+              mt.getValueType(),
+              SchemaUtils.getFullyQualifiedPath(
+                  fieldPath, InternalField.Constants.MAP_VALUE_FIELD_NAME),
+              mt.getValueType().isNullable());
+      InternalField valueField =
+          InternalField.builder()
+              .name(InternalField.Constants.MAP_VALUE_FIELD_NAME)
+              .parentPath(fieldPath)
+              .schema(valueSchema)
+              .build();
+      fields = Arrays.asList(keyField, valueField);
+      internalType = InternalType.MAP;
+    } else {
+      throw new NotSupportedException("Unsupported Paimon type: " + type.asSQLString());
+    }
+
+    return InternalSchema.builder()
+        .name(type.asSQLString())
+        .dataType(internalType)
+        .isNullable(nullable)
+        .metadata(metadata)
+        .fields(fields)
+        .build();
+  }
+}

--- a/xtable-core/src/test/java/org/apache/xtable/GenericTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/GenericTable.java
@@ -18,9 +18,7 @@
  
 package org.apache.xtable;
 
-import static org.apache.xtable.model.storage.TableFormat.DELTA;
-import static org.apache.xtable.model.storage.TableFormat.HUDI;
-import static org.apache.xtable.model.storage.TableFormat.ICEBERG;
+import static org.apache.xtable.model.storage.TableFormat.*;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -85,6 +83,9 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       case ICEBERG:
         return TestIcebergTable.forStandardSchemaAndPartitioning(
             tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration());
+      case PAIMON:
+        return TestPaimonTable.createTable(
+            tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration(), false);
       default:
         throw new IllegalArgumentException("Unsupported source format: " + sourceFormat);
     }
@@ -107,6 +108,9 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       case ICEBERG:
         return TestIcebergTable.forSchemaWithAdditionalColumnsAndPartitioning(
             tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration());
+      case PAIMON:
+        return TestPaimonTable.createTable(
+            tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration(), true);
       default:
         throw new IllegalArgumentException("Unsupported source format: " + sourceFormat);
     }

--- a/xtable-core/src/test/java/org/apache/xtable/ITConversionController.java
+++ b/xtable-core/src/test/java/org/apache/xtable/ITConversionController.java
@@ -21,9 +21,7 @@ package org.apache.xtable;
 import static org.apache.xtable.GenericTable.getTableName;
 import static org.apache.xtable.hudi.HudiSourceConfig.PARTITION_FIELD_SPEC_CONFIG;
 import static org.apache.xtable.hudi.HudiTestUtil.PartitionConfig;
-import static org.apache.xtable.model.storage.TableFormat.DELTA;
-import static org.apache.xtable.model.storage.TableFormat.HUDI;
-import static org.apache.xtable.model.storage.TableFormat.ICEBERG;
+import static org.apache.xtable.model.storage.TableFormat.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -37,16 +35,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -65,6 +54,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -91,11 +81,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 
-import org.apache.xtable.conversion.ConversionConfig;
-import org.apache.xtable.conversion.ConversionController;
-import org.apache.xtable.conversion.ConversionSourceProvider;
-import org.apache.xtable.conversion.SourceTable;
-import org.apache.xtable.conversion.TargetTable;
+import org.apache.xtable.conversion.*;
 import org.apache.xtable.delta.DeltaConversionSourceProvider;
 import org.apache.xtable.hudi.HudiConversionSourceProvider;
 import org.apache.xtable.hudi.HudiTestUtil;
@@ -103,9 +89,12 @@ import org.apache.xtable.iceberg.IcebergConversionSourceProvider;
 import org.apache.xtable.iceberg.TestIcebergDataHelper;
 import org.apache.xtable.model.storage.TableFormat;
 import org.apache.xtable.model.sync.SyncMode;
+import org.apache.xtable.paimon.PaimonConversionSourceProvider;
 
 public class ITConversionController {
-  @TempDir public static Path tempDir;
+  @TempDir(cleanup = CleanupMode.NEVER) // TODO remove CleanupMode.NEVER after debugging
+  public static Path tempDir;
+
   private static final DateTimeFormatter DATE_FORMAT =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.of("UTC"));
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -122,6 +111,15 @@ public class ITConversionController {
         .sparkContext()
         .hadoopConfiguration()
         .set("parquet.avro.write-old-list-structure", "false");
+    sparkSession
+        .sparkContext()
+        .conf()
+        .set(
+            "spark.sql.extensions",
+            "org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions")
+        .set("spark.sql.catalog.paimon", "org.apache.paimon.spark.SparkCatalog")
+        .set("spark.sql.catalog.paimon.warehouse", tempDir.toUri().toString());
+
     jsc = JavaSparkContext.fromSparkContext(sparkSession.sparkContext());
   }
 
@@ -141,10 +139,13 @@ public class ITConversionController {
 
   private static Stream<Arguments> generateTestParametersForFormatsSyncModesAndPartitioning() {
     List<Arguments> arguments = new ArrayList<>();
-    for (String sourceTableFormat : Arrays.asList(HUDI, DELTA, ICEBERG)) {
+    for (String sourceFormat : Arrays.asList(HUDI, DELTA, ICEBERG, PAIMON)) {
       for (SyncMode syncMode : SyncMode.values()) {
+        if (sourceFormat.equals(PAIMON) && syncMode == SyncMode.INCREMENTAL)
+          continue; // Paimon does not support incremental sync yet
+
         for (boolean isPartitioned : new boolean[] {true, false}) {
-          arguments.add(Arguments.of(sourceTableFormat, syncMode, isPartitioned));
+          arguments.add(Arguments.of(sourceFormat, syncMode, isPartitioned));
         }
       }
     }
@@ -169,23 +170,37 @@ public class ITConversionController {
   }
 
   private ConversionSourceProvider<?> getConversionSourceProvider(String sourceTableFormat) {
-    if (sourceTableFormat.equalsIgnoreCase(HUDI)) {
-      ConversionSourceProvider<HoodieInstant> hudiConversionSourceProvider =
-          new HudiConversionSourceProvider();
-      hudiConversionSourceProvider.init(jsc.hadoopConfiguration());
-      return hudiConversionSourceProvider;
-    } else if (sourceTableFormat.equalsIgnoreCase(DELTA)) {
-      ConversionSourceProvider<Long> deltaConversionSourceProvider =
-          new DeltaConversionSourceProvider();
-      deltaConversionSourceProvider.init(jsc.hadoopConfiguration());
-      return deltaConversionSourceProvider;
-    } else if (sourceTableFormat.equalsIgnoreCase(ICEBERG)) {
-      ConversionSourceProvider<Snapshot> icebergConversionSourceProvider =
-          new IcebergConversionSourceProvider();
-      icebergConversionSourceProvider.init(jsc.hadoopConfiguration());
-      return icebergConversionSourceProvider;
-    } else {
-      throw new IllegalArgumentException("Unsupported source format: " + sourceTableFormat);
+    switch (sourceTableFormat.toUpperCase()) {
+      case HUDI:
+        {
+          ConversionSourceProvider<HoodieInstant> hudiConversionSourceProvider =
+              new HudiConversionSourceProvider();
+          hudiConversionSourceProvider.init(jsc.hadoopConfiguration());
+          return hudiConversionSourceProvider;
+        }
+      case DELTA:
+        {
+          ConversionSourceProvider<Long> deltaConversionSourceProvider =
+              new DeltaConversionSourceProvider();
+          deltaConversionSourceProvider.init(jsc.hadoopConfiguration());
+          return deltaConversionSourceProvider;
+        }
+      case ICEBERG:
+        {
+          ConversionSourceProvider<Snapshot> icebergConversionSourceProvider =
+              new IcebergConversionSourceProvider();
+          icebergConversionSourceProvider.init(jsc.hadoopConfiguration());
+          return icebergConversionSourceProvider;
+        }
+      case PAIMON:
+        {
+          ConversionSourceProvider<org.apache.paimon.Snapshot> paimonConversionSourceProvider =
+              new PaimonConversionSourceProvider();
+          paimonConversionSourceProvider.init(jsc.hadoopConfiguration());
+          return paimonConversionSourceProvider;
+        }
+      default:
+        throw new IllegalArgumentException("Unsupported source format: " + sourceTableFormat);
     }
   }
 
@@ -486,6 +501,7 @@ public class ITConversionController {
   private static List<String> getOtherFormats(String sourceTableFormat) {
     return Arrays.stream(TableFormat.values())
         .filter(format -> !format.equals(sourceTableFormat))
+        .filter(format -> !format.equals(PAIMON)) // Paimon target is not supported yet
         .collect(Collectors.toList());
   }
 
@@ -906,34 +922,34 @@ public class ITConversionController {
                     }));
 
     String[] selectColumnsArr = sourceTable.getColumnsToSelect().toArray(new String[] {});
-    List<String> dataset1Rows = sourceRows.selectExpr(selectColumnsArr).toJSON().collectAsList();
+    List<String> sourceRowsList = sourceRows.selectExpr(selectColumnsArr).toJSON().collectAsList();
     targetRowsByFormat.forEach(
-        (format, targetRows) -> {
-          List<String> dataset2Rows =
+        (targetFormat, targetRows) -> {
+          List<String> targetRowsList =
               targetRows.selectExpr(selectColumnsArr).toJSON().collectAsList();
           assertEquals(
-              dataset1Rows.size(),
-              dataset2Rows.size(),
+              sourceRowsList.size(),
+              targetRowsList.size(),
               String.format(
                   "Datasets have different row counts when reading from Spark. Source: %s, Target: %s",
-                  sourceFormat, format));
+                  sourceFormat, targetFormat));
           // sanity check the count to ensure test is set up properly
           if (expectedCount != null) {
-            assertEquals(expectedCount, dataset1Rows.size());
+            assertEquals(expectedCount, sourceRowsList.size());
           } else {
             // if count is not known ahead of time, ensure datasets are non-empty
-            assertFalse(dataset1Rows.isEmpty());
+            assertFalse(sourceRowsList.isEmpty());
           }
 
-          if (containsUUIDFields(dataset1Rows) && containsUUIDFields(dataset2Rows)) {
-            compareDatasetWithUUID(dataset1Rows, dataset2Rows);
+          if (containsUUIDFields(sourceRowsList) && containsUUIDFields(targetRowsList)) {
+            compareDatasetWithUUID(sourceRowsList, targetRowsList);
           } else {
             assertEquals(
-                dataset1Rows,
-                dataset2Rows,
+                sourceRowsList,
+                targetRowsList,
                 String.format(
                     "Datasets are not equivalent when reading from Spark. Source: %s, Target: %s",
-                    sourceFormat, format));
+                    sourceFormat, targetFormat));
           }
         });
   }

--- a/xtable-core/src/test/java/org/apache/xtable/TestPaimonTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/TestPaimonTable.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.manifest.BucketEntry;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.*;
+import org.apache.paimon.utils.ParameterUtils;
+
+public class TestPaimonTable implements GenericTable<GenericRow, String> {
+
+  private final Random random = new Random();
+  private final FileStoreTable paimonTable;
+  private final String partitionField;
+
+  public TestPaimonTable(FileStoreTable paimonTable, String partitionField) {
+    this.paimonTable = paimonTable;
+    this.partitionField = partitionField;
+  }
+
+  public static GenericTable<GenericRow, String> createTable(
+      String tableName,
+      String partitionField,
+      Path tempDir,
+      Configuration hadoopConf,
+      boolean additionalColumns) {
+    String basePath = initBasePath(tempDir, tableName);
+    Catalog catalog = createFilesystemCatalog(basePath, hadoopConf);
+    FileStoreTable paimonTable = createTable(catalog, partitionField, additionalColumns);
+
+    System.out.println(
+        "Initialized Paimon test table at base path: "
+            + basePath
+            + " with partition field: "
+            + partitionField
+            + " and additional columns: "
+            + additionalColumns);
+
+    return new TestPaimonTable(paimonTable, partitionField);
+  }
+
+  public static Catalog createFilesystemCatalog(String basePath, Configuration hadoopConf) {
+    CatalogContext context = CatalogContext.create(new org.apache.paimon.fs.Path(basePath));
+    return CatalogFactory.createCatalog(context);
+  }
+
+  public static FileStoreTable createTable(
+      Catalog catalog, String partitionField, boolean additionalColumns) {
+    try {
+      catalog.createDatabase("test_db", true);
+      Identifier identifier = Identifier.create("test_db", "test_table");
+      Schema schema = buildSchema(partitionField, additionalColumns);
+      catalog.createTable(identifier, schema, true);
+      return (FileStoreTable) catalog.getTable(identifier);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Schema buildSchema(String partitionField, boolean additionalColumns) {
+    Schema.Builder builder =
+        Schema.newBuilder()
+            .primaryKey("id")
+            .column("id", DataTypes.INT())
+            .column("name", DataTypes.STRING())
+            .column("value", DataTypes.DOUBLE())
+            .column("created_at", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
+            .column("updated_at", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
+            .column("is_active", DataTypes.BOOLEAN())
+            .column("description", DataTypes.VARCHAR(255))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+            .option("full-compaction.delta-commits", "1");
+
+    if (partitionField != null) {
+      builder
+          .primaryKey("id", partitionField)
+          .column(partitionField, DataTypes.STRING())
+          .partitionKeys(partitionField);
+    }
+
+    if (additionalColumns) {
+      builder.column("extra_info", DataTypes.STRING()).column("extra_value", DataTypes.DOUBLE());
+    }
+
+    return builder.build();
+  }
+
+  private GenericRow buildGenericRow(int rowIdx, TableSchema schema, String partitionValue) {
+    List<Object> rowValues = new ArrayList<>(schema.fields().size());
+    for (int i = 0; i < schema.fields().size(); i++) {
+      DataField field = schema.fields().get(i);
+      if (field.name().equals(partitionField)) {
+        rowValues.add(BinaryString.fromString(partitionValue));
+      } else if (field.type() instanceof IntType) {
+        rowValues.add(random.nextInt());
+      } else if (field.type() instanceof DoubleType) {
+        rowValues.add(random.nextDouble());
+      } else if (field.type() instanceof VarCharType) {
+        rowValues.add(BinaryString.fromString(field.name() + "_" + rowIdx + "_" + i));
+      } else if (field.type() instanceof LocalZonedTimestampType) {
+        rowValues.add(Timestamp.fromEpochMillis(System.currentTimeMillis()));
+      } else if (field.type() instanceof BooleanType) {
+        rowValues.add(random.nextBoolean());
+      } else {
+        throw new UnsupportedOperationException("Unsupported field type: " + field.type());
+      }
+    }
+
+    return GenericRow.of(rowValues.toArray());
+  }
+
+  private static String initBasePath(Path tempDir, String tableName) {
+    try {
+      Path basePath = tempDir.resolve(tableName);
+      Files.createDirectories(basePath);
+      return basePath.toUri().toString();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public List<GenericRow> insertRows(int numRows) {
+    String partitionValue = LEVEL_VALUES.get(0);
+    return insertRecordsToPartition(numRows, partitionValue);
+  }
+
+  @Override
+  public List<GenericRow> insertRecordsForSpecialPartition(int numRows) {
+    return insertRecordsToPartition(numRows, SPECIAL_PARTITION_VALUE);
+  }
+
+  private List<GenericRow> insertRecordsToPartition(int numRows, String partitionValue) {
+    BatchWriteBuilder batchWriteBuilder = paimonTable.newBatchWriteBuilder();
+    try (BatchTableWrite writer = batchWriteBuilder.newWrite()) {
+      List<GenericRow> rows = new ArrayList<>(numRows);
+      for (int i = 0; i < numRows; i++) {
+        GenericRow row = buildGenericRow(i, paimonTable.schema(), partitionValue);
+        writer.write(row);
+        rows.add(row);
+      }
+      commitWrites(batchWriteBuilder, writer);
+      compactTable();
+      return rows;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to insert rows into Paimon table", e);
+    }
+  }
+
+  @Override
+  public void upsertRows(List<GenericRow> rows) {
+    BatchWriteBuilder batchWriteBuilder = paimonTable.newBatchWriteBuilder();
+    try (BatchTableWrite writer = batchWriteBuilder.newWrite()) {
+      for (GenericRow row : rows) {
+        writer.write(row);
+      }
+      commitWrites(batchWriteBuilder, writer);
+      compactTable();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to upsert rows into Paimon table", e);
+    }
+  }
+
+  @Override
+  public void deleteRows(List<GenericRow> rows) {
+    BatchWriteBuilder batchWriteBuilder = paimonTable.newBatchWriteBuilder();
+    try (BatchTableWrite writer = batchWriteBuilder.newWrite()) {
+      for (GenericRow row : rows) {
+        row.setRowKind(RowKind.DELETE);
+        writer.write(row);
+      }
+      commitWrites(batchWriteBuilder, writer);
+      compactTable();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to delete rows from Paimon table", e);
+    }
+  }
+
+  private void compactTable() {
+    BatchWriteBuilder batchWriteBuilder = paimonTable.newBatchWriteBuilder();
+    SnapshotReader snapshotReader = paimonTable.newSnapshotReader();
+    try (BatchTableWrite writer = batchWriteBuilder.newWrite()) {
+      for (BucketEntry bucketEntry : snapshotReader.bucketEntries()) {
+        writer.compact(bucketEntry.partition(), bucketEntry.bucket(), true);
+      }
+      commitWrites(batchWriteBuilder, writer);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to compact writes in Paimon table", e);
+    }
+  }
+
+  private static void commitWrites(BatchWriteBuilder batchWriteBuilder, BatchTableWrite writer)
+      throws Exception {
+    BatchTableCommit commit = batchWriteBuilder.newCommit();
+    List<CommitMessage> messages = writer.prepareCommit();
+    try {
+      commit.commit(messages);
+    } catch (Exception e) {
+      commit.abort(messages);
+      throw new RuntimeException("Failed to commit writes to Paimon table", e);
+    } finally {
+      commit.close();
+    }
+  }
+
+  @Override
+  public void deletePartition(String partitionValue) {
+    try (BatchTableCommit commit = paimonTable.newBatchWriteBuilder().newCommit()) {
+      commit.truncatePartitions(
+          ParameterUtils.getPartitions(partitionField + "=" + partitionValue));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to delete partition from Paimon table", e);
+    }
+  }
+
+  @Override
+  public void deleteSpecialPartition() {
+    deletePartition(SPECIAL_PARTITION_VALUE);
+  }
+
+  @Override
+  public String getBasePath() {
+    return paimonTable.location().toString();
+  }
+
+  @Override
+  public String getMetadataPath() {
+    return paimonTable.snapshotManager().snapshotDirectory().toString();
+  }
+
+  @Override
+  public String getOrderByColumn() {
+    return "id";
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void reload() {}
+
+  @Override
+  public List<String> getColumnsToSelect() {
+    return paimonTable.schema().fieldNames().stream()
+        .filter(
+            // TODO Hudi thinks that paimon buckets are partition values, not sure how to handle it
+            // filtering out the partition field on the comparison for now
+            field -> !field.equals(partitionField))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public String getFilterQuery() {
+    return "id % 2 = 0";
+  }
+}

--- a/xtable-service/pom.xml
+++ b/xtable-service/pom.xml
@@ -216,6 +216,17 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Paimon dependencies -->
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-bundle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-spark-${spark.version.prefix}</artifactId>
+            <version>${paimon.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
Issue: https://github.com/apache/incubator-xtable/issues/275 

Draft PR to add support for [Apache Paimon](https://paimon.apache.org/) as the source table. This is an early sharing to collect feedback on whether the approach is right and on a few issues I've encountered. 🙂 

Things that are missing yet:
- **Comprehensive unit test:** I've relied on `ITConversionController` to validate the code so far. Once we are good with the approach, I'll cover the implementation with more tests.
- **Incremental Sync:** I've only implemented the `ConversionSource` methods for the snapshot sync. Once we are good with the approach, I'll implement the incremental sync methods.
- **Target to Paimon:** I've only focused on implementing Paimon as a source. The target implementation will be out of scope for this contribution, if that's okay.

Things where I need help:
### **Hudi partitions and Paimon buckets** 

Paimon has buckets as another folder division within partitions (e.g. `partition=2025-09-01/bucket-0/data-file.parquet`), however, Hudi considers the bucket value as part of the partition value (e.g. `2025-09-01/bucket-0`). Looking at the code, it seems that directory structure == partition values assumption is pretty deep, so I wonder if there is a way to work around that, or we should call out as a limitation between both formats.

### **Iceberg Parquet conversion errors** 

When executing the `ITConversionController#testVariousOperations` with source=paimon and target=iceberg, I'm facing the follow error:
```
class org.apache.iceberg.shaded.org.apache.arrow.vector.IntVector cannot be cast to class org.apache.iceberg.shaded.org.apache.arrow.vector.BaseVariableWidthVector 
```
From debugging, it seems the Parquet reader is trying to read the `id int` field value with the `VarWidthReader` class instead of the `IntegerReader`, causing the conversion issue:
<img width="512" height="173" alt="image" src="https://github.com/user-attachments/assets/d4f98940-e0f9-4ba2-9d57-2a1403457a02" />

Disabling vectorization doesn't help; doing so makes the error appear on the Spark level, indicating that there is something wrong with the schema conversion for Iceberg that I quite don't understand... 🤔 

Thank you so much in advance for your help! 
