### PR TITLE
[LICENSE] Remove duplicate entry for org.javassist:javassist:3.25.0-G…

### DIFF
--- a/xtable-aws/src/main/resources/META-INF/LICENSE-bundled
+++ b/xtable-aws/src/main/resources/META-INF/LICENSE-bundled
@@ -267,4 +267,3 @@ org.glassfish:javax.el:3.0.0
 Mozilla Public License 2.0
 --------------------------
 org.jamon:jamon-runtime:2.4.1
-org.javassist:javassist:3.25.0-GA


### PR DESCRIPTION
## Issue Details
Issue - #717 

## What is the purpose of the pull request
This PR removes the duplicate LICENSE entry for org.javassist:javassist:3.25.0-GA
org.javassist:javassist:3.25.0-GA is a dual license package. Keeping the Apache License 2.0

## Brief change log
- Removed Mozilla Public License 2.0

## Verify this pull request
This pull request is a trivial rework / code cleanup without any test coverage.