### PR TITLE
fix(delta): null partition value for composite generated-column partitions

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaPartitionExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaPartitionExtractor.java
@@ -326,15 +326,11 @@ public class DeltaPartitionExtractor {
     if (partitionFieldNames.size() == 1) {
       return values.getOrDefault(partitionFieldNames.get(0), null);
     }
-    // Composite partition (e.g. year and month generated columns derived from a single source
-    // field). If any component value is missing the partition value cannot be reconstructed, so
-    // return null instead of joining into a string containing the literal "null".
+    // Composite partition: any null component yields a null value, not joined "null"s.
     if (partitionFieldNames.stream().anyMatch(name -> values.get(name) == null)) {
       return null;
     }
-    return partitionFieldNames.stream()
-        .map(values::get)
-        .collect(Collectors.joining("-"));
+    return partitionFieldNames.stream().map(values::get).collect(Collectors.joining("-"));
   }
 
   private String getGeneratedColumnName(InternalPartitionField internalPartitionField) {

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaPartitionExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaPartitionExtractor.java
@@ -326,8 +326,14 @@ public class DeltaPartitionExtractor {
     if (partitionFieldNames.size() == 1) {
       return values.getOrDefault(partitionFieldNames.get(0), null);
     }
+    // Composite partition (e.g. year and month generated columns derived from a single source
+    // field). If any component value is missing the partition value cannot be reconstructed, so
+    // return null instead of joining into a string containing the literal "null".
+    if (partitionFieldNames.stream().anyMatch(name -> values.get(name) == null)) {
+      return null;
+    }
     return partitionFieldNames.stream()
-        .map(name -> values.get(name))
+        .map(values::get)
         .collect(Collectors.joining("-"));
   }
 

--- a/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelPartitionExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelPartitionExtractor.java
@@ -319,8 +319,14 @@ public class DeltaKernelPartitionExtractor {
     if (partitionFieldNames.size() == 1) {
       return values.getOrDefault(partitionFieldNames.get(0), null);
     }
+    // Composite partition (e.g. year and month generated columns derived from a single source
+    // field). If any component value is missing the partition value cannot be reconstructed, so
+    // return null instead of joining into a string containing the literal "null".
+    if (partitionFieldNames.stream().anyMatch(name -> values.get(name) == null)) {
+      return null;
+    }
     return partitionFieldNames.stream()
-        .map(name -> values.get(name))
+        .map(values::get)
         .collect(Collectors.joining("-"));
   }
 

--- a/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelPartitionExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/kernel/DeltaKernelPartitionExtractor.java
@@ -319,15 +319,11 @@ public class DeltaKernelPartitionExtractor {
     if (partitionFieldNames.size() == 1) {
       return values.getOrDefault(partitionFieldNames.get(0), null);
     }
-    // Composite partition (e.g. year and month generated columns derived from a single source
-    // field). If any component value is missing the partition value cannot be reconstructed, so
-    // return null instead of joining into a string containing the literal "null".
+    // Composite partition: any null component yields a null value, not joined "null"s.
     if (partitionFieldNames.stream().anyMatch(name -> values.get(name) == null)) {
       return null;
     }
-    return partitionFieldNames.stream()
-        .map(values::get)
-        .collect(Collectors.joining("-"));
+    return partitionFieldNames.stream().map(values::get).collect(Collectors.joining("-"));
   }
 
   private String getGeneratedColumnName(InternalPartitionField internalPartitionField) {

--- a/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
@@ -368,6 +368,63 @@ public class ITDeltaConversionSource {
     InternalSnapshot snapshot = conversionSource.getCurrentSnapshot();
   }
 
+  @Test
+  void getCurrentSnapshotGenColPartitionedWithNullSourceTest() {
+    // Reproduces partition value corruption for a composite generated-column partition. The
+    // year/month/day partition columns are all generated from a single source column, so a row
+    // whose source value is null produces null for every component. The extractor must resolve
+    // such a partition value to null instead of joining the components into a string containing
+    // the literal "null" (e.g. "null-null-null") and then failing to parse it as a date.
+    final String tableName = GenericTable.getTableName();
+    final Path basePath = tempDir.resolve(tableName);
+    sparkSession.sql(
+        "CREATE TABLE `"
+            + tableName
+            + "` (id BIGINT, event_time TIMESTAMP,"
+            + " year_col INT GENERATED ALWAYS AS (YEAR(event_time)),"
+            + " month_col INT GENERATED ALWAYS AS (MONTH(event_time)),"
+            + " day_col INT GENERATED ALWAYS AS (DAY(event_time)))"
+            + " USING DELTA PARTITIONED BY (year_col, month_col, day_col) LOCATION '"
+            + basePath
+            + "'");
+    // One row with a valid timestamp and one row whose timestamp (and therefore every generated
+    // partition column) is null.
+    sparkSession.sql(
+        "INSERT INTO TABLE `"
+            + tableName
+            + "` VALUES (1, CAST('2013-08-20 00:00:00' AS TIMESTAMP)),"
+            + " (2, CAST(NULL AS TIMESTAMP))");
+
+    SourceTable tableConfig =
+        SourceTable.builder()
+            .name(tableName)
+            .basePath(basePath.toString())
+            .formatName(TableFormat.DELTA)
+            .build();
+    DeltaConversionSource conversionSource =
+        conversionSourceProvider.getConversionSourceInstance(tableConfig);
+
+    // Before the fix this call throws while parsing the "null-null-null" partition value.
+    InternalSnapshot snapshot = conversionSource.getCurrentSnapshot();
+
+    List<InternalDataFile> dataFiles =
+        snapshot.getPartitionedDataFiles().stream()
+            .flatMap(group -> group.getDataFiles().stream())
+            .collect(Collectors.toList());
+    assertEquals(2, dataFiles.size());
+
+    // Exactly one file belongs to the null-source partition and its composite partition value is
+    // null rather than a corrupted, parsed-from-"null" value.
+    long nullPartitionFiles =
+        dataFiles.stream()
+            .filter(
+                file ->
+                    file.getPartitionValues().stream()
+                        .anyMatch(pv -> pv.getRange().getMaxValue() == null))
+            .count();
+    assertEquals(1, nullPartitionFiles);
+  }
+
   @ParameterizedTest
   @MethodSource("testWithPartitionToggle")
   public void testInsertsUpsertsAndDeletes(boolean isPartitioned) {

--- a/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
@@ -18,6 +18,9 @@
  
 package org.apache.xtable.delta;
 
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
+import static org.apache.spark.sql.types.DataTypes.LongType;
+import static org.apache.spark.sql.types.DataTypes.TimestampType;
 import static org.apache.xtable.testutil.ITTestUtils.validateTable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -51,6 +54,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import io.delta.tables.DeltaTable;
 
 import org.apache.xtable.GenericTable;
 import org.apache.xtable.TestSparkDeltaTable;
@@ -370,29 +375,38 @@ public class ITDeltaConversionSource {
 
   @Test
   void getCurrentSnapshotGenColPartitionedWithNullSourceTest() {
-    // Reproduces partition value corruption for a composite generated-column partition. The
-    // year/month/day partition columns are all generated from a single source column, so a row
-    // whose source value is null produces null for every component. The extractor must resolve
-    // such a partition value to null instead of joining the components into a string containing
-    // the literal "null" (e.g. "null-null-null") and then failing to parse it as a date.
+    // year/month/day partition columns generated from one source column; a null source produces a
+    // null component for each, which must resolve to a null partition value, not "null-null-null".
     final String tableName = GenericTable.getTableName();
     final Path basePath = tempDir.resolve(tableName);
-    sparkSession.sql(
-        "CREATE TABLE `"
-            + tableName
-            + "` (id BIGINT, event_time TIMESTAMP,"
-            + " year_col INT GENERATED ALWAYS AS (YEAR(event_time)),"
-            + " month_col INT GENERATED ALWAYS AS (MONTH(event_time)),"
-            + " day_col INT GENERATED ALWAYS AS (DAY(event_time)))"
-            + " USING DELTA PARTITIONED BY (year_col, month_col, day_col) LOCATION '"
-            + basePath
-            + "'");
-    // One row with a valid timestamp and one row whose timestamp (and therefore every generated
-    // partition column) is null.
+    // Builder API, not CREATE TABLE SQL: Spark 3.4 rejects generated partition columns via SQL.
+    DeltaTable.createIfNotExists(sparkSession)
+        .tableName(tableName)
+        .location(basePath.toString())
+        .addColumn("id", LongType)
+        .addColumn("event_time", TimestampType)
+        .addColumn(
+            DeltaTable.columnBuilder("year_col")
+                .dataType(IntegerType)
+                .generatedAlwaysAs("YEAR(event_time)")
+                .build())
+        .addColumn(
+            DeltaTable.columnBuilder("month_col")
+                .dataType(IntegerType)
+                .generatedAlwaysAs("MONTH(event_time)")
+                .build())
+        .addColumn(
+            DeltaTable.columnBuilder("day_col")
+                .dataType(IntegerType)
+                .generatedAlwaysAs("DAY(event_time)")
+                .build())
+        .partitionedBy("year_col", "month_col", "day_col")
+        .execute();
+    // Second row has a null timestamp, so every generated partition column is null.
     sparkSession.sql(
         "INSERT INTO TABLE `"
             + tableName
-            + "` VALUES (1, CAST('2013-08-20 00:00:00' AS TIMESTAMP)),"
+            + "` (id, event_time) VALUES (1, CAST('2013-08-20 00:00:00' AS TIMESTAMP)),"
             + " (2, CAST(NULL AS TIMESTAMP))");
 
     SourceTable tableConfig =
@@ -404,7 +418,6 @@ public class ITDeltaConversionSource {
     DeltaConversionSource conversionSource =
         conversionSourceProvider.getConversionSourceInstance(tableConfig);
 
-    // Before the fix this call throws while parsing the "null-null-null" partition value.
     InternalSnapshot snapshot = conversionSource.getCurrentSnapshot();
 
     List<InternalDataFile> dataFiles =
@@ -413,8 +426,7 @@ public class ITDeltaConversionSource {
             .collect(Collectors.toList());
     assertEquals(2, dataFiles.size());
 
-    // Exactly one file belongs to the null-source partition and its composite partition value is
-    // null rather than a corrupted, parsed-from-"null" value.
+    // Exactly one file is in the null-source partition, with a null partition value.
     long nullPartitionFiles =
         dataFiles.stream()
             .filter(

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaPartitionExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaPartitionExtractor.java
@@ -497,6 +497,67 @@ public class TestDeltaPartitionExtractor {
   }
 
   @Test
+  public void testGeneratedPartitionValueExtractionWithMissingComponent() {
+    // A composite (generated column) partition is derived from multiple columns. When one of the
+    // component values is missing from the partition values map the value cannot be reconstructed
+    // and must resolve to null rather than a string containing the literal "null".
+    Map<String, String> partitionValuesMap =
+        new HashMap<String, String>() {
+          {
+            put("partition_column1", "partition_value1");
+            put("year_partition_column", "2013");
+            // month_partition_column is intentionally absent
+            put("day_partition_column", "20");
+          }
+        };
+    scala.collection.mutable.Map<String, String> scalaMap =
+        convertJavaMapToScalaMap(partitionValuesMap);
+    InternalPartitionField internalPartitionField1 =
+        InternalPartitionField.builder()
+            .sourceField(
+                InternalField.builder()
+                    .name("partition_column1")
+                    .schema(
+                        InternalSchema.builder()
+                            .name("string")
+                            .dataType(InternalType.STRING)
+                            .build())
+                    .build())
+            .transformType(PartitionTransformType.VALUE)
+            .build();
+    InternalPartitionField internalPartitionField2 =
+        InternalPartitionField.builder()
+            .sourceField(
+                InternalField.builder()
+                    .name("some_date_column")
+                    .schema(
+                        InternalSchema.builder()
+                            .name("timestamp")
+                            .dataType(InternalType.TIMESTAMP)
+                            .build())
+                    .build())
+            .partitionFieldNames(
+                Arrays.asList(
+                    "year_partition_column", "month_partition_column", "day_partition_column"))
+            .transformType(PartitionTransformType.DAY)
+            .build();
+    List<PartitionValue> expectedPartitionValues =
+        Arrays.asList(
+            PartitionValue.builder()
+                .partitionField(internalPartitionField1)
+                .range(Range.scalar("partition_value1"))
+                .build(),
+            PartitionValue.builder()
+                .partitionField(internalPartitionField2)
+                .range(Range.scalar(null))
+                .build());
+    List<PartitionValue> partitionValues =
+        deltaPartitionExtractor.partitionValueExtraction(
+            scalaMap, Arrays.asList(internalPartitionField1, internalPartitionField2));
+    assertEquals(expectedPartitionValues, partitionValues);
+  }
+
+  @Test
   void convertBucketPartition() {
     InternalPartitionField internalPartitionField =
         InternalPartitionField.builder()

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaPartitionExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaPartitionExtractor.java
@@ -498,11 +498,8 @@ public class TestDeltaPartitionExtractor {
 
   @Test
   public void testGeneratedPartitionValueExtractionWithNullSource() {
-    // A composite (generated column) partition is derived from a single source column (e.g. year,
-    // month and day generated from one timestamp column). When the source value is null all of the
-    // derived component values are null in the Delta partition values. The partition value must
-    // resolve to null rather than a string containing the literal "null" (e.g. "null-null-null")
-    // which would then fail date parsing.
+    // Composite partition whose components (year/month/day) are all null must resolve to a null
+    // partition value, not the literal "null-null-null".
     Map<String, String> partitionValuesMap =
         new HashMap<String, String>() {
           {

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaPartitionExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaPartitionExtractor.java
@@ -497,17 +497,19 @@ public class TestDeltaPartitionExtractor {
   }
 
   @Test
-  public void testGeneratedPartitionValueExtractionWithMissingComponent() {
-    // A composite (generated column) partition is derived from multiple columns. When one of the
-    // component values is missing from the partition values map the value cannot be reconstructed
-    // and must resolve to null rather than a string containing the literal "null".
+  public void testGeneratedPartitionValueExtractionWithNullSource() {
+    // A composite (generated column) partition is derived from a single source column (e.g. year,
+    // month and day generated from one timestamp column). When the source value is null all of the
+    // derived component values are null in the Delta partition values. The partition value must
+    // resolve to null rather than a string containing the literal "null" (e.g. "null-null-null")
+    // which would then fail date parsing.
     Map<String, String> partitionValuesMap =
         new HashMap<String, String>() {
           {
             put("partition_column1", "partition_value1");
-            put("year_partition_column", "2013");
-            // month_partition_column is intentionally absent
-            put("day_partition_column", "20");
+            put("year_partition_column", null);
+            put("month_partition_column", null);
+            put("day_partition_column", null);
           }
         };
     scala.collection.mutable.Map<String, String> scalaMap =

--- a/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelPartitionExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelPartitionExtractor.java
@@ -514,17 +514,19 @@ public class TestDeltaKernelPartitionExtractor {
   }
 
   @Test
-  public void testGeneratedPartitionValueExtractionWithMissingComponent() {
-    // A composite (generated column) partition is derived from multiple columns. When one of the
-    // component values is missing from the partition values map the value cannot be reconstructed
-    // and must resolve to null rather than a string containing the literal "null".
+  public void testGeneratedPartitionValueExtractionWithNullSource() {
+    // A composite (generated column) partition is derived from a single source column (e.g. year,
+    // month and day generated from one timestamp column). When the source value is null all of the
+    // derived component values are null in the Delta partition values. The partition value must
+    // resolve to null rather than a string containing the literal "null" (e.g. "null-null-null")
+    // which would then fail date parsing.
     Map<String, String> partitionValuesMap =
         new HashMap<String, String>() {
           {
             put("partition_column1", "partition_value1");
-            put("year_partition_column", "2013");
-            // month_partition_column is intentionally absent
-            put("day_partition_column", "20");
+            put("year_partition_column", null);
+            put("month_partition_column", null);
+            put("day_partition_column", null);
           }
         };
     java.util.Map<String, String> scalaMap = partitionValuesMap;

--- a/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelPartitionExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelPartitionExtractor.java
@@ -514,6 +514,66 @@ public class TestDeltaKernelPartitionExtractor {
   }
 
   @Test
+  public void testGeneratedPartitionValueExtractionWithMissingComponent() {
+    // A composite (generated column) partition is derived from multiple columns. When one of the
+    // component values is missing from the partition values map the value cannot be reconstructed
+    // and must resolve to null rather than a string containing the literal "null".
+    Map<String, String> partitionValuesMap =
+        new HashMap<String, String>() {
+          {
+            put("partition_column1", "partition_value1");
+            put("year_partition_column", "2013");
+            // month_partition_column is intentionally absent
+            put("day_partition_column", "20");
+          }
+        };
+    java.util.Map<String, String> scalaMap = partitionValuesMap;
+    InternalPartitionField internalPartitionField1 =
+        InternalPartitionField.builder()
+            .sourceField(
+                InternalField.builder()
+                    .name("partition_column1")
+                    .schema(
+                        InternalSchema.builder()
+                            .name("string")
+                            .dataType(InternalType.STRING)
+                            .build())
+                    .build())
+            .transformType(PartitionTransformType.VALUE)
+            .build();
+    InternalPartitionField internalPartitionField2 =
+        InternalPartitionField.builder()
+            .sourceField(
+                InternalField.builder()
+                    .name("some_date_column")
+                    .schema(
+                        InternalSchema.builder()
+                            .name("timestamp")
+                            .dataType(InternalType.TIMESTAMP)
+                            .build())
+                    .build())
+            .partitionFieldNames(
+                Arrays.asList(
+                    "year_partition_column", "month_partition_column", "day_partition_column"))
+            .transformType(PartitionTransformType.DAY)
+            .build();
+    List<PartitionValue> expectedPartitionValues =
+        Arrays.asList(
+            PartitionValue.builder()
+                .partitionField(internalPartitionField1)
+                .range(Range.scalar("partition_value1"))
+                .build(),
+            PartitionValue.builder()
+                .partitionField(internalPartitionField2)
+                .range(Range.scalar(null))
+                .build());
+    List<PartitionValue> partitionValues =
+        deltaKernelPartitionExtractor.partitionValueExtraction(
+            scalaMap, Arrays.asList(internalPartitionField1, internalPartitionField2));
+    assertEquals(expectedPartitionValues, partitionValues);
+  }
+
+  @Test
   void convertBucketPartition() {
     InternalPartitionField internalPartitionField =
         InternalPartitionField.builder()

--- a/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelPartitionExtractor.java
+++ b/xtable-core/src/test/java/org/apache/xtable/kernel/TestDeltaKernelPartitionExtractor.java
@@ -515,11 +515,8 @@ public class TestDeltaKernelPartitionExtractor {
 
   @Test
   public void testGeneratedPartitionValueExtractionWithNullSource() {
-    // A composite (generated column) partition is derived from a single source column (e.g. year,
-    // month and day generated from one timestamp column). When the source value is null all of the
-    // derived component values are null in the Delta partition values. The partition value must
-    // resolve to null rather than a string containing the literal "null" (e.g. "null-null-null")
-    // which would then fail date parsing.
+    // Composite partition whose components (year/month/day) are all null must resolve to a null
+    // partition value, not the literal "null-null-null".
     Map<String, String> partitionValuesMap =
         new HashMap<String, String>() {
           {
@@ -529,7 +526,6 @@ public class TestDeltaKernelPartitionExtractor {
             put("day_partition_column", null);
           }
         };
-    java.util.Map<String, String> scalaMap = partitionValuesMap;
     InternalPartitionField internalPartitionField1 =
         InternalPartitionField.builder()
             .sourceField(
@@ -571,7 +567,7 @@ public class TestDeltaKernelPartitionExtractor {
                 .build());
     List<PartitionValue> partitionValues =
         deltaKernelPartitionExtractor.partitionValueExtraction(
-            scalaMap, Arrays.asList(internalPartitionField1, internalPartitionField2));
+            partitionValuesMap, Arrays.asList(internalPartitionField1, internalPartitionField2));
     assertEquals(expectedPartitionValues, partitionValues);
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

When a Delta table is partitioned by a **composite generated-column** partition — e.g. `year`/`month`/`day` columns all generated from a single source column — the partition extractor reconstructs the partition value by joining the component values with `Collectors.joining("-")`.

If the source column value is null, every generated component is null, and the join produced the literal string `"null-null-null"` (`StringJoiner` renders null elements as `"null"`). That corrupted value was then passed to the date parser, throwing `ParseException: Unable to parse partition value` and failing the snapshot.

This affected both the Spark-based `DeltaPartitionExtractor` and the `DeltaKernelPartitionExtractor`, which carried identical logic. A null partition value is the correct result here: Delta stores null partition values as `null` in the AddFile `partitionValues` map, and the `__HIVE_DEFAULT_PARTITION__` sentinel only ever appears in the physical directory path.

## Brief change log

- `DeltaPartitionExtractor#getSerializedPartitionValue`: return `null` when any component of a composite partition is null, consistent with the single-field branch (`getOrDefault(name, null)`).
- `DeltaKernelPartitionExtractor#getSerializedPartitionValue`: same fix.
- Added regression tests (unit + integration).

## Verify this pull request

- Unit: `testGeneratedPartitionValueExtractionWithNullSource` in both `TestDeltaPartitionExtractor` and `TestDeltaKernelPartitionExtractor` — asserts the composite partition value resolves to `null` instead of `"null-null-null"`.
- Integration: `ITDeltaConversionSource#getCurrentSnapshotGenColPartitionedWithNullSourceTest` — creates a Delta table partitioned by `year`/`month`/`day` generated from a nullable `event_time`, inserts a row with a null timestamp, and verifies the snapshot reads back one file with a null partition value (previously this threw while parsing the partition value).
- Verified locally: `ITDeltaConversionSource` — `Tests run: 15, Failures: 0, Errors: 0`.
