### PR TITLE
Added a basic auto-setup script for mac os and some setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Snowflake. Creating transformations from one format to another is straightforwar
 of a few interfaces, which we believe will facilitate the expansion of supported source and target formats in the
 future.
 
+# macOS Setup
+
+**New to macOS?** Get set up in one command:
+
+```bash
+cd macos-setup && ./setup-macos.sh
+```
+
+This installs Java 11, Maven, Docker, and configures all environment variables automatically.
+
+See **[macos-setup/](./macos-setup/)** for the automation script, manual setup guide, and command reference.
+
 # Building the project and running tests.
 1. Use Java 11 for building the project. If you are using another Java version, you can use [jenv](https://github.com/jenv/jenv) to use multiple Java versions locally.
 2. Build the project using `mvn clean package`. Use `mvn clean package -DskipTests` to skip tests while building.

--- a/macos-setup/MACOS_SETUP_GUIDE.md
+++ b/macos-setup/MACOS_SETUP_GUIDE.md
@@ -1,0 +1,393 @@
+# macOS Setup Guide for Apache XTable™ Development
+
+This guide documents the complete setup process for developing Apache XTable™ on macOS. All commands are listed in the order they were executed.
+
+---
+
+## Prerequisites Check
+
+Before installation, we checked for existing installations of required tools.
+
+### 1. Check Java Installation
+```bash
+java -version
+```
+**Purpose**: Verify if Java is already installed on the system.  
+**Expected**: Should show Java version if installed, or error if not present.
+
+---
+
+### 2. Check JAVA_HOME Environment Variable
+```bash
+echo $JAVA_HOME
+```
+**Purpose**: Check if JAVA_HOME environment variable is set, which many Java tools require.  
+**Expected**: Shows the path to Java installation, or empty if not set.
+
+---
+
+### 3. Check Maven Installation
+```bash
+mvn -version
+```
+**Purpose**: Verify if Apache Maven build tool is installed.  
+**Expected**: Shows Maven version, Java version it's using, and system details if installed.
+
+---
+
+### 4. Check Docker Installation
+```bash
+docker --version
+```
+**Purpose**: Check if Docker is installed for containerized builds.  
+**Expected**: Shows Docker version if installed.
+
+---
+
+### 5. Check Homebrew Installation
+```bash
+brew --version
+```
+**Purpose**: Verify if Homebrew package manager is available (needed to install other tools).  
+**Expected**: Shows Homebrew version if installed.
+
+---
+
+## Installation Steps
+
+### 6. Install Homebrew (Package Manager for macOS)
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+**Purpose**: Install Homebrew, the de facto package manager for macOS that simplifies software installation.  
+**Details**: 
+- Downloads and runs the official Homebrew installation script
+- Creates necessary directories in `/usr/local/`
+- Sets up proper permissions
+- May require your admin password
+- Press RETURN when prompted to continue
+
+**Post-Install**: Homebrew will provide instructions to add it to your PATH.
+
+---
+
+### 7. Add Homebrew to PATH (Current Session)
+```bash
+eval "$(/usr/local/bin/brew shellenv)"
+```
+**Purpose**: Load Homebrew into the current terminal session immediately.  
+**Details**: This command sets up environment variables so you can use `brew` command right away.
+
+---
+
+### 8. Verify Homebrew Installation
+```bash
+brew --version
+```
+**Purpose**: Confirm Homebrew was installed successfully.  
+**Expected Output**: Should show Homebrew version (e.g., "Homebrew 4.6.15").
+
+---
+
+### 9. Install OpenJDK 11
+```bash
+brew install openjdk@11
+```
+**Purpose**: Install Java Development Kit version 11, which is required for building Apache XTable™.  
+**Details**: 
+- Downloads and installs OpenJDK 11 and its dependencies
+- Installs to `/usr/local/Cellar/openjdk@11/`
+- Version 11 is specifically required by the project (not newer versions)
+- Installation includes ~30 dependencies (fonts, graphics libraries, etc.)
+
+---
+
+### 10. Add OpenJDK 11 to PATH (Current Session)
+```bash
+export PATH="/usr/local/opt/openjdk@11/bin:$PATH"
+```
+**Purpose**: Add Java 11 binaries to the PATH for the current terminal session.  
+**Details**: Ensures the `java` and `javac` commands use OpenJDK 11.
+
+---
+
+### 11. Add OpenJDK 11 to PATH (Permanent - in .zshrc)
+```bash
+echo 'export PATH="/usr/local/opt/openjdk@11/bin:$PATH"' >> /Users/<your-username>/.zshrc
+```
+**Purpose**: Make Java 11 available in all future terminal sessions.  
+**Details**: 
+- Adds the PATH export to your zsh configuration file
+- Will be loaded automatically when you open a new terminal
+- Replace `/Users/amoghnatu/` with your actual home directory path
+
+---
+
+### 12. Set JAVA_HOME Environment Variable (Current Session)
+```bash
+export JAVA_HOME="/usr/local/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"
+```
+**Purpose**: Set the JAVA_HOME variable that many Java tools require.  
+**Details**: Points to the Java 11 installation directory structure.
+
+---
+
+### 13. Set JAVA_HOME Permanently (in .zshrc)
+```bash
+echo 'export JAVA_HOME="/usr/local/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"' >> /Users/amoghnatu/.zshrc
+```
+**Purpose**: Persist JAVA_HOME setting across terminal sessions.  
+**Details**: Ensures Maven and other tools can always find Java 11.
+
+---
+
+### 14. Create System Symlink for Java 11
+```bash
+sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
+```
+**Purpose**: Make Java 11 discoverable by macOS system Java wrappers.  
+**Details**: 
+- Requires admin password (`sudo`)
+- Creates a symbolic link in the system Java directory
+- Allows system tools to find and use Java 11
+- The `-sfn` flags: symbolic link, force (overwrite if exists), no dereference
+
+---
+
+### 15. Verify Java 11 Installation
+```bash
+java -version
+```
+**Purpose**: Confirm Java 11 is properly installed and accessible.  
+**Expected Output**: 
+```
+openjdk version "11.0.28" 2025-07-15
+OpenJDK Runtime Environment Homebrew (build 11.0.28+0)
+OpenJDK 64-Bit Server VM Homebrew (build 11.0.28+0, mixed mode)
+```
+
+---
+
+### 16. Install Apache Maven
+```bash
+brew install maven
+```
+**Purpose**: Install Maven, the build automation tool used by Apache XTable™.  
+**Details**: 
+- Downloads and installs Maven and dependencies (including OpenJDK for latest version)
+- Maven will be installed to `/usr/local/Cellar/maven/`
+- Homebrew automatically adds Maven to PATH
+
+---
+
+### 17. Verify Maven Installation
+```bash
+mvn -version
+```
+**Purpose**: Confirm Maven is installed and using Java 11.  
+**Expected Output**: Should show Maven 3.9.11 and Java version 11.0.28.  
+**Important**: Check that the "Java version" line shows version 11, not a newer version.
+
+---
+
+### 18. Install Docker Desktop
+```bash
+brew install --cask docker
+```
+**Purpose**: Install Docker Desktop application for running containers.  
+**Details**: 
+- Downloads and installs Docker Desktop GUI application
+- Installs to `/Applications/Docker.app`
+- Creates command-line tools: docker, docker-compose, etc.
+- May require admin password for linking binaries
+- The `--cask` flag indicates it's a GUI application, not just a command-line tool
+
+---
+
+### 19. Start Docker Desktop
+```bash
+open -a Docker
+```
+**Purpose**: Launch the Docker Desktop application.  
+**Details**: 
+- Opens Docker.app from Applications folder
+- Docker daemon will start running in the background
+- May take a minute for Docker to fully start
+- You'll see the Docker icon in the macOS menu bar when ready
+
+---
+
+## Verification Steps
+
+### 20. Verify Complete Maven Setup
+```bash
+mvn -version
+```
+**Purpose**: Double-check that Maven is using Java 11 after all configuration.  
+**Expected Output**: Should confirm Java version 11.0.28 is being used by Maven.
+
+---
+
+### 21. Test Docker Installation
+```bash
+docker run hello-world
+```
+**Purpose**: Verify Docker is working correctly by running a simple test container.  
+**Details**: 
+- Downloads the "hello-world" image if not present
+- Runs a container that prints a success message
+- Confirms Docker daemon, client, and image pulling all work
+**Expected Output**: Message stating "Hello from Docker!" with explanation of how it worked.
+
+---
+
+### 22. Validate Maven Project Configuration
+```bash
+mvn validate
+```
+**Purpose**: Run Maven validation to ensure the project structure and dependencies are correct.  
+**Details**: 
+- Executed from the Apache XTable™ project root directory
+- Downloads all project dependencies (may take several minutes first time)
+- Validates POM files and project structure
+- Runs enforcer rules for Maven version, Java version, and dependencies
+**Expected Output**: "BUILD SUCCESS" with all modules passing validation.
+
+---
+
+### 23. Test Maven Compile (Optional but Recommended)
+```bash
+mvn compile -DskipTests
+```
+**Purpose**: Compile the project source code without running tests to verify full build setup.  
+**Details**: 
+- Compiles all Java source files
+- Downloads remaining dependencies
+- The `-DskipTests` flag skips test execution for faster initial setup verification
+- Can take 5-10 minutes on first run due to dependency downloads
+
+---
+
+## System Requirements Summary
+
+| Component | Required Version | Installation Method |
+|-----------|------------------|-------------------|
+| macOS | Any recent version | Pre-installed |
+| Homebrew | Latest | curl install script |
+| Java | OpenJDK 11 | `brew install openjdk@11` |
+| Maven | 3.9+ | `brew install maven` |
+| Docker | Latest | `brew install --cask docker` |
+
+---
+
+## Environment Variables Configured
+
+```bash
+# Java 11 in PATH
+export PATH="/usr/local/opt/openjdk@11/bin:$PATH"
+
+# Java Home for tools
+export JAVA_HOME="/usr/local/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"
+```
+
+These should be in your `~/.zshrc` file for persistence.
+
+---
+
+## Common Build Commands
+
+After setup, you can use these Maven commands:
+
+```bash
+# Validate project structure
+mvn validate
+
+# Compile source code
+mvn compile
+
+# Build without tests
+mvn clean package -DskipTests
+
+# Build with tests
+mvn clean package
+
+# Run only unit tests
+mvn clean test
+
+# Run integration tests
+mvn clean verify
+
+# Clean build artifacts
+mvn clean
+```
+
+---
+
+## Troubleshooting
+
+### Maven using wrong Java version
+If Maven shows Java 25 or another version instead of Java 11:
+```bash
+# Re-export JAVA_HOME
+export JAVA_HOME="/usr/local/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"
+
+# Verify
+mvn -version
+```
+
+### Docker not starting
+If `docker` command fails:
+```bash
+# Make sure Docker Desktop is running
+open -a Docker
+
+# Wait 30 seconds, then test again
+docker --version
+```
+
+### Homebrew not found after installation
+```bash
+# Re-run the shellenv command
+eval "$(/usr/local/bin/brew shellenv)"
+
+# Or restart your terminal
+```
+
+### Java not found after installation
+```bash
+# Re-add to PATH
+export PATH="/usr/local/opt/openjdk@11/bin:$PATH"
+
+# Or source your zshrc
+source ~/.zshrc
+```
+
+---
+
+## Notes
+
+1. **Java Version**: The project specifically requires Java 11. Do not use newer versions (Java 17, 21, etc.) as they may cause compatibility issues.
+
+2. **First Build**: The first Maven build will download hundreds of megabytes of dependencies. Subsequent builds will be much faster.
+
+3. **Maven Cache**: Maven 3.9+ has build caching enabled by default. You can disable it with `-Dmaven.build.cache.enabled=false` if needed.
+
+4. **Code Style**: The project uses Spotless and Google Java Format. Run `mvn spotless:check` to check style and `mvn spotless:apply` to auto-fix issues.
+
+5. **Architecture**: This guide was tested on macOS x86_64 (Intel). Most steps are the same for Apple Silicon (M1/M2/M3), but Homebrew might install to `/opt/homebrew/` instead of `/usr/local/`. Adjust paths accordingly.
+
+---
+
+## References
+
+- [Apache XTable™ GitHub Repository](https://github.com/apache/incubator-xtable)
+- [Apache XTable™ Documentation](https://xtable.apache.org/)
+- [Homebrew Documentation](https://docs.brew.sh/)
+- [Maven Documentation](https://maven.apache.org/guides/)
+- [OpenJDK 11 Information](https://openjdk.org/projects/jdk/11/)
+
+---
+
+**Last Updated**: October 1, 2025  
+**macOS Version Tested**: macOS 15.7 (Sequoia)  
+**Architecture**: x86_64 (Intel Mac)

--- a/macos-setup/QUICK_REFERENCE.md
+++ b/macos-setup/QUICK_REFERENCE.md
@@ -1,0 +1,240 @@
+# Quick Reference Card - Apache XTable™ Development on macOS
+
+## One-Command Setup
+
+```bash
+./setup-macos.sh
+```
+
+---
+
+## Installed Versions
+
+| Tool | Version | Location |
+|------|---------|----------|
+| Java | OpenJDK 11.0.28 | `/usr/local/opt/openjdk@11` or `/opt/homebrew/opt/openjdk@11` |
+| Maven | 3.9.11+ | Managed by Homebrew |
+| Docker | Latest | `/Applications/Docker.app` |
+| Homebrew | 4.6+ | `/usr/local` or `/opt/homebrew` |
+
+---
+
+## Essential Commands
+
+### Check Versions
+```bash
+java -version          # Should show 11.x
+mvn -version           # Should show Java 11
+docker --version       # Any version
+```
+
+### Environment Variables
+```bash
+echo $JAVA_HOME        # Should point to Java 11
+echo $PATH             # Should include Java 11 bin
+```
+
+### Reload Configuration
+```bash
+source ~/.zshrc
+```
+
+---
+
+## Maven Commands
+
+```bash
+# Quick validation
+mvn validate
+
+# Compile only
+mvn compile
+
+# Build without tests (fast)
+mvn clean package -DskipTests
+
+# Full build with tests
+mvn clean package
+
+# Run tests only
+mvn test
+
+# Integration tests
+mvn verify
+
+# Clean build artifacts
+mvn clean
+
+# Code style check
+mvn spotless:check
+
+# Fix code style
+mvn spotless:apply
+```
+
+---
+
+## Docker Commands
+
+```bash
+# Check Docker status
+docker info
+
+# Start Docker Desktop
+open -a Docker
+
+# Test Docker
+docker run hello-world
+
+# List running containers
+docker ps
+
+# List all containers
+docker ps -a
+```
+
+---
+
+## Troubleshooting Quick Fixes
+
+### Maven using wrong Java version
+```bash
+export JAVA_HOME="/usr/local/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"
+# Or for Apple Silicon:
+export JAVA_HOME="/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"
+```
+
+### Reload shell configuration
+```bash
+source ~/.zshrc
+# or restart terminal
+```
+
+### Docker not running
+```bash
+open -a Docker
+# Wait 30 seconds, then try again
+```
+
+### Re-run setup script
+```bash
+./setup-macos.sh
+# It's idempotent - safe to run anytime
+```
+
+---
+
+## Project Structure
+
+```
+incubator-xtable/
+├── xtable-api/              # API definitions
+├── xtable-core/             # Core functionality
+├── xtable-hudi-support/     # Hudi integration
+├── xtable-utilities/        # CLI utilities
+├── xtable-service/          # REST service
+└── pom.xml                  # Maven parent POM
+```
+
+---
+
+## Common Build Issues
+
+### Build fails with Java version error
+**Solution**: Ensure `mvn -version` shows Java 11
+
+### Dependencies download slowly
+**Solution**: First build downloads ~1GB. Subsequent builds are faster.
+
+### Tests failing
+**Solution**: Skip tests initially: `mvn clean package -DskipTests`
+
+### Style check failures
+**Solution**: Run `mvn spotless:apply` before committing
+
+---
+
+## Important Paths (Intel Mac)
+
+```
+Java 11:      /usr/local/opt/openjdk@11/
+Maven:        /usr/local/Cellar/maven/
+Docker:       /Applications/Docker.app
+Homebrew:     /usr/local/
+Shell config: ~/.zshrc
+```
+
+## Important Paths (Apple Silicon)
+
+```
+Java 11:      /opt/homebrew/opt/openjdk@11/
+Maven:        /opt/homebrew/Cellar/maven/
+Docker:       /Applications/Docker.app
+Homebrew:     /opt/homebrew/
+Shell config: ~/.zshrc
+```
+
+---
+
+## Shell Configuration
+
+Your `~/.zshrc` should contain:
+
+```bash
+# Homebrew
+eval "$(/usr/local/bin/brew shellenv)"  # Intel
+# or
+eval "$(/opt/homebrew/bin/brew shellenv)"  # Apple Silicon
+
+# Java 11
+export PATH="/usr/local/opt/openjdk@11/bin:$PATH"  # Intel
+# or
+export PATH="/opt/homebrew/opt/openjdk@11/bin:$PATH"  # Apple Silicon
+
+export JAVA_HOME="/usr/local/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"  # Intel
+# or
+export JAVA_HOME="/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"  # Apple Silicon
+```
+
+---
+
+## Getting Help
+
+1. **Setup issues**: See `MACOS_SETUP_GUIDE.md`
+2. **Script help**: See `SETUP_README.md`
+3. **Project help**: See main `README.md`
+4. **GitHub Issues**: https://github.com/apache/incubator-xtable/issues
+
+---
+
+## Quick Health Check
+
+Run these to verify everything is working:
+
+```bash
+# All should pass
+java -version | grep "11\."
+mvn -version | grep "Java version: 11"
+docker info > /dev/null 2>&1 && echo "Docker OK"
+
+# Or run the setup script again
+./setup-macos.sh
+```
+
+---
+
+## Uninstall
+
+```bash
+brew uninstall openjdk@11 maven
+brew uninstall --cask docker
+# Edit ~/.zshrc to remove added lines
+```
+
+---
+
+**Print this page for quick reference during development!**
+
+---
+
+Last updated: October 1, 2025

--- a/macos-setup/README.md
+++ b/macos-setup/README.md
@@ -1,0 +1,145 @@
+# macOS Setup for Apache XTable™ Development
+
+This directory contains automated setup tools and comprehensive documentation for setting up Apache XTable™ development environment on macOS.
+
+## 🚀 Quick Start
+
+**One command to set up everything:**
+
+```bash
+./setup-macos.sh
+```
+
+After the script completes, reload your shell:
+```bash
+source ~/.zshrc
+```
+
+That's it! You're ready to develop.
+
+---
+
+## 📁 What's in This Directory
+
+| File | Purpose |
+|------|---------|
+| **[`setup-macos.sh`](./setup-macos.sh)** | ⭐ Automated setup script - **START HERE** |
+| **[`MACOS_SETUP_GUIDE.md`](./MACOS_SETUP_GUIDE.md)** | Detailed manual setup with command explanations |
+| **[`QUICK_REFERENCE.md`](./QUICK_REFERENCE.md)** | Command cheat sheet for daily development |
+| `setup-macos.log` | Installation summary (auto-generated after setup) |
+
+---
+
+## 🎯 Choose Your Path
+
+### Path 1: Automated Setup (Recommended)
+```bash
+./setup-macos.sh
+```
+Everything is installed and configured automatically. Takes 5-10 minutes.
+
+### Path 2: Manual Setup
+Follow step-by-step instructions in [`MACOS_SETUP_GUIDE.md`](./MACOS_SETUP_GUIDE.md)
+
+### Path 3: Quick Command Lookup
+Check [`QUICK_REFERENCE.md`](./QUICK_REFERENCE.md) for daily dev commands
+
+---
+
+## ✅ What Gets Installed
+
+| Component | Version | Purpose |
+|-----------|---------|---------|
+| Homebrew | Latest | Package manager for macOS |
+| OpenJDK | 11 | Java Development Kit (required) |
+| Maven | 3.9+ | Build automation tool |
+| Docker Desktop | Latest | Container platform |
+
+---
+
+## 🔄 Idempotency & Safety
+
+The setup script is **idempotent** - safe to run multiple times:
+
+- ✅ Detects existing installations
+- ✅ Skips already-installed components  
+- ✅ Only installs what's missing
+- ✅ Safe to re-run if something fails
+
+**Example:** If you already have Homebrew and Java, the script will only install Maven and Docker.
+
+---
+
+## 🖥️ Architecture Support
+
+Works on both Intel and Apple Silicon Macs:
+- **Intel Macs** (x86_64) → Homebrew in `/usr/local`
+- **Apple Silicon** (M1/M2/M3 - arm64) → Homebrew in `/opt/homebrew`
+
+The script auto-detects your Mac type and adjusts paths accordingly.
+
+---
+
+## 📋 After Setup
+
+### Verify Installation
+```bash
+java -version          # Should show 11.x
+mvn -version           # Should show Java 11
+docker --version       # Should show Docker version
+```
+
+### Build the Project
+```bash
+cd ..                  # Go back to project root
+mvn validate           # Validate project
+mvn clean package -DskipTests  # Build without tests
+```
+
+---
+
+## 🆘 Troubleshooting
+
+**Script fails with "Permission denied"**
+```bash
+chmod +x setup-macos.sh
+```
+
+**Homebrew installation requires password**  
+This is normal - Homebrew needs admin access to create directories.
+
+**Maven not using Java 11**  
+Reload your shell configuration:
+```bash
+source ~/.zshrc
+mvn -version  # Should now show Java 11
+```
+
+**Docker not starting**  
+Docker Desktop can take 30-60 seconds to start. Start it manually:
+```bash
+open -a Docker
+```
+
+**"Command not found" after installation**  
+Reload your shell:
+```bash
+source ~/.zshrc
+```
+
+**Re-run the setup** (it's safe!):
+```bash
+./setup-macos.sh
+```
+
+**Check installation log**:
+```bash
+cat setup-macos.log
+```
+
+For more troubleshooting, see [`QUICK_REFERENCE.md`](./QUICK_REFERENCE.md) or [`MACOS_SETUP_GUIDE.md`](./MACOS_SETUP_GUIDE.md).
+
+---
+
+**Last Updated**: October 1, 2025  
+**Tested On**: macOS 15.7 (Sequoia) - Intel & Apple Silicon

--- a/macos-setup/setup-macos.sh
+++ b/macos-setup/setup-macos.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env zsh
+#
+# Apache XTable™ Development Environment Setup Script for macOS
+# 
+# This script automates the installation and configuration of all required
+# tools for developing Apache XTable™ on macOS. All steps are idempotent,
+# meaning you can safely run this script multiple times.
+#
+# Usage: 
+#   chmod +x setup-macos.sh
+#   ./setup-macos.sh
+#
+# Requirements: macOS with zsh (default shell on macOS Catalina and later)
+#
+
+set -e  # Exit on error
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_info() {
+    echo "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo "${RED}[ERROR]${NC} $1"
+}
+
+print_section() {
+    echo ""
+    echo "${BLUE}========================================${NC}"
+    echo "${BLUE}$1${NC}"
+    echo "${BLUE}========================================${NC}"
+}
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Detect architecture for proper paths
+if [[ $(uname -m) == 'arm64' ]]; then
+    BREW_PREFIX="/opt/homebrew"
+    print_info "Detected Apple Silicon (M1/M2/M3) Mac"
+else
+    BREW_PREFIX="/usr/local"
+    print_info "Detected Intel Mac"
+fi
+
+# Detect shell configuration file
+if [ -f "$HOME/.zshrc" ]; then
+    SHELL_CONFIG="$HOME/.zshrc"
+elif [ -f "$HOME/.zprofile" ]; then
+    SHELL_CONFIG="$HOME/.zprofile"
+else
+    SHELL_CONFIG="$HOME/.zshrc"
+    touch "$SHELL_CONFIG"
+fi
+
+print_info "Using shell configuration file: $SHELL_CONFIG"
+
+# ============================================
+# 1. Install Homebrew
+# ============================================
+print_section "Step 1: Installing Homebrew"
+
+if command_exists brew; then
+    print_success "Homebrew is already installed"
+    brew --version
+else
+    print_info "Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    
+    # Add Homebrew to PATH for current session
+    if [[ -f "${BREW_PREFIX}/bin/brew" ]]; then
+        eval "$("${BREW_PREFIX}/bin/brew" shellenv)"
+        print_success "Homebrew installed successfully"
+    else
+        print_error "Homebrew installation failed"
+        exit 1
+    fi
+fi
+
+# Ensure Homebrew is in PATH for current session
+if ! command_exists brew; then
+    if [[ -f "${BREW_PREFIX}/bin/brew" ]]; then
+        eval "$("${BREW_PREFIX}/bin/brew" shellenv)"
+    fi
+fi
+
+# Add Homebrew to shell config if not already present
+if ! grep -q "brew shellenv" "$SHELL_CONFIG"; then
+    print_info "Adding Homebrew to $SHELL_CONFIG"
+    echo "" >> "$SHELL_CONFIG"
+    echo '# Homebrew' >> "$SHELL_CONFIG"
+    echo "eval \"\$(${BREW_PREFIX}/bin/brew shellenv)\"" >> "$SHELL_CONFIG"
+fi
+
+# ============================================
+# 2. Install Java 11
+# ============================================
+print_section "Step 2: Installing OpenJDK 11"
+
+if brew list openjdk@11 &>/dev/null; then
+    print_success "OpenJDK 11 is already installed"
+    "${BREW_PREFIX}/opt/openjdk@11/bin/java" -version
+else
+    print_info "Installing OpenJDK 11..."
+    brew install openjdk@11
+    print_success "OpenJDK 11 installed successfully"
+fi
+
+# Add Java 11 to PATH in shell config if not already present
+JAVA_PATH="${BREW_PREFIX}/opt/openjdk@11/bin"
+if ! grep -q "openjdk@11/bin" "$SHELL_CONFIG"; then
+    print_info "Adding Java 11 to PATH in $SHELL_CONFIG"
+    echo "" >> "$SHELL_CONFIG"
+    echo '# Java 11' >> "$SHELL_CONFIG"
+    echo "export PATH=\"${JAVA_PATH}:\$PATH\"" >> "$SHELL_CONFIG"
+fi
+
+# Add Java 11 to PATH for current session
+if [[ ":$PATH:" != *":${JAVA_PATH}:"* ]]; then
+    export PATH="${JAVA_PATH}:$PATH"
+fi
+
+# Set JAVA_HOME in shell config if not already present
+JAVA_HOME_PATH="${BREW_PREFIX}/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home"
+if ! grep -q "JAVA_HOME.*openjdk@11" "$SHELL_CONFIG"; then
+    print_info "Setting JAVA_HOME in $SHELL_CONFIG"
+    echo "export JAVA_HOME=\"${JAVA_HOME_PATH}\"" >> "$SHELL_CONFIG"
+fi
+
+# Set JAVA_HOME for current session
+export JAVA_HOME="${JAVA_HOME_PATH}"
+
+# Create system symlink for Java 11 if not already present
+SYSTEM_JAVA_LINK="/Library/Java/JavaVirtualMachines/openjdk-11.jdk"
+if [ ! -L "$SYSTEM_JAVA_LINK" ] || [ ! -e "$SYSTEM_JAVA_LINK" ]; then
+    print_info "Creating system symlink for Java 11 (requires sudo)..."
+    sudo ln -sfn "${BREW_PREFIX}/opt/openjdk@11/libexec/openjdk.jdk" "$SYSTEM_JAVA_LINK"
+    print_success "System symlink created"
+else
+    print_success "System symlink already exists"
+fi
+
+# Verify Java 11 installation
+print_info "Verifying Java 11 installation..."
+if java -version 2>&1 | grep -q "11\."; then
+    print_success "Java 11 is properly configured"
+    java -version
+else
+    print_warning "Java 11 may not be the default version"
+    print_info "Current Java version:"
+    java -version
+fi
+
+# ============================================
+# 3. Install Maven
+# ============================================
+print_section "Step 3: Installing Apache Maven"
+
+if command_exists mvn; then
+    print_success "Maven is already installed"
+    mvn -version
+else
+    print_info "Installing Maven..."
+    brew install maven
+    print_success "Maven installed successfully"
+fi
+
+# Verify Maven is using Java 11
+print_info "Verifying Maven is using Java 11..."
+if mvn -version 2>&1 | grep -q "Java version: 11\."; then
+    print_success "Maven is configured to use Java 11"
+    mvn -version
+else
+    print_warning "Maven may not be using Java 11"
+    print_info "Current Maven configuration:"
+    mvn -version
+    print_info "You may need to restart your terminal or run: source $SHELL_CONFIG"
+fi
+
+# ============================================
+# 4. Install Docker Desktop
+# ============================================
+print_section "Step 4: Installing Docker Desktop"
+
+if [ -d "/Applications/Docker.app" ]; then
+    print_success "Docker Desktop is already installed"
+    if command_exists docker; then
+        docker --version
+    else
+        print_info "Docker Desktop installed but not running. Starting Docker..."
+        open -a Docker
+        print_info "Waiting for Docker to start (30 seconds)..."
+        sleep 30
+    fi
+else
+    print_info "Installing Docker Desktop..."
+    brew install --cask docker
+    print_success "Docker Desktop installed successfully"
+    
+    print_info "Starting Docker Desktop..."
+    open -a Docker
+    print_info "Waiting for Docker to start (30 seconds)..."
+    sleep 30
+fi
+
+# Wait for Docker daemon to be ready
+print_info "Checking Docker daemon status..."
+DOCKER_WAIT_TIME=0
+MAX_WAIT=60
+while ! docker info >/dev/null 2>&1; do
+    if [ $DOCKER_WAIT_TIME -ge $MAX_WAIT ]; then
+        print_warning "Docker daemon did not start within ${MAX_WAIT} seconds"
+        print_info "Please start Docker Desktop manually and run this script again"
+        break
+    fi
+    sleep 5
+    DOCKER_WAIT_TIME=$((DOCKER_WAIT_TIME + 5))
+done
+
+if docker info >/dev/null 2>&1; then
+    print_success "Docker is running"
+    docker --version
+fi
+
+# ============================================
+# 5. Verify Installation
+# ============================================
+print_section "Step 5: Verification"
+
+print_info "Verifying all components..."
+echo ""
+
+# Check Homebrew
+if command_exists brew; then
+    echo "${GREEN}✓${NC} Homebrew: $(brew --version | head -1)"
+else
+    echo "${RED}✗${NC} Homebrew: Not found"
+fi
+
+# Check Java
+if command_exists java; then
+    JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2)
+    if [[ $JAVA_VERSION == 11.* ]]; then
+        echo "${GREEN}✓${NC} Java: OpenJDK $JAVA_VERSION"
+    else
+        echo "${YELLOW}⚠${NC} Java: Version $JAVA_VERSION (expected 11.x)"
+    fi
+else
+    echo "${RED}✗${NC} Java: Not found"
+fi
+
+# Check JAVA_HOME
+if [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ]; then
+    echo "${GREEN}✓${NC} JAVA_HOME: $JAVA_HOME"
+else
+    echo "${RED}✗${NC} JAVA_HOME: Not set or invalid"
+fi
+
+# Check Maven
+if command_exists mvn; then
+    MVN_VERSION=$(mvn -version | head -1 | awk '{print $3}')
+    MVN_JAVA=$(mvn -version | grep "Java version" | awk '{print $3}')
+    if [[ $MVN_JAVA == 11.* ]]; then
+        echo "${GREEN}✓${NC} Maven: $MVN_VERSION (using Java $MVN_JAVA)"
+    else
+        echo "${YELLOW}⚠${NC} Maven: $MVN_VERSION (using Java $MVN_JAVA, expected 11.x)"
+    fi
+else
+    echo "${RED}✗${NC} Maven: Not found"
+fi
+
+# Check Docker
+if command_exists docker && docker info >/dev/null 2>&1; then
+    DOCKER_VERSION=$(docker --version | awk '{print $3}' | tr -d ',')
+    echo "${GREEN}✓${NC} Docker: $DOCKER_VERSION (running)"
+elif command_exists docker; then
+    echo "${YELLOW}⚠${NC} Docker: Installed but not running"
+else
+    echo "${RED}✗${NC} Docker: Not found"
+fi
+
+# ============================================
+# 6. Test Docker (Optional)
+# ============================================
+print_section "Step 6: Testing Docker (Optional)"
+
+if docker info >/dev/null 2>&1; then
+    print_info "Running Docker hello-world test..."
+    if docker run --rm hello-world >/dev/null 2>&1; then
+        print_success "Docker test passed"
+    else
+        print_warning "Docker test failed, but Docker is installed"
+    fi
+else
+    print_warning "Skipping Docker test (Docker not running)"
+fi
+
+# ============================================
+# Final Instructions
+# ============================================
+print_section "Setup Complete!"
+
+echo ""
+echo "${GREEN}All required components have been installed!${NC}"
+echo ""
+echo "${YELLOW}Important:${NC} To ensure all environment variables are loaded, please run:"
+echo "  ${BLUE}source $SHELL_CONFIG${NC}"
+echo ""
+echo "Or restart your terminal."
+echo ""
+echo "${YELLOW}Next Steps:${NC}"
+echo "  1. Restart your terminal or run: source $SHELL_CONFIG"
+echo "  2. Navigate to the Apache XTable™ project directory"
+echo "  3. Run: ${BLUE}mvn validate${NC} to verify project setup"
+echo "  4. Run: ${BLUE}mvn clean package -DskipTests${NC} to build the project"
+echo ""
+echo "For detailed information, see: ${BLUE}MACOS_SETUP_GUIDE.md${NC}"
+echo ""
+
+# Write a summary to a log file
+LOG_FILE="setup-macos.log"
+{
+    echo "Apache XTable™ Setup Log"
+    echo "Date: $(date)"
+    echo "macOS Version: $(sw_vers -productVersion)"
+    echo "Architecture: $(uname -m)"
+    echo ""
+    echo "Installed Components:"
+    command_exists brew && echo "- Homebrew: $(brew --version | head -1)"
+    command_exists java && echo "- Java: $(java -version 2>&1 | head -1)"
+    [ -n "$JAVA_HOME" ] && echo "- JAVA_HOME: $JAVA_HOME"
+    command_exists mvn && echo "- Maven: $(mvn -version | head -1)"
+    command_exists docker && echo "- Docker: $(docker --version)"
+    echo ""
+    echo "Shell Configuration: $SHELL_CONFIG"
+} > "$LOG_FILE"
+
+print_success "Setup log written to: $LOG_FILE"


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

*(For example: This pull request implements the sync for delta format.)*
This PR adds a basic auto-setup script for mac os users. Additionally, it adds a setup guide, and a quick reference guide of useful commands, and provides explaination to some of the steps documented.

## Brief change log

- Adds a new setup-macos.sh file that automates setting up a development environment on mac os for XTable devs.
- Adds MACOS_SETUP_GUIDE.md that explains each command used for setup. Can be used as a DIY guide for step-by-step setup.
- Adds QUICK_REFERENCE.md for quick reference of useful commands
- Adds a relevant README.md
- Updated root README.md to reference to these new setup guides. 

## Verify this pull request

*(Please pick either of the following options)*

[x] This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

[ ] This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

[ ] This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end.*
- *Added TestConversionController to verify the change.*
- *Manually verified the change by running a job locally.*
