### PR TITLE
[MINOR] Preserve original cause in ReadException on close failure

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/hudi/HudiDataFileExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/HudiDataFileExtractor.java
@@ -371,7 +371,8 @@ public class HudiDataFileExtractor implements AutoCloseable {
       fileSystemViewManager.close();
     } catch (Exception e) {
       throw new ReadException(
-          "Could not close table metadata for table " + metaClient.getTableConfig().getTableName());
+          "Could not close table metadata for table " + metaClient.getTableConfig().getTableName(),
+          e);
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

`HudiDataFileExtractor.close()` wrapped any failure from closing the table
metadata or file system view in a new `ReadException` without passing the
caught exception as the cause. This discarded the original stack trace and
root cause (e.g. I/O or permission errors), making such failures hard to
diagnose.

## Brief change log

- Pass the caught exception to the `ReadException(message, Throwable)`
  constructor in `HudiDataFileExtractor.close()` so the original cause is
  preserved in the exception chain.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.