### PR TITLE
[bug] Fix batch INSERT_OVERWRITE replacecommits dropping adds in HudiDataFileExtractor

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiDataFileExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiDataFileExtractor.java
@@ -326,9 +326,7 @@ public class HudiDataFileExtractor implements AutoCloseable {
         partitionValuesExtractor.extractPartitionValues(partitioningFields, partitionPath);
     Stream<HoodieFileGroup> fileGroups =
         Stream.concat(
-            fsView.getAllFileGroups(partitionPath),
-            fsView.getReplacedFileGroupsBeforeOrOn(
-                instantToConsider.getTimestamp(), partitionPath));
+            fsView.getAllFileGroups(partitionPath), fsView.getAllReplacedFileGroups(partitionPath));
     fileGroups.forEach(
         fileGroup -> {
           List<HoodieBaseFile> baseFiles = fileGroup.getAllBaseFiles().collect(Collectors.toList());

--- a/xtable-core/src/test/java/org/apache/xtable/TestSparkHudiTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/TestSparkHudiTable.java
@@ -220,6 +220,19 @@ public class TestSparkHudiTable extends TestAbstractHudiTable {
     assertNoWriteErrors(result);
   }
 
+  public List<HoodieRecord<HoodieAvroPayload>> insertOverwrite(
+      List<HoodieRecord<HoodieAvroPayload>> records) {
+    String actionType =
+        CommitUtils.getCommitActionType(
+            WriteOperationType.INSERT_OVERWRITE, HoodieTableType.COPY_ON_WRITE);
+    String instant = getStartCommitOfActionType(actionType);
+    JavaRDD<HoodieRecord<HoodieAvroPayload>> writeRecords = jsc.parallelize(records, 1);
+    HoodieWriteResult writeResult = writeClient.insertOverwrite(writeRecords, instant);
+    List<WriteStatus> result = writeResult.getWriteStatuses().collect();
+    assertNoWriteErrors(result);
+    return records;
+  }
+
   public void cluster() {
     String instant = writeClient.scheduleClustering(Option.empty()).get();
     writeClient.cluster(instant, true);

--- a/xtable-core/src/test/java/org/apache/xtable/TestSparkHudiTable.java
+++ b/xtable-core/src/test/java/org/apache/xtable/TestSparkHudiTable.java
@@ -220,17 +220,15 @@ public class TestSparkHudiTable extends TestAbstractHudiTable {
     assertNoWriteErrors(result);
   }
 
-  public List<HoodieRecord<HoodieAvroPayload>> insertOverwrite(
-      List<HoodieRecord<HoodieAvroPayload>> records) {
+  public void insertOverwrite(
+      List<HoodieRecord<HoodieAvroPayload>> records, HoodieTableType tableType) {
     String actionType =
-        CommitUtils.getCommitActionType(
-            WriteOperationType.INSERT_OVERWRITE, HoodieTableType.COPY_ON_WRITE);
+        CommitUtils.getCommitActionType(WriteOperationType.INSERT_OVERWRITE, tableType);
     String instant = getStartCommitOfActionType(actionType);
     JavaRDD<HoodieRecord<HoodieAvroPayload>> writeRecords = jsc.parallelize(records, 1);
     HoodieWriteResult writeResult = writeClient.insertOverwrite(writeRecords, instant);
     List<WriteStatus> result = writeResult.getWriteStatuses().collect();
     assertNoWriteErrors(result);
-    return records;
   }
 
   public void cluster() {

--- a/xtable-core/src/test/java/org/apache/xtable/hudi/ITHudiConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/hudi/ITHudiConversionSource.java
@@ -419,12 +419,13 @@ public class ITHudiConversionSource {
     }
   }
 
-  @Test
-  public void testMultipleInsertOverwriteOnSamePartitions() {
+  @ParameterizedTest
+  @MethodSource("testsForAllTableTypes")
+  public void testMultipleInsertOverwriteOnSamePartitions(HoodieTableType tableType) {
     String tableName = "test_table_" + UUID.randomUUID();
     try (TestSparkHudiTable table =
         TestSparkHudiTable.forStandardSchema(
-            tableName, tempDir, jsc, "level:SIMPLE", HoodieTableType.COPY_ON_WRITE)) {
+            tableName, tempDir, jsc, "level:SIMPLE", tableType)) {
       List<List<String>> allBaseFilePaths = new ArrayList<>();
       List<TableChange> allTableChanges = new ArrayList<>();
 
@@ -436,12 +437,12 @@ public class ITHudiConversionSource {
 
       // INSERT_OVERWRITE on "INFO" partition (replacecommit A — new file groups replace initial)
       List<HoodieRecord<HoodieAvroPayload>> overwriteRecords1 = table.generateRecords(30, "INFO");
-      table.insertOverwrite(overwriteRecords1);
+      table.insertOverwrite(overwriteRecords1, tableType);
       allBaseFilePaths.add(table.getAllLatestBaseFilePaths());
 
       // INSERT_OVERWRITE on "INFO" partition again (replacecommit B — new file groups replace A's)
       List<HoodieRecord<HoodieAvroPayload>> overwriteRecords2 = table.generateRecords(20, "INFO");
-      table.insertOverwrite(overwriteRecords2);
+      table.insertOverwrite(overwriteRecords2, tableType);
       allBaseFilePaths.add(table.getAllLatestBaseFilePaths());
 
       HudiConversionSource hudiClient =

--- a/xtable-core/src/test/java/org/apache/xtable/hudi/ITHudiConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/hudi/ITHudiConversionSource.java
@@ -424,8 +424,7 @@ public class ITHudiConversionSource {
   public void testMultipleInsertOverwriteOnSamePartitions(HoodieTableType tableType) {
     String tableName = "test_table_" + UUID.randomUUID();
     try (TestSparkHudiTable table =
-        TestSparkHudiTable.forStandardSchema(
-            tableName, tempDir, jsc, "level:SIMPLE", tableType)) {
+        TestSparkHudiTable.forStandardSchema(tableName, tempDir, jsc, "level:SIMPLE", tableType)) {
       List<List<String>> allBaseFilePaths = new ArrayList<>();
       List<TableChange> allTableChanges = new ArrayList<>();
 

--- a/xtable-core/src/test/java/org/apache/xtable/hudi/ITHudiConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/hudi/ITHudiConversionSource.java
@@ -419,6 +419,54 @@ public class ITHudiConversionSource {
     }
   }
 
+  @Test
+  public void testMultipleInsertOverwriteOnSamePartitions() {
+    String tableName = "test_table_" + UUID.randomUUID();
+    try (TestSparkHudiTable table =
+        TestSparkHudiTable.forStandardSchema(
+            tableName, tempDir, jsc, "level:SIMPLE", HoodieTableType.COPY_ON_WRITE)) {
+      List<List<String>> allBaseFilePaths = new ArrayList<>();
+      List<TableChange> allTableChanges = new ArrayList<>();
+
+      // Initial insert into partition "INFO"
+      String commitInstant1 = table.startCommit();
+      List<HoodieRecord<HoodieAvroPayload>> insertsForCommit1 = table.generateRecords(50, "INFO");
+      table.insertRecordsWithCommitAlreadyStarted(insertsForCommit1, commitInstant1, true);
+      allBaseFilePaths.add(table.getAllLatestBaseFilePaths());
+
+      // INSERT_OVERWRITE on "INFO" partition (replacecommit A — new file groups replace initial)
+      List<HoodieRecord<HoodieAvroPayload>> overwriteRecords1 = table.generateRecords(30, "INFO");
+      table.insertOverwrite(overwriteRecords1);
+      allBaseFilePaths.add(table.getAllLatestBaseFilePaths());
+
+      // INSERT_OVERWRITE on "INFO" partition again (replacecommit B — new file groups replace A's)
+      List<HoodieRecord<HoodieAvroPayload>> overwriteRecords2 = table.generateRecords(20, "INFO");
+      table.insertOverwrite(overwriteRecords2);
+      allBaseFilePaths.add(table.getAllLatestBaseFilePaths());
+
+      HudiConversionSource hudiClient =
+          getHudiSourceClient(CONFIGURATION, table.getBasePath(), "level:VALUE");
+      // Get the current snapshot
+      InternalSnapshot internalSnapshot = hudiClient.getCurrentSnapshot();
+      ValidationTestHelper.validateSnapshot(
+          internalSnapshot, allBaseFilePaths.get(allBaseFilePaths.size() - 1));
+      // Get changes in Incremental format since the initial insert
+      InstantsForIncrementalSync instantsForIncrementalSync =
+          InstantsForIncrementalSync.builder()
+              .lastSyncInstant(HudiInstantUtils.parseFromInstantTime(commitInstant1))
+              .build();
+      CommitsBacklog<HoodieInstant> instantCommitsBacklog =
+          hudiClient.getCommitsBacklog(instantsForIncrementalSync);
+      for (HoodieInstant instant : instantCommitsBacklog.getCommitsToProcess()) {
+        TableChange tableChange = hudiClient.getTableChangeForCommit(instant);
+        allTableChanges.add(tableChange);
+      }
+      // Without the fix, replacecommit A would have 0 adds because the FileSystemView
+      // built from the full timeline marks A's file groups as replaced by B.
+      ValidationTestHelper.validateTableChanges(allBaseFilePaths, allTableChanges);
+    }
+  }
+
   @ParameterizedTest
   @MethodSource("testsForAllTableTypes")
   public void testsForDeleteAllRecordsInPartition(HoodieTableType tableType) {


### PR DESCRIPTION
## Problem

When XTable processes multiple `INSERT_OVERWRITE` `replacecommit` instants in a single batch (e.g., commit A replaces the initial file groups, then commit B replaces A's file groups on the same partition), `getUpdatesToPartitionForReplaceCommit` uses `getReplacedFileGroupsBeforeOrOn(A.timestamp)` to find replaced file groups. This **excludes** A's own file groups because they were replaced by B (and B's timestamp > A's), and `getAllFileGroups` also excludes them (globally marked replaced). The result: replacecommit A emits **0 adds**, causing downstream format sync failures.

## Fix

Change `getReplacedFileGroupsBeforeOrOn` → `getAllReplacedFileGroups` in the replace commit handler. This is consistent with how `getUpdatesToPartition` already handles regular commits (where all file groups across the timeline are considered). The `newFileIds` and `replacedFileIds` sets derived from each commit's write stats already ensure only the correct files are emitted as adds or removes for that specific commit.

## Tests

- Added `insertOverwrite()` helper to `TestSparkHudiTable`
- Added `testMultipleInsertOverwriteOnSamePartitions` integration test in `ITHudiConversionSource` that reproduces the bug and validates the fix
- New test fails without the fix (replacecommit A has `expected: <[...parquet]> but was: <[]>`) and passes with it