### PR TITLE
Enable Delta checkpoint CRC exception throwing by default

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionUtils.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionUtils.java
@@ -39,7 +39,8 @@ public class DeltaConversionUtils {
             .set(
                 "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog")
-            .set("spark.databricks.delta.constraints.allowUnenforcedNotNull.enabled", "true");
+            .set("spark.databricks.delta.constraints.allowUnenforcedNotNull.enabled", "true")
+            .set("spark.databricks.delta.checkpoint.exceptionThrowing.enabled", "true");
     SparkSession.Builder builder = SparkSession.builder().config(sparkConf);
     conf.forEach(
         entry ->


### PR DESCRIPTION
## Summary

- Sets `spark.databricks.delta.checkpoint.exceptionThrowing.enabled=true` in `DeltaConversionUtils.buildSparkSession` so that Delta CRC integrity failures surface as exceptions rather than being silently swallowed during checkpoint reads.
- Delta OSS [defaults this to `false`](https://github.com/delta-io/delta/blob/v3.3.2/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala#L1175), but Databricks enforces the check. We enable it explicitly to catch CRC corruption early.

## Test plan

- [ ] Existing Delta sync tests pass