### PR TITLE
feat(hudi): enable concurrent hudi s3 footer collection

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiFileStatsExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiFileStatsExtractor.java
@@ -104,7 +104,11 @@ public class HudiFileStatsExtractor {
 
   private Stream<InternalDataFile> computeColumnStatsFromParquetFooters(
       Stream<InternalDataFile> files, Map<String, InternalField> nameFieldMap) {
-    return files.map(
+    // Use the common ForkJoinPool for parquet footer reads; parallelism can be tuned via
+    // -Djava.util.concurrent.ForkJoinPool.common.parallelism.
+    return files
+        .parallel()
+        .map(
         file -> {
           HudiFileStats fileStats =
               computeColumnStatsForFile(new Path(file.getPhysicalPath()), nameFieldMap);

--- a/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiFileStatsExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/hudi/TestHudiFileStatsExtractor.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.avro.Conversions;
@@ -197,6 +198,50 @@ public class TestHudiFileStatsExtractor {
             .addStatsToFiles(null, Stream.of(inputFile), schema)
             .collect(Collectors.toList());
     validateOutput(output);
+  }
+
+  @Test
+  void columnStatsWithoutMetadataTable_parallelFooterReadsAreThreadSafe(@TempDir Path tempDir)
+      throws IOException {
+    Path file = tempDir.resolve("tmp.parquet");
+    GenericData genericData = GenericData.get();
+    genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
+    try (ParquetWriter<GenericRecord> writer =
+        AvroParquetWriter.<GenericRecord>builder(
+                HadoopOutputFile.fromPath(
+                    new org.apache.hadoop.fs.Path(file.toUri()), configuration))
+            .withSchema(AVRO_SCHEMA)
+            .withDataModel(genericData)
+            .build()) {
+      for (GenericRecord record : getRecords()) {
+        writer.write(record);
+      }
+    }
+
+    HoodieTableMetaClient mockMetaClient = mock(HoodieTableMetaClient.class);
+    when(mockMetaClient.getHadoopConf()).thenReturn(configuration);
+    HudiFileStatsExtractor fileStatsExtractor = new HudiFileStatsExtractor(mockMetaClient);
+
+    List<InternalDataFile> inputFiles =
+        IntStream.range(0, 200)
+            .mapToObj(
+                i ->
+                    InternalDataFile.builder()
+                        .physicalPath(file.toString())
+                        .columnStats(Collections.emptyList())
+                        .fileFormat(FileFormat.APACHE_PARQUET)
+                        .lastModified(1234L)
+                        .fileSizeBytes(4321L)
+                        .recordCount(0)
+                        .build())
+            .collect(Collectors.toList());
+
+    List<InternalDataFile> output =
+        fileStatsExtractor.addStatsToFiles(null, inputFiles.stream(), schema).collect(Collectors.toList());
+
+    assertEquals(200, output.size());
+    assertTrue(output.stream().allMatch(fileWithStats -> fileWithStats.getRecordCount() == 2));
+    assertTrue(output.stream().allMatch(fileWithStats -> fileWithStats.getColumnStats().size() == 9));
   }
 
   private void validateOutput(List<InternalDataFile> output) {


### PR DESCRIPTION
  Improve Hudi sync performance when Hudi metadata column stats are not enabled and XTable falls back to parquet footer reads on S3.

  ## Brief change log

  - Parallelized computeColumnStatsFromParquetFooters in HudiFileStatsExtractor using Stream.parallel().
  - Added regression test columnStatsWithoutMetadataTable_parallelFooterReadsAreThreadSafe to validate stability under parallel execution.
  - Added runtime tuning note for ForkJoinPool parallelism:
    -Djava.util.concurrent.ForkJoinPool.common.parallelism=16.

  ## Impact

  - In our XTable runs (fallback-to-S3 footer path), this improved processing time by about 4x.

  ## Verify this pull request

  This change added tests and can be verified as follows:

  - Run:
      - mvn -pl xtable-core -Dtest=TestHudiFileStatsExtractor test -DskipITs
  - Optional tuned run:
      - MAVEN_OPTS="-Djava.util.concurrent.ForkJoinPool.common.parallelism=16" mvn -pl xtable-core -Dtest=TestHudiFileStatsExtractor test -DskipITs
  - Result:
      - TestHudiFileStatsExtractor passed (3 tests, 0 failures).
