### PR TITLE
Delta source: extract nested field's stats

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -124,7 +124,7 @@ public class DeltaConversionSource implements ConversionSource<Long> {
                 snapshotAtVersion,
                 fileFormat,
                 tableAtVersion.getPartitioningFields(),
-                tableAtVersion.getReadSchema().getFields(),
+                tableAtVersion.getReadSchema().getAllFields(),
                 true,
                 DeltaPartitionExtractor.getInstance(),
                 DeltaStatsExtractor.getInstance());

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaDataFileExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaDataFileExtractor.java
@@ -64,7 +64,7 @@ public class DeltaDataFileExtractor {
         Snapshot snapshot, InternalSchema schema, boolean includeColumnStats) {
       this.fileFormat =
           actionsConverter.convertToFileFormat(snapshot.metadata().format().provider());
-      this.fields = schema.getFields();
+      this.fields = schema.getAllFields();
       this.partitionFields =
           partitionExtractor.convertFromDeltaPartitionFormat(
               schema, snapshot.metadata().partitionSchema());

--- a/xtable-core/src/test/java/org/apache/xtable/testutil/ColumnStatMapUtil.java
+++ b/xtable-core/src/test/java/org/apache/xtable/testutil/ColumnStatMapUtil.java
@@ -200,6 +200,24 @@ public class ColumnStatMapUtil {
           .schema(InternalSchema.builder().name("double").dataType(InternalType.DOUBLE).build())
           .build();
 
+  private static final InternalField NESTED_STRING_FIELD =
+      InternalField.builder()
+          .name("nested_string_field")
+          .parentPath("nested_struct_field_primitive")
+          .schema(InternalSchema.builder().name("a_string").dataType(InternalType.STRING).build())
+          .build();
+
+  private static final InternalField NESTED_STRUCT_FIELD_PRIMITIVE =
+      InternalField.builder()
+          .name("nested_struct_field_primitive")
+          .schema(
+              InternalSchema.builder()
+                  .name("nested_struct_field_primitive")
+                  .dataType(InternalType.RECORD)
+                  .fields(Arrays.asList(NESTED_STRING_FIELD))
+                  .build())
+          .build();
+
   public static InternalSchema getSchema() {
     return InternalSchema.builder()
         .name("record")
@@ -216,6 +234,7 @@ public class ColumnStatMapUtil {
                 ARRAY_LONG_FIELD,
                 MAP_STRING_LONG_FIELD,
                 NESTED_STRUCT_FIELD,
+                NESTED_STRUCT_FIELD_PRIMITIVE,
                 DECIMAL_FIELD,
                 FLOAT_FIELD,
                 DOUBLE_FIELD))
@@ -343,7 +362,21 @@ public class ColumnStatMapUtil {
             .numValues(50)
             .totalSize(123)
             .build();
+    ColumnStat nestedStringColumnStats =
+        ColumnStat.builder()
+            .field(NESTED_STRING_FIELD)
+            .numNulls(1)
+            .range(Range.vector("alice", "zion"))
+            .numValues(50)
+            .totalSize(500)
+            .build();
 
+    ColumnStat ignoredColumnStatsNestedStructFieldPrimitive =
+        ColumnStat.builder()
+            .field(NESTED_STRUCT_FIELD_PRIMITIVE)
+            .numNulls(0)
+            .range(Range.scalar("IGNORED"))
+            .build();
     ColumnStat ignoredColumnStatsArrayLongField =
         ColumnStat.builder()
             .field(ARRAY_LONG_FIELD)
@@ -385,6 +418,8 @@ public class ColumnStatMapUtil {
         decimalColumnStats,
         floatColumnStats,
         doubleColumnStats,
+        nestedStringColumnStats,
+        ignoredColumnStatsNestedStructFieldPrimitive,
         ignoredColumnStatsArrayLongField,
         ignoredColumnStatsMapStringField,
         ignoredColumnStatsNestedStructField,


### PR DESCRIPTION
##  Important Read
Aims to fix https://github.com/apache/incubator-xtable/issues/771

## What is the purpose of the pull request

While converting from Delta table, the nested field's stats got filtered out due the wrong list of the fields used.
This Pr aims to fix it.

## Brief change log

The pr make sure the nested field's stats is extracted.
## Verify this pull request

This pull request is already covered by existing tests, such as https://github.com/emilie-wang/incubator-xtable/blob/27f6a162082a04c21755ff49184c34a975caef00/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaStatsExtractor.java#L119
The test doesn't need change because it uses `List<InternalField> fields = schema.getAllFields();` instead of `List<InternalField> fields = schema.getAllFields();`, so that no nested fields are filtered out.
-  Add a new nested field into the existing test.


