### PR TITLE
Handle empty Iceberg table source in conversion

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/iceberg/IcebergConversionSource.java
@@ -109,7 +109,7 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
   public InternalTable getTable(Snapshot snapshot) {
     Table iceTable = getSourceTable();
     Schema iceSchema =
-            (snapshot != null) ? iceTable.schemas().get(snapshot.schemaId()) : iceTable.schema();
+        (snapshot != null) ? iceTable.schemas().get(snapshot.schemaId()) : iceTable.schema();
     TableOperations iceOps = ((BaseTable) iceTable).operations();
     IcebergSchemaExtractor schemaExtractor = IcebergSchemaExtractor.getInstance();
     InternalSchema irSchema = schemaExtractor.fromIceberg(iceSchema);
@@ -126,10 +126,10 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
             : DataLayoutStrategy.FLAT;
 
     Instant latestCommitTime =
-            (snapshot != null)
-                    ? Instant.ofEpochMilli(snapshot.timestampMillis())
-                    : Instant.ofEpochMilli(
-                    ((BaseTable) iceTable).operations().current().lastUpdatedMillis());
+        (snapshot != null)
+            ? Instant.ofEpochMilli(snapshot.timestampMillis())
+            : Instant.ofEpochMilli(
+                ((BaseTable) iceTable).operations().current().lastUpdatedMillis());
 
     return InternalTable.builder()
         .tableFormat(TableFormat.ICEBERG)
@@ -160,11 +160,11 @@ public class IcebergConversionSource implements ConversionSource<Snapshot> {
       // Handle empty table case - return snapshot with schema but no data files
       InternalTable irTable = getTable(null);
       return InternalSnapshot.builder()
-              .version("0")
-              .table(irTable)
-              .partitionedDataFiles(Collections.emptyList())
-              .sourceIdentifier("0")
-              .build();
+          .version("0")
+          .table(irTable)
+          .partitionedDataFiles(Collections.emptyList())
+          .sourceIdentifier("0")
+          .build();
     }
 
     InternalTable irTable = getTable(currentSnapshot);

--- a/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/iceberg/TestIcebergConversionSource.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -228,7 +227,8 @@ class TestIcebergConversionSource {
         ((BaseTable) emptyTable).operations().current().lastUpdatedMillis(),
         internalTable.getLatestCommitTime().toEpochMilli());
 
-    assertEquals(emptyTable.schema().columns().size(), internalTable.getReadSchema().getFields().size());
+    assertEquals(
+        emptyTable.schema().columns().size(), internalTable.getReadSchema().getFields().size());
 
     verify(spyPartitionConverter, never()).toXTable(any(), any(), any());
     verify(spyDataFileExtractor, never()).fromIceberg(any(), any(), any());


### PR DESCRIPTION
Addresses #757 
This PR introduce null-checks and fallback logic throughout the conversion in the IcebergConversionSource class to handle empty tables gracefully without data.
## Brief change log
IcebergConversionSource.java: Added a conditional for computing the latest commit time when the snapshot is null.
IcebergConversionSource.java: Inserted logic to return a default InternalSnapshot (version "0" with no data files) if the current snapshot is missing.
IcebergConversionSource.java: Updated the getTable method to use a fallback schema when provided snapshot is null.

## Verify this pull request

- Added UTs for this change in TestIcebergConversionSource