### PR TITLE
Fix map key path handling in Delta schema extractors

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaSchemaExtractor.java
@@ -196,7 +196,7 @@ public class DeltaSchemaExtractor {
             toInternalSchema(
                 mapType.keyType(),
                 SchemaUtils.getFullyQualifiedPath(
-                    parentPath, InternalField.Constants.MAP_VALUE_FIELD_NAME),
+                    parentPath, InternalField.Constants.MAP_KEY_FIELD_NAME),
                 false,
                 null,
                 null);

--- a/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelSchemaExtractor.java
@@ -79,6 +79,8 @@ public class DeltaKernelSchemaExtractor {
     InternalType type = null;
     Map<InternalSchema.MetadataKey, Object> metadata = null;
     List<InternalField> fields = null;
+    InternalType type;
+    String trimmedTypeName;
 
     if (dataType instanceof IntegerType) {
       type = InternalType.INT;
@@ -193,7 +195,7 @@ public class DeltaKernelSchemaExtractor {
           toInternalSchema(
               mapType.getKeyType(),
               SchemaUtils.getFullyQualifiedPath(
-                  parentPath, InternalField.Constants.MAP_VALUE_FIELD_NAME),
+                  parentPath, InternalField.Constants.MAP_KEY_FIELD_NAME),
               false,
               null,
               null);
@@ -220,6 +222,8 @@ public class DeltaKernelSchemaExtractor {
       type = InternalType.MAP;
       fields = Arrays.asList(keyField, valueField);
       trimmedTypeName = "map";
+    } else {
+      throw new NotSupportedException("Unsupported type: " + dataType);
     }
     return InternalSchema.builder()
         .name(trimmedTypeName)

--- a/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelSchemaExtractor.java
@@ -79,8 +79,6 @@ public class DeltaKernelSchemaExtractor {
     InternalType type = null;
     Map<InternalSchema.MetadataKey, Object> metadata = null;
     List<InternalField> fields = null;
-    InternalType type;
-    String trimmedTypeName;
 
     if (dataType instanceof IntegerType) {
       type = InternalType.INT;

--- a/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelSchemaExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelSchemaExtractor.java
@@ -98,7 +98,8 @@ public class DeltaKernelSchemaExtractor {
       type = InternalType.DOUBLE;
       trimmedTypeName = "double";
     } else if (dataType instanceof BinaryType) {
-      if (originalMetadata.contains(InternalSchema.XTABLE_LOGICAL_TYPE)
+      if (originalMetadata != null
+          && originalMetadata.contains(InternalSchema.XTABLE_LOGICAL_TYPE)
           && "uuid".equals(originalMetadata.getString(InternalSchema.XTABLE_LOGICAL_TYPE))) {
         type = InternalType.UUID;
         trimmedTypeName = "binary";

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaSchemaExtractor.java
@@ -473,6 +473,98 @@ public class TestDeltaSchemaExtractor {
   }
 
   @Test
+  public void testMapWithStructKey() {
+    InternalSchema structKeySchema =
+        InternalSchema.builder()
+            .name("struct")
+            .isNullable(false)
+            .fields(
+                Arrays.asList(
+                    InternalField.builder()
+                        .name("id")
+                        .parentPath("structKeyMap._one_field_key")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("long")
+                                .dataType(InternalType.LONG)
+                                .isNullable(false)
+                                .build())
+                        .build(),
+                    InternalField.builder()
+                        .name("region")
+                        .parentPath("structKeyMap._one_field_key")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("string")
+                                .dataType(InternalType.STRING)
+                                .isNullable(true)
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build()))
+            .dataType(InternalType.RECORD)
+            .build();
+    InternalSchema structValueSchema =
+        InternalSchema.builder()
+            .name("struct")
+            .isNullable(true)
+            .fields(
+                Collections.singletonList(
+                    InternalField.builder()
+                        .name("payload")
+                        .parentPath("structKeyMap._one_field_value")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("string")
+                                .dataType(InternalType.STRING)
+                                .isNullable(false)
+                                .build())
+                        .build()))
+            .dataType(InternalType.RECORD)
+            .build();
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .name("struct")
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .fields(
+                Collections.singletonList(
+                    InternalField.builder()
+                        .name("structKeyMap")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("map")
+                                .isNullable(true)
+                                .dataType(InternalType.MAP)
+                                .fields(
+                                    Arrays.asList(
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.MAP_KEY_FIELD_NAME)
+                                            .parentPath("structKeyMap")
+                                            .schema(structKeySchema)
+                                            .build(),
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.MAP_VALUE_FIELD_NAME)
+                                            .parentPath("structKeyMap")
+                                            .schema(structValueSchema)
+                                            .build()))
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build()))
+            .build();
+
+    StructType keyStruct =
+        new StructType()
+            .add("id", DataTypes.LongType, false)
+            .add("region", DataTypes.StringType, true);
+    StructType valueStruct = new StructType().add("payload", DataTypes.StringType, false);
+    StructType structRepresentation =
+        new StructType().add("structKeyMap", DataTypes.createMapType(keyStruct, valueStruct, true));
+
+    Assertions.assertEquals(
+        internalSchema, DeltaSchemaExtractor.getInstance().toInternalSchema(structRepresentation));
+  }
+
+  @Test
   public void testLists() {
     InternalSchema recordListElementSchema =
         InternalSchema.builder()

--- a/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelSchemaExtractor.java
@@ -500,6 +500,98 @@ public class TestDeltaKernelSchemaExtractor {
   }
 
   @Test
+  public void testMapWithStructKey() {
+    InternalSchema structKeySchema =
+        InternalSchema.builder()
+            .name("struct")
+            .isNullable(false)
+            .fields(
+                Arrays.asList(
+                    InternalField.builder()
+                        .name("id")
+                        .parentPath("structKeyMap._one_field_key")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("long")
+                                .dataType(InternalType.LONG)
+                                .isNullable(false)
+                                .build())
+                        .build(),
+                    InternalField.builder()
+                        .name("region")
+                        .parentPath("structKeyMap._one_field_key")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("string")
+                                .dataType(InternalType.STRING)
+                                .isNullable(true)
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build()))
+            .dataType(InternalType.RECORD)
+            .build();
+    InternalSchema structValueSchema =
+        InternalSchema.builder()
+            .name("struct")
+            .isNullable(true)
+            .fields(
+                Collections.singletonList(
+                    InternalField.builder()
+                        .name("payload")
+                        .parentPath("structKeyMap._one_field_value")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("string")
+                                .dataType(InternalType.STRING)
+                                .isNullable(false)
+                                .build())
+                        .build()))
+            .dataType(InternalType.RECORD)
+            .build();
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .name("struct")
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .fields(
+                Collections.singletonList(
+                    InternalField.builder()
+                        .name("structKeyMap")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("map")
+                                .isNullable(true)
+                                .dataType(InternalType.MAP)
+                                .fields(
+                                    Arrays.asList(
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.MAP_KEY_FIELD_NAME)
+                                            .parentPath("structKeyMap")
+                                            .schema(structKeySchema)
+                                            .build(),
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.MAP_VALUE_FIELD_NAME)
+                                            .parentPath("structKeyMap")
+                                            .schema(structValueSchema)
+                                            .build()))
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build()))
+            .build();
+
+    io.delta.kernel.types.StructType keyStruct =
+        new StructType().add("id", LongType.LONG, false).add("region", StringType.STRING, true);
+    io.delta.kernel.types.StructType valueStruct =
+        new StructType().add("payload", StringType.STRING, false);
+    io.delta.kernel.types.StructType structRepresentation =
+        new StructType().add("structKeyMap", new MapType(keyStruct, valueStruct, true));
+
+    Assertions.assertEquals(
+        internalSchema,
+        DeltaKernelSchemaExtractor.getInstance().toInternalSchema(structRepresentation));
+  }
+
+  @Test
   public void testLists() {
     InternalSchema recordListElementSchema =
         InternalSchema.builder()

--- a/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelSchemaExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelSchemaExtractor.java
@@ -592,6 +592,82 @@ public class TestDeltaKernelSchemaExtractor {
   }
 
   @Test
+  public void testBinaryInComplexTypesDoesNotThrow() {
+    // Regression: BinaryType nested inside MapType/ArrayType receives null originalMetadata
+    // from the parent recursion; ensure the BinaryType branch handles null without NPE.
+    InternalSchema internalSchema =
+        InternalSchema.builder()
+            .name("struct")
+            .dataType(InternalType.RECORD)
+            .isNullable(false)
+            .fields(
+                Arrays.asList(
+                    InternalField.builder()
+                        .name("binaryKeyMap")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("map")
+                                .isNullable(true)
+                                .dataType(InternalType.MAP)
+                                .fields(
+                                    Arrays.asList(
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.MAP_KEY_FIELD_NAME)
+                                            .parentPath("binaryKeyMap")
+                                            .schema(
+                                                InternalSchema.builder()
+                                                    .name("binary")
+                                                    .dataType(InternalType.BYTES)
+                                                    .isNullable(false)
+                                                    .build())
+                                            .build(),
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.MAP_VALUE_FIELD_NAME)
+                                            .parentPath("binaryKeyMap")
+                                            .schema(
+                                                InternalSchema.builder()
+                                                    .name("binary")
+                                                    .dataType(InternalType.BYTES)
+                                                    .isNullable(true)
+                                                    .build())
+                                            .build()))
+                                .build())
+                        .defaultValue(InternalField.Constants.NULL_DEFAULT_VALUE)
+                        .build(),
+                    InternalField.builder()
+                        .name("binaryList")
+                        .schema(
+                            InternalSchema.builder()
+                                .name("array")
+                                .isNullable(false)
+                                .dataType(InternalType.LIST)
+                                .fields(
+                                    Collections.singletonList(
+                                        InternalField.builder()
+                                            .name(InternalField.Constants.ARRAY_ELEMENT_FIELD_NAME)
+                                            .parentPath("binaryList")
+                                            .schema(
+                                                InternalSchema.builder()
+                                                    .name("binary")
+                                                    .dataType(InternalType.BYTES)
+                                                    .isNullable(false)
+                                                    .build())
+                                            .build()))
+                                .build())
+                        .build()))
+            .build();
+
+    io.delta.kernel.types.StructType structRepresentation =
+        new StructType()
+            .add("binaryKeyMap", new MapType(BinaryType.BINARY, BinaryType.BINARY, true))
+            .add("binaryList", new ArrayType(BinaryType.BINARY, false), false);
+
+    Assertions.assertEquals(
+        internalSchema,
+        DeltaKernelSchemaExtractor.getInstance().toInternalSchema(structRepresentation));
+  }
+
+  @Test
   public void testLists() {
     InternalSchema recordListElementSchema =
         InternalSchema.builder()


### PR DESCRIPTION
Fixes #825

Both `DeltaSchemaExtractor` and `DeltaKernelSchemaExtractor` were passing `MAP_VALUE_FIELD_NAME` when recursing into a map **key**, so nested fields under a complex (struct/array/map) map key were qualified with `<map>._one_field_value.<child>` instead of `<map>._one_field_key.<child>`. This collides with the value-side fully-qualified paths and breaks any downstream lookup keyed off `InternalField.parentPath` (column stats, field resolution, etc.).

### Changes

- **`DeltaSchemaExtractor`**: pass `MAP_KEY_FIELD_NAME` (instead of `MAP_VALUE_FIELD_NAME`) when building the key schema's parent path.
- **`DeltaKernelSchemaExtractor`**:
  - Same map-key path fix.
  - Guard the `BinaryType` branch with `originalMetadata != null` before reading `XTABLE_LOGICAL_TYPE`. Map/array recursion passes `null` metadata, so a binary nested inside a complex type previously NPE'd here.
  - Throw `NotSupportedException` on an unknown `DataType` instead of silently falling through (which would build an `InternalSchema` with a `null` dataType and `""` name).
- **Tests**:
  - `TestDeltaSchemaExtractor` / `TestDeltaKernelSchemaExtractor`: add `testMapWithStructKey`, covering a map whose key is a 2-field struct (nullable + non-nullable) and whose value is also a struct, asserting both `_one_field_key` and `_one_field_value` nested `parentPath` propagation.
  - `TestDeltaKernelSchemaExtractor`: add `testBinaryInComplexTypesDoesNotThrow`, a regression for a `BinaryType` nested in `MapType`/`ArrayType` receiving `null` `originalMetadata`.
