### PR TITLE
feat: built-in databricks unity catalog sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>xtable-core</module>
         <module>xtable-utilities</module>
         <module>xtable-aws</module>
+        <module>xtable-databricks</module>
         <module>xtable-hive-metastore</module>
         <module>xtable-service</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <hudi.version>0.14.0</hudi.version>
         <aws.version>2.29.40</aws.version>
         <hive.version>2.3.9</hive.version>
+        <databricks.sdk.version>0.85.0</databricks.sdk.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
@@ -454,6 +455,13 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>glue</artifactId>
                 <version>${aws.version}</version>
+            </dependency>
+
+            <!-- Databricks -->
+            <dependency>
+                <groupId>com.databricks</groupId>
+                <artifactId>databricks-sdk-java</artifactId>
+                <version>${databricks.sdk.version}</version>
             </dependency>
 
             <!-- Protobuf -->

--- a/website/docs/unity-catalog.md
+++ b/website/docs/unity-catalog.md
@@ -4,29 +4,36 @@ title: "Unity Catalog"
 ---
 
 # Syncing to Unity Catalog
-This document walks through the steps to register an Apache XTable™ (Incubating) synced Delta table in Unity Catalog on Databricks and open-source Unity Catalog.
+
+This page covers **Databricks Unity Catalog** and **open-source Unity Catalog**. They are different systems:
+Databricks Unity Catalog is a managed service in Databricks, while open-source Unity Catalog is a standalone server.
+Both support **Delta external tables only** as Unity Catalog targets; Iceberg/Hudi are not supported as UC targets.
 
 ## Pre-requisites (for Databricks Unity Catalog)
+
 1. Source table(s) (Hudi/Iceberg) already written to external storage locations like S3/GCS/ADLS.
    If you don't have a source table written in S3/GCS/ADLS,
    you can follow the steps in [this](/docs/hms) tutorial to set it up.
 2. Setup connection to external storage locations from Databricks.
-   * Follow the steps outlined [here](https://docs.databricks.com/en/storage/amazon-s3.html) for Amazon S3
-   * Follow the steps outlined [here](https://docs.databricks.com/en/storage/gcs.html) for Google Cloud Storage
-   * Follow the steps outlined [here](https://docs.databricks.com/en/storage/azure-storage.html) for Azure Data Lake Storage Gen2 and Blob Storage.
+   - Follow the steps outlined [here](https://docs.databricks.com/en/storage/amazon-s3.html) for Amazon S3
+   - Follow the steps outlined [here](https://docs.databricks.com/en/storage/gcs.html) for Google Cloud Storage
+   - Follow the steps outlined [here](https://docs.databricks.com/en/storage/azure-storage.html) for Azure Data Lake Storage Gen2 and Blob Storage.
 3. Create a Unity Catalog metastore in Databricks as outlined [here](https://docs.gcp.databricks.com/data-governance/unity-catalog/create-metastore.html#create-a-unity-catalog-metastore).
 4. Create an external location in Databricks as outlined [here](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-location.html).
 5. Clone the Apache XTable™ (Incubating) [repository](https://github.com/apache/incubator-xtable) and create the
    `xtable-utilities_2.12-0.2.0-SNAPSHOT-bundled.jar` by following the steps on the [Installation page](/docs/setup)
 
 ## Pre-requisites (for open-source Unity Catalog)
+
 1. Source table(s) (Hudi/Iceberg) already written to external storage locations like S3/GCS/ADLS or local.
-   In this guide, we will use the local file system. 
+   In this guide, we will use the local file system.
    But for S3/GCS/ADLS, you must add additional properties related to the respective cloud object storage system you're working with as mentioned [here](https://github.com/unitycatalog/unitycatalog/blob/main/docs/server.md)
 2. Clone the Unity Catalog repository from [here](https://github.com/unitycatalog/unitycatalog) and build the project by following the steps outlined [here](https://github.com/unitycatalog/unitycatalog?tab=readme-ov-file#prerequisites)
 
 ## Steps
+
 ### Running sync
+
 Create `my_config.yaml` in the cloned Apache XTable™ (Incubating) directory.
 
 ```yaml md title="yaml"
@@ -34,16 +41,17 @@ sourceFormat: HUDI|ICEBERG # choose only one
 targetFormats:
   - DELTA
 datasets:
-  -
-    tableBasePath: s3://path/to/source/data
+  - tableBasePath: s3://path/to/source/data
     tableName: table_name
     partitionSpec: partitionpath:VALUE # you only need to specify partitionSpec for HUDI sourceFormat
 ```
+
 :::note Note:
+
 1. Replace `s3://path/to/source/data` to `gs://path/to/source/data` if you have your source table in GCS
    and `abfss://<container-name>@<storage-account-name>.dfs.core.windows.net/<path-to-data>` if you have your source table in ADLS.
-2. And replace with appropriate values for `sourceFormat`, and `tableName` fields. 
-:::
+2. And replace with appropriate values for `sourceFormat`, and `tableName` fields.
+   :::
 
 From your terminal under the cloned Apache XTable™ (Incubating) directory, run the sync process using the below command.
 
@@ -51,12 +59,13 @@ From your terminal under the cloned Apache XTable™ (Incubating) directory, run
 java -jar xtable-utilities/target/xtable-utilities_2.12-0.2.0-SNAPSHOT-bundled.jar --datasetConfig my_config.yaml
 ```
 
-:::tip Note: 
-At this point, if you check your bucket path, you will be able to see `_delta_log` directory with 
+:::tip Note:
+At this point, if you check your bucket path, you will be able to see `_delta_log` directory with
 00000000000000000000.json which contains the logs that helps query engines to interpret the source table as a Delta table.
 :::
 
-### Register the target table in Databricks Unity Catalog
+### Databricks Unity Catalog: manual registration (SQL)
+
 (After making sure you complete the pre-requisites mentioned for Databricks Unity Catalog above) In your Databricks workspace, under SQL editor, run the following queries.
 
 ```sql md title="SQL"
@@ -68,12 +77,14 @@ CREATE TABLE xtable.synced_delta_schema.<table_name>
 USING DELTA
 LOCATION 's3://path/to/source/data';
 ```
+
 :::note Note:
 Replace `s3://path/to/source/data` to `gs://path/to/source/data` if you have your source table in GCS
 and `abfss://<container-name>@<storage-account-name>.dfs.core.windows.net/<path-to-data>` if you have your source table in ADLS.
 :::
 
-### Validating the results
+### Validating the results (Databricks)
+
 You can now see the created delta table in **Unity Catalog** under **Catalog** as `<table_name>` under
 `synced_delta_schema` and also query the table in the SQL editor:
 
@@ -82,6 +93,7 @@ SELECT * FROM xtable.synced_delta_schema.<table_name>;
 ```
 
 ### Register the target table in open-source Unity Catalog using the CLI
+
 (After making sure you complete the pre-requisites mentioned for open-source Unity Catalog above) In your terminal start the UC server by following the steps outlined [here](https://github.com/unitycatalog/unitycatalog/tree/main?tab=readme-ov-file#quickstart---hello-uc)
 
 In a different terminal, run the following commands to register the target table in Unity Catalog.
@@ -91,14 +103,108 @@ bin/uc table create --full_name unity.default.people --columns "id INT, name STR
 ```
 
 ### Validating the results
+
 You can now read the table registered in Unity Catalog using the below command.
 
 ```shell md title="shell"
 bin/uc table read --full_name unity.default.people
 ```
 
+### Databricks Unity Catalog: built-in catalog sync (XTable)
+
+XTable can also register the Delta table directly in Databricks Unity Catalog using the catalog
+sync configuration. This uses the Databricks Java SDK and issues DDL against a SQL Warehouse.
+
+```yaml md title="yaml"
+sourceCatalog:
+  catalogId: source
+  catalogType: STORAGE
+  catalogProperties: {}
+targetCatalogs:
+  - catalogId: uc
+    catalogType: DATABRICKS_UC
+    catalogProperties:
+      externalCatalog.uc.host: https://<workspace>
+      externalCatalog.uc.warehouseId: <sql-warehouse-id>
+      # OAuth M2M (recommended)
+      externalCatalog.uc.authType: oauth-m2m
+      externalCatalog.uc.clientId: <client-id>
+      externalCatalog.uc.clientSecret: <client-secret>
+datasets:
+  - sourceCatalogTableIdentifier:
+      tableIdentifier:
+        hierarchicalId: <db>.<table>
+        partitionSpec: partitionpath:VALUE
+      storageIdentifier:
+        tableFormat: HUDI
+        tableBasePath: s3://path/to/source/data
+        tableDataPath: s3://path/to/source/data
+        tableName: <table>
+        partitionSpec: partitionpath:VALUE
+        namespace: <db>
+    targetCatalogTableIdentifiers:
+      - catalogId: uc
+        tableFormat: DELTA
+        tableIdentifier:
+          hierarchicalId: <catalog>.<schema>.<table>
+```
+
+### Authentication (Databricks UC)
+
+**Supported now**
+
+- OAuth M2M via:
+  - `externalCatalog.uc.authType: oauth-m2m`
+  - `externalCatalog.uc.clientId`
+  - `externalCatalog.uc.clientSecret`
+
+**Not supported yet**
+
+- PAT/token-based auth is intentionally not wired in the current XTable UC integration.
+
+**Possible later**
+
+- PAT or other auth flows could be added by extending the UC config and SDK wiring,
+  but they are out of scope for now.
+
+### Implementation details (Databricks UC)
+
+- XTable uses the Databricks SQL Statement Execution API (`StatementExecutionAPI`) to run DDL
+  against a SQL Warehouse.
+- The built-in sync registers **external Delta tables** only:
+  - `CREATE TABLE IF NOT EXISTS <catalog>.<schema>.<table> USING DELTA LOCATION '<path>'`
+- Schema evolution currently uses **drop + recreate** of the UC table metadata (not data).
+  See the limitations section below.
+
+### Schema evolution limitations (Databricks UC)
+
+Unity Catalog does not provide a catalog-only schema evolution API for external tables.
+While `ALTER TABLE ...` can update the catalog, it also assumes control over the Delta
+transaction log. For external tables managed outside Databricks, this can be unsafe.
+
+To avoid mutating the Delta log, XTable currently:
+
+1. Detects any schema differences (new columns, dropped columns, type/comment changes).
+2. Drops the UC table metadata.
+3. Recreates the table at the same location.
+
+This approach **does not delete data** and typically preserves metadata such as statistics,
+usage, and lineage because Unity Catalog keeps that information even after a drop/recreate.
+However, it causes a short period (seconds) where the table is not accessible.
+Schema evolution is usually rare in production pipelines, so this trade-off is considered acceptable.
+
+### Databricks UC limitations and requirements
+
+- Unity Catalog enforces **unique external locations**. A location used by another
+  table/volume cannot be reused. This means you cannot register multiple external tables
+  (e.g., Iceberg/Delta via Glue federation and Databricks UC external) pointing to the same location.
+- Ensure your Unity Catalog storage credential has **write** access to the Delta
+  `_delta_log` directory at the table location.
+
 ## Conclusion
+
 In this guide we saw how to,
+
 1. sync a source table to create metadata for the desired target table formats using Apache XTable™ (Incubating)
 2. catalog the data in Delta format in Unity Catalog on Databricks, and also open-source Unity Catalog
 3. query the Delta table using Databricks SQL editor, and open-source Unity Catalog CLI.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -38,7 +38,7 @@ module.exports = {
                     items: [
                         'hms',
                         'glue-catalog',
-                        'unity-catalog',
+                        'databricks-unity-catalog',
                         'biglake-metastore',
                     ],
                 },

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -38,7 +38,7 @@ module.exports = {
                     items: [
                         'hms',
                         'glue-catalog',
-                        'databricks-unity-catalog',
+                        'unity-catalog',
                         'biglake-metastore',
                     ],
                 },

--- a/xtable-api/src/main/java/org/apache/xtable/model/storage/CatalogType.java
+++ b/xtable-api/src/main/java/org/apache/xtable/model/storage/CatalogType.java
@@ -27,4 +27,5 @@ public class CatalogType {
   public static final String STORAGE = "STORAGE";
   public static final String GLUE = "GLUE";
   public static final String HMS = "HMS";
+  public static final String DATABRICKS_UC = "DATABRICKS_UC";
 }

--- a/xtable-databricks/pom.xml
+++ b/xtable-databricks/pom.xml
@@ -40,5 +40,41 @@
             <artifactId>databricks-sdk-java</artifactId>
             <version>0.85.0</version>
         </dependency>
+
+        <!-- Hadoop dependencies -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Junit -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/xtable-databricks/pom.xml
+++ b/xtable-databricks/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.xtable</groupId>
+        <artifactId>xtable</artifactId>
+        <version>0.3.0-incubating</version>
+    </parent>
+
+    <artifactId>xtable-databricks</artifactId>
+    <name>XTable Databricks</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.xtable</groupId>
+            <artifactId>xtable-core_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>databricks-sdk-java</artifactId>
+            <version>0.85.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/xtable-databricks/pom.xml
+++ b/xtable-databricks/pom.xml
@@ -28,6 +28,10 @@
     <artifactId>xtable-databricks</artifactId>
     <name>XTable Databricks</name>
 
+    <properties>
+        <databricks.sdk.version>0.85.0</databricks.sdk.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.xtable</groupId>
@@ -38,7 +42,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-sdk-java</artifactId>
-            <version>0.85.0</version>
+            <version>${databricks.sdk.version}</version>
         </dependency>
 
         <!-- Hadoop dependencies -->

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogConfig.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.databricks;
+
+import java.util.Map;
+
+import lombok.Value;
+
+import org.apache.xtable.conversion.ExternalCatalogConfig;
+
+@Value
+public class DatabricksUnityCatalogConfig {
+  public static final String HOST = "externalCatalog.uc.host";
+  public static final String WAREHOUSE_ID = "externalCatalog.uc.warehouseId";
+  public static final String AUTH_TYPE = "externalCatalog.uc.authType";
+  public static final String CLIENT_ID = "externalCatalog.uc.clientId";
+  public static final String CLIENT_SECRET = "externalCatalog.uc.clientSecret";
+  public static final String TOKEN = "externalCatalog.uc.token";
+
+  String host;
+  String warehouseId;
+  String authType;
+  String clientId;
+  String clientSecret;
+  String token;
+
+  public static DatabricksUnityCatalogConfig from(ExternalCatalogConfig catalogConfig) {
+    Map<String, String> props = catalogConfig.getCatalogProperties();
+    return new DatabricksUnityCatalogConfig(
+        props.get(HOST),
+        props.get(WAREHOUSE_ID),
+        props.get(AUTH_TYPE),
+        props.get(CLIENT_ID),
+        props.get(CLIENT_SECRET),
+        props.get(TOKEN));
+  }
+}

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogConfig.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogConfig.java
@@ -31,14 +31,12 @@ public class DatabricksUnityCatalogConfig {
   public static final String AUTH_TYPE = "externalCatalog.uc.authType";
   public static final String CLIENT_ID = "externalCatalog.uc.clientId";
   public static final String CLIENT_SECRET = "externalCatalog.uc.clientSecret";
-  public static final String TOKEN = "externalCatalog.uc.token";
 
   String host;
   String warehouseId;
   String authType;
   String clientId;
   String clientSecret;
-  String token;
 
   public static DatabricksUnityCatalogConfig from(ExternalCatalogConfig catalogConfig) {
     Map<String, String> props = catalogConfig.getCatalogProperties();
@@ -47,7 +45,6 @@ public class DatabricksUnityCatalogConfig {
         props.get(WAREHOUSE_ID),
         props.get(AUTH_TYPE),
         props.get(CLIENT_ID),
-        props.get(CLIENT_SECRET),
-        props.get(TOKEN));
+        props.get(CLIENT_SECRET));
   }
 }

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -386,9 +386,7 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
     if (!StringUtils.isBlank(config.getAuthType())) {
       dbConfig.setAuthType(config.getAuthType());
     }
-    if (!StringUtils.isBlank(config.getToken())) {
-      dbConfig.setToken(config.getToken());
-    } else if (!StringUtils.isBlank(config.getClientId())
+    if (!StringUtils.isBlank(config.getClientId())
         && !StringUtils.isBlank(config.getClientSecret())) {
       dbConfig.setClientId(config.getClientId());
       dbConfig.setClientSecret(config.getClientSecret());

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -186,7 +186,9 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
   @Override
   public void refreshTable(
       InternalTable table, TableInfo catalogTable, CatalogTableIdentifier tableIdentifier) {
-    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+    log.warn(
+        "Databricks UC refreshTable is not implemented. Skipping refresh for {}",
+        tableIdentifier.getId());
   }
 
   @Override

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -226,8 +226,22 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
   @Override
   public void createOrReplaceTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
     ensureDeltaOnly();
+    String fullName = getFullName(tableIdentifier);
     dropTable(table, tableIdentifier);
-    createTable(table, tableIdentifier);
+    try {
+      createTable(table, tableIdentifier);
+    } catch (Exception e) {
+      log.error(
+          "Databricks UC createOrReplaceTable failed to recreate {} after drop. "
+              + "Table was dropped but not recreated.",
+          fullName,
+          e);
+      throw new CatalogSyncException(
+          "Databricks UC createOrReplaceTable failed after drop for "
+              + fullName
+              + ": table was dropped but not recreated",
+          e);
+    }
   }
 
   @Override

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -59,11 +59,12 @@ import org.apache.xtable.model.storage.TableFormat;
 import org.apache.xtable.spi.sync.CatalogSyncClient;
 
 /**
- * Databricks Unity Catalog implementation skeleton for CatalogSyncClient.
+ * Databricks Unity Catalog implementation of {@link CatalogSyncClient}.
  *
- * <p>This is a placeholder to wire Databricks UC as a catalog target via the SQL Statement
- * Execution API. Actual DDL execution and schema diffing should be implemented in a follow-up
- * change.
+ * <p>Supports external Delta table sync operations (create, drop, create-or-replace, get table and
+ * schema/database operations) using Databricks SDK APIs and SQL Statement Execution API. Schema
+ * refresh compares desired and existing schemas and triggers metadata sync when differences are
+ * detected.
  */
 @Log4j2
 public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<TableInfo> {

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.databricks;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.hadoop.conf.Configuration;
+
+import org.apache.xtable.conversion.ExternalCatalogConfig;
+import org.apache.xtable.exception.CatalogSyncException;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.catalog.CatalogTableIdentifier;
+import org.apache.xtable.model.storage.CatalogType;
+import org.apache.xtable.spi.sync.CatalogSyncClient;
+
+/**
+ * Databricks Unity Catalog implementation skeleton for CatalogSyncClient.
+ *
+ * <p>This is a placeholder to wire Databricks UC as a catalog target via the SQL Statement
+ * Execution API. Actual DDL execution and schema diffing should be implemented in a follow-up
+ * change.
+ */
+@Log4j2
+public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Object> {
+
+  private ExternalCatalogConfig catalogConfig;
+  private DatabricksUnityCatalogConfig databricksConfig;
+  private Configuration hadoopConf;
+  private String tableFormat;
+
+  // For loading the instance using ServiceLoader
+  public DatabricksUnityCatalogSyncClient() {}
+
+  public DatabricksUnityCatalogSyncClient(
+      ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration) {
+    init(catalogConfig, tableFormat, configuration);
+  }
+
+  @Override
+  public String getCatalogId() {
+    return catalogConfig.getCatalogId();
+  }
+
+  @Override
+  public String getCatalogType() {
+    return CatalogType.DATABRICKS_UC;
+  }
+
+  @Override
+  public String getStorageLocation(Object table) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public boolean hasDatabase(CatalogTableIdentifier tableIdentifier) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public void createDatabase(CatalogTableIdentifier tableIdentifier) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public Object getTable(CatalogTableIdentifier tableIdentifier) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public void createTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public void refreshTable(
+      InternalTable table, Object catalogTable, CatalogTableIdentifier tableIdentifier) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public void createOrReplaceTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public void dropTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
+    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+  }
+
+  @Override
+  public void init(
+      ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration) {
+    this.catalogConfig = catalogConfig;
+    this.tableFormat = tableFormat;
+    this.hadoopConf = configuration;
+    this.databricksConfig = DatabricksUnityCatalogConfig.from(catalogConfig);
+
+    if (databricksConfig.getHost() == null || databricksConfig.getWarehouseId() == null) {
+      throw new CatalogSyncException(
+          "Databricks UC catalog requires host and warehouseId in catalogProperties");
+    }
+    log.info(
+        "Initialized Databricks UC sync client for catalogId={} tableFormat={}",
+        catalogConfig.getCatalogId(),
+        tableFormat);
+  }
+}

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -191,7 +191,18 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
 
   @Override
   public void createOrReplaceTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
-    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+    ensureDeltaOnly();
+    String fullName = getFullName(tableIdentifier);
+    String location = table.getBasePath();
+    if (StringUtils.isBlank(location)) {
+      throw new CatalogSyncException("Storage location is required for external Delta tables");
+    }
+
+    String statement =
+        String.format(
+            "CREATE OR REPLACE TABLE %s USING DELTA LOCATION '%s'",
+            fullName, escapeSqlString(location));
+    executeStatement(statement);
   }
 
   @Override

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -208,7 +208,9 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
       return;
     }
     if (!schemasMatch(schema, catalogTable)) {
-      createOrReplaceTable(table, tableIdentifier);
+      String fullName = getFullName(tableIdentifier);
+      log.info("Databricks UC refresh table metadata (MSCK REPAIR TABLE): {}", fullName);
+      executeStatement(String.format("MSCK REPAIR TABLE %s SYNC METADATA", fullName));
     } else {
       log.info(
           "Databricks UC refreshTable: schema already up to date for {}", tableIdentifier.getId());

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -207,7 +207,12 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
 
   @Override
   public void dropTable(InternalTable table, CatalogTableIdentifier tableIdentifier) {
-    throw new UnsupportedOperationException("Databricks UC sync not implemented");
+    String fullName = getFullName(tableIdentifier);
+    try {
+      tablesApi.delete(fullName);
+    } catch (Exception e) {
+      throw new CatalogSyncException("Failed to drop table: " + fullName, e);
+    }
   }
 
   @Override

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -267,26 +267,28 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
       throw new CatalogSyncException(
           "Databricks UC catalog requires host and warehouseId in catalogProperties");
     }
-    if (this.statementExecution == null) {
+    if (shouldInitializeWorkspaceClient()) {
       this.workspaceClient = new WorkspaceClient(buildConfig(databricksConfig));
+    }
+    if (this.statementExecution == null) {
       this.statementExecution = workspaceClient.statementExecution();
     }
     if (this.tablesApi == null) {
-      if (this.workspaceClient == null) {
-        this.workspaceClient = new WorkspaceClient(buildConfig(databricksConfig));
-      }
       this.tablesApi = this.workspaceClient.tables();
     }
     if (this.schemasApi == null) {
-      if (this.workspaceClient == null) {
-        this.workspaceClient = new WorkspaceClient(buildConfig(databricksConfig));
-      }
       this.schemasApi = this.workspaceClient.schemas();
     }
     log.info(
         "Initialized Databricks UC sync client for catalogId={} tableFormat={}",
         catalogConfig.getCatalogId(),
         tableFormat);
+  }
+
+  private boolean shouldInitializeWorkspaceClient() {
+    boolean missingApis =
+        this.statementExecution == null || this.tablesApi == null || this.schemasApi == null;
+    return this.workspaceClient == null && missingApis;
   }
 
   private void ensureDeltaOnly() {

--- a/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/main/java/org/apache/xtable/databricks/DatabricksUnityCatalogSyncClient.java
@@ -72,7 +72,6 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
 
   private ExternalCatalogConfig catalogConfig;
   private DatabricksUnityCatalogConfig databricksConfig;
-  private Configuration hadoopConf;
   private String tableFormat;
   private WorkspaceClient workspaceClient;
   private StatementExecutionAPI statementExecution;
@@ -274,7 +273,6 @@ public class DatabricksUnityCatalogSyncClient implements CatalogSyncClient<Table
       ExternalCatalogConfig catalogConfig, String tableFormat, Configuration configuration) {
     this.catalogConfig = catalogConfig;
     this.tableFormat = tableFormat;
-    this.hadoopConf = configuration;
     this.databricksConfig = DatabricksUnityCatalogConfig.from(catalogConfig);
 
     if (databricksConfig.getHost() == null || databricksConfig.getWarehouseId() == null) {

--- a/xtable-databricks/src/main/resources/META-INF/services/org.apache.xtable.spi.sync.CatalogSyncClient
+++ b/xtable-databricks/src/main/resources/META-INF/services/org.apache.xtable.spi.sync.CatalogSyncClient
@@ -1,1 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 org.apache.xtable.databricks.DatabricksUnityCatalogSyncClient

--- a/xtable-databricks/src/main/resources/META-INF/services/org.apache.xtable.spi.sync.CatalogSyncClient
+++ b/xtable-databricks/src/main/resources/META-INF/services/org.apache.xtable.spi.sync.CatalogSyncClient
@@ -1,0 +1,1 @@
+org.apache.xtable.databricks.DatabricksUnityCatalogSyncClient

--- a/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
@@ -139,6 +139,34 @@ public class TestDatabricksUnityCatalogSyncClient {
   }
 
   @Test
+  void testCreateTableRejectsInvalidIdentifier() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
+    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
+    ExternalCatalogConfig config =
+        ExternalCatalogConfig.builder()
+            .catalogId("uc")
+            .catalogType(CatalogType.DATABRICKS_UC)
+            .catalogProperties(props)
+            .build();
+
+    DatabricksUnityCatalogSyncClient client =
+        new DatabricksUnityCatalogSyncClient(
+            config,
+            TableFormat.DELTA,
+            new Configuration(),
+            mockStatementExecution,
+            mockTablesApi,
+            mockSchemasApi);
+
+    InternalTable table = InternalTable.builder().basePath("s3://bucket/path").build();
+    ThreePartHierarchicalTableIdentifier tableIdentifier =
+        new ThreePartHierarchicalTableIdentifier("main", "default", "people;DROP_TABLE");
+
+    assertThrows(CatalogSyncException.class, () -> client.createTable(table, tableIdentifier));
+  }
+
+  @Test
   void testCreateOrReplaceTableDelta() {
     Map<String, String> props = new HashMap<>();
     props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
@@ -387,6 +415,33 @@ public class TestDatabricksUnityCatalogSyncClient {
         new ThreePartHierarchicalTableIdentifier("main", "default", "people");
     boolean exists = client.hasDatabase(tableIdentifier);
     assertEquals(false, exists);
+  }
+
+  @Test
+  void testHasDatabaseRejectsInvalidIdentifier() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
+    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
+    ExternalCatalogConfig config =
+        ExternalCatalogConfig.builder()
+            .catalogId("uc")
+            .catalogType(CatalogType.DATABRICKS_UC)
+            .catalogProperties(props)
+            .build();
+
+    DatabricksUnityCatalogSyncClient client =
+        new DatabricksUnityCatalogSyncClient(
+            config,
+            TableFormat.DELTA,
+            new Configuration(),
+            mockStatementExecution,
+            mockTablesApi,
+            mockSchemasApi);
+
+    ThreePartHierarchicalTableIdentifier tableIdentifier =
+        new ThreePartHierarchicalTableIdentifier("main", "default;DROP_SCHEMA", "people");
+
+    assertThrows(CatalogSyncException.class, () -> client.hasDatabase(tableIdentifier));
   }
 
   @Test

--- a/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
@@ -262,9 +262,8 @@ public class TestDatabricksUnityCatalogSyncClient {
     ArgumentCaptor<ExecuteStatementRequest> requestCaptor =
         ArgumentCaptor.forClass(ExecuteStatementRequest.class);
     verify(mockStatementExecution).executeStatement(requestCaptor.capture());
-    verify(mockTablesApi).delete("main.default.people");
     assertEquals(
-        "CREATE TABLE IF NOT EXISTS main.default.people USING DELTA LOCATION 's3://bucket/path'",
+        "MSCK REPAIR TABLE main.default.people SYNC METADATA",
         requestCaptor.getValue().getStatement());
   }
 

--- a/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.xtable.databricks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.databricks.sdk.service.sql.ExecuteStatementRequest;
+import com.databricks.sdk.service.sql.StatementExecutionAPI;
+import com.databricks.sdk.service.sql.StatementResponse;
+import com.databricks.sdk.service.sql.StatementState;
+import com.databricks.sdk.service.sql.StatementStatus;
+
+import org.apache.xtable.conversion.ExternalCatalogConfig;
+import org.apache.xtable.exception.CatalogSyncException;
+import org.apache.xtable.model.InternalTable;
+import org.apache.xtable.model.catalog.ThreePartHierarchicalTableIdentifier;
+import org.apache.xtable.model.storage.CatalogType;
+import org.apache.xtable.model.storage.TableFormat;
+
+@ExtendWith(MockitoExtension.class)
+public class TestDatabricksUnityCatalogSyncClient {
+
+  @Mock private StatementExecutionAPI mockStatementExecution;
+
+  @Test
+  void testCreateTableDelta_NoColumns() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
+    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
+    props.put(DatabricksUnityCatalogConfig.AUTH_TYPE, "oauth-m2m");
+    ExternalCatalogConfig config =
+        ExternalCatalogConfig.builder()
+            .catalogId("uc")
+            .catalogType(CatalogType.DATABRICKS_UC)
+            .catalogProperties(props)
+            .build();
+
+    DatabricksUnityCatalogSyncClient client =
+        new DatabricksUnityCatalogSyncClient(
+            config, TableFormat.DELTA, new Configuration(), mockStatementExecution);
+
+    when(mockStatementExecution.executeStatement(any(ExecuteStatementRequest.class)))
+        .thenReturn(
+            new StatementResponse()
+                .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED)));
+
+    InternalTable table = InternalTable.builder().basePath("s3://bucket/path").build();
+    ThreePartHierarchicalTableIdentifier tableIdentifier =
+        new ThreePartHierarchicalTableIdentifier("main", "default", "people");
+
+    client.createTable(table, tableIdentifier);
+
+    ArgumentCaptor<ExecuteStatementRequest> requestCaptor =
+        ArgumentCaptor.forClass(ExecuteStatementRequest.class);
+    verify(mockStatementExecution).executeStatement(requestCaptor.capture());
+    ExecuteStatementRequest request = requestCaptor.getValue();
+    assertEquals("wh-1", request.getWarehouseId());
+    assertEquals(
+        "CREATE TABLE IF NOT EXISTS main.default.people USING DELTA LOCATION 's3://bucket/path'",
+        request.getStatement());
+  }
+
+  @Test
+  void testCreateTableRejectsNonDelta() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
+    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
+    ExternalCatalogConfig config =
+        ExternalCatalogConfig.builder()
+            .catalogId("uc")
+            .catalogType(CatalogType.DATABRICKS_UC)
+            .catalogProperties(props)
+            .build();
+
+    DatabricksUnityCatalogSyncClient client =
+        new DatabricksUnityCatalogSyncClient(
+            config, TableFormat.ICEBERG, new Configuration(), mockStatementExecution);
+
+    InternalTable table = InternalTable.builder().basePath("s3://bucket/path").build();
+    ThreePartHierarchicalTableIdentifier tableIdentifier =
+        new ThreePartHierarchicalTableIdentifier("main", "default", "people");
+
+    assertThrows(CatalogSyncException.class, () -> client.createTable(table, tableIdentifier));
+  }
+}

--- a/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
@@ -205,6 +205,68 @@ public class TestDatabricksUnityCatalogSyncClient {
   }
 
   @Test
+  void testDropTable() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
+    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
+    ExternalCatalogConfig config =
+        ExternalCatalogConfig.builder()
+            .catalogId("uc")
+            .catalogType(CatalogType.DATABRICKS_UC)
+            .catalogProperties(props)
+            .build();
+
+    DatabricksUnityCatalogSyncClient client =
+        new DatabricksUnityCatalogSyncClient(
+            config,
+            TableFormat.DELTA,
+            new Configuration(),
+            mockStatementExecution,
+            mockTablesApi,
+            mockSchemasApi);
+
+    ThreePartHierarchicalTableIdentifier tableIdentifier =
+        new ThreePartHierarchicalTableIdentifier("main", "default", "people");
+
+    client.dropTable(InternalTable.builder().basePath("s3://bucket/path").build(), tableIdentifier);
+
+    verify(mockTablesApi).delete("main.default.people");
+  }
+
+  @Test
+  void testDropTableFailure() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
+    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
+    ExternalCatalogConfig config =
+        ExternalCatalogConfig.builder()
+            .catalogId("uc")
+            .catalogType(CatalogType.DATABRICKS_UC)
+            .catalogProperties(props)
+            .build();
+
+    DatabricksUnityCatalogSyncClient client =
+        new DatabricksUnityCatalogSyncClient(
+            config,
+            TableFormat.DELTA,
+            new Configuration(),
+            mockStatementExecution,
+            mockTablesApi,
+            mockSchemasApi);
+
+    ThreePartHierarchicalTableIdentifier tableIdentifier =
+        new ThreePartHierarchicalTableIdentifier("main", "default", "people");
+
+    doThrow(new RuntimeException("boom")).when(mockTablesApi).delete("main.default.people");
+
+    assertThrows(
+        CatalogSyncException.class,
+        () ->
+            client.dropTable(
+                InternalTable.builder().basePath("s3://bucket/path").build(), tableIdentifier));
+  }
+
+  @Test
   void testHasDatabaseTrue() {
     Map<String, String> props = new HashMap<>();
     props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");

--- a/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
@@ -79,25 +79,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateTableDelta_NoColumns() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    props.put(DatabricksUnityCatalogConfig.AUTH_TYPE, "oauth-m2m");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockStatementExecution.executeStatement(any(ExecuteStatementRequest.class)))
         .thenReturn(
@@ -122,24 +104,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateTableRejectsNonDelta() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.ICEBERG,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.ICEBERG);
 
     InternalTable table = InternalTable.builder().basePath("s3://bucket/path").build();
     ThreePartHierarchicalTableIdentifier tableIdentifier =
@@ -150,24 +115,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateTableRejectsInvalidIdentifier() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     InternalTable table = InternalTable.builder().basePath("s3://bucket/path").build();
     ThreePartHierarchicalTableIdentifier tableIdentifier =
@@ -178,24 +126,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateOrReplaceTableDelta() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockStatementExecution.executeStatement(any(ExecuteStatementRequest.class)))
         .thenReturn(
@@ -220,24 +151,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateOrReplaceTableRejectsNonDelta() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.ICEBERG,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.ICEBERG);
 
     InternalTable table = InternalTable.builder().basePath("s3://bucket/path").build();
     ThreePartHierarchicalTableIdentifier tableIdentifier =
@@ -249,24 +163,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateOrReplaceTableRecreateFailureWarnsAndThrows() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockStatementExecution.executeStatement(any(ExecuteStatementRequest.class)))
         .thenReturn(
@@ -286,24 +183,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testRefreshTableSchemaEvolution() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockStatementExecution.executeStatement(any(ExecuteStatementRequest.class)))
         .thenReturn(
@@ -344,24 +224,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testRefreshTableSchemaMatchNoop() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     InternalSchema idSchema =
         InternalSchema.builder().name("id").dataType(InternalType.INT).isNullable(true).build();
@@ -392,24 +255,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testRefreshTableWithNullCatalogTableNoop() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     InternalSchema idSchema =
         InternalSchema.builder().name("id").dataType(InternalType.INT).isNullable(true).build();
@@ -434,24 +280,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testRefreshTableWithNullSchemaNoop() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     InternalTable table = InternalTable.builder().basePath("s3://bucket/path").build();
     TableInfo catalogTable = new TableInfo();
@@ -465,24 +294,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testRefreshTableWithEmptySchemaNoop() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     InternalSchema readSchema =
         InternalSchema.builder()
@@ -504,24 +316,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testDropTable() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     ThreePartHierarchicalTableIdentifier tableIdentifier =
         new ThreePartHierarchicalTableIdentifier("main", "default", "people");
@@ -533,24 +328,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testDropTableFailure() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     ThreePartHierarchicalTableIdentifier tableIdentifier =
         new ThreePartHierarchicalTableIdentifier("main", "default", "people");
@@ -566,24 +344,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testHasDatabaseTrue() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockSchemasApi.get("main.default")).thenReturn(new SchemaInfo());
 
@@ -597,24 +358,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testHasDatabaseFalse() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockSchemasApi.get("main.default")).thenThrow(new NotFound("not found", null));
 
@@ -626,24 +370,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testHasDatabaseRejectsInvalidIdentifier() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     ThreePartHierarchicalTableIdentifier tableIdentifier =
         new ThreePartHierarchicalTableIdentifier("main", "default;DROP_SCHEMA", "people");
@@ -653,24 +380,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testHasDatabaseFailedStatement() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockSchemasApi.get("main.default")).thenThrow(new RuntimeException("boom"));
 
@@ -681,24 +391,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateDatabase() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     ThreePartHierarchicalTableIdentifier tableIdentifier =
         new ThreePartHierarchicalTableIdentifier("main", "default", "people");
@@ -714,24 +407,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testCreateDatabaseFailure() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     ThreePartHierarchicalTableIdentifier tableIdentifier =
         new ThreePartHierarchicalTableIdentifier("main", "default", "people");
@@ -743,24 +419,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testGetTableFound() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     TableInfo tableInfo = new TableInfo().setStorageLocation("s3://bucket/path");
     when(mockTablesApi.get("main.default.people")).thenReturn(tableInfo);
@@ -775,24 +434,7 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testGetTableNotFound() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockTablesApi.get("main.default.people")).thenThrow(new NotFound("not found", null));
 
@@ -804,29 +446,33 @@ public class TestDatabricksUnityCatalogSyncClient {
 
   @Test
   void testGetTableFailedStatement() {
-    Map<String, String> props = new HashMap<>();
-    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
-    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
-    ExternalCatalogConfig config =
-        ExternalCatalogConfig.builder()
-            .catalogId("uc")
-            .catalogType(CatalogType.DATABRICKS_UC)
-            .catalogProperties(props)
-            .build();
-
-    DatabricksUnityCatalogSyncClient client =
-        new DatabricksUnityCatalogSyncClient(
-            config,
-            TableFormat.DELTA,
-            new Configuration(),
-            mockStatementExecution,
-            mockTablesApi,
-            mockSchemasApi);
+    DatabricksUnityCatalogSyncClient client = createClient(TableFormat.DELTA);
 
     when(mockTablesApi.get("main.default.people")).thenThrow(new RuntimeException("boom"));
 
     ThreePartHierarchicalTableIdentifier tableIdentifier =
         new ThreePartHierarchicalTableIdentifier("main", "default", "people");
     assertThrows(CatalogSyncException.class, () -> client.getTable(tableIdentifier));
+  }
+
+  private DatabricksUnityCatalogSyncClient createClient(String tableFormat) {
+    return new DatabricksUnityCatalogSyncClient(
+        createCatalogConfig(),
+        tableFormat,
+        new Configuration(),
+        mockStatementExecution,
+        mockTablesApi,
+        mockSchemasApi);
+  }
+
+  private ExternalCatalogConfig createCatalogConfig() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");
+    props.put(DatabricksUnityCatalogConfig.WAREHOUSE_ID, "wh-1");
+    return ExternalCatalogConfig.builder()
+        .catalogId("uc")
+        .catalogType(CatalogType.DATABRICKS_UC)
+        .catalogProperties(props)
+        .build();
   }
 }

--- a/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
+++ b/xtable-databricks/src/test/java/org/apache/xtable/databricks/TestDatabricksUnityCatalogSyncClient.java
@@ -69,6 +69,14 @@ public class TestDatabricksUnityCatalogSyncClient {
   @Mock private SchemasAPI mockSchemasApi;
 
   @Test
+  void testGetCatalogIdFailsWhenNotInitialized() {
+    DatabricksUnityCatalogSyncClient client = new DatabricksUnityCatalogSyncClient();
+
+    CatalogSyncException exception = assertThrows(CatalogSyncException.class, client::getCatalogId);
+    assertTrue(exception.getMessage().contains("not initialized"));
+  }
+
+  @Test
   void testCreateTableDelta_NoColumns() {
     Map<String, String> props = new HashMap<>();
     props.put(DatabricksUnityCatalogConfig.HOST, "https://example.cloud.databricks.com");


### PR DESCRIPTION
  ## Important Read

  - Please ensure the GitHub issue is mentioned at the beginning of the PR

  ## What is the purpose of the pull request

  This pull request adds Databricks Unity Catalog (DATABRICKS_UC) catalog sync support to XTable, with a new xtable-databricks module, UC config wiring, UC sync client
  implementation, and documentation updates.

  ## Brief change log

  - Added new xtable-databricks module + ServiceLoader wiring.
  - Added DatabricksUnityCatalogConfig and DatabricksUnityCatalogSyncClient (DDL-based UC registration).
  - Implemented UC sync methods: hasDatabase, createDatabase, getTable, createTable, createOrReplaceTable, dropTable, refreshTable.
  - Added UC-specific unit tests for all catalog sync methods.
  - Documented Databricks UC sync flow, auth (OAuth M2M), limitations (Delta-only, unique location), and schema evolution strategy (drop/recreate).

  ## Verify this pull request

  This change added tests and can be verified as follows:

  - Added TestDatabricksUnityCatalogSyncClient in xtable-databricks.
  - Run:
      - mvn -Drat.skip=true -Dspotless.skip=true -Dtest=TestDatabricksUnityCatalogSyncClient -pl xtable-databricks test
