### PR TITLE
[736] Make the bundled xtable-utilities jar runnable again (Hudi 0.x) + CI on branch-0.4

### DIFF
--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -24,10 +24,12 @@ on:
   push:
     branches:
       - "main"
+      - "main-hudi-0x"
 
   pull_request:
     branches:
       - "main"
+      - "main-hudi-0x"
 
 jobs:
   build:

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -24,12 +24,12 @@ on:
   push:
     branches:
       - "main"
-      - "main-hudi-0x"
+      - "branch-0.4"
 
   pull_request:
     branches:
       - "main"
-      - "main-hudi-0x"
+      - "branch-0.4"
 
 jobs:
   build:

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -24,10 +24,12 @@ on:
   push:
     branches:
       - "main"
+      - "main-hudi-0x"
 
   pull_request:
     branches:
       - "main"
+      - "main-hudi-0x"
 
 jobs:
   build:

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -24,12 +24,12 @@ on:
   push:
     branches:
       - "main"
-      - "main-hudi-0x"
+      - "branch-0.4"
 
   pull_request:
     branches:
       - "main"
-      - "main-hudi-0x"
+      - "branch-0.4"
 
 jobs:
   build:

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -222,10 +222,17 @@
             <artifactId>hudi-spark${spark.version.prefix}-bundle_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+          Hudi's ObjectSizeCalculator loads org.openjdk.jol at runtime (not only in tests),
+          so the bundled utilities jar must ship it. The parent dependencyManagement pins
+          jol-core to test scope, so override to runtime here and add it to the shaded
+          artifactSet below. See https://github.com/apache/incubator-xtable/issues/736.
+        -->
         <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
-            <scope>test</scope>
+            <version>${jol.core.version}</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 
@@ -681,6 +688,7 @@
                             <include>org.json4s:json4s-scalap_${scala.binary.version}</include>
                             <include>org.lz4:lz4-java</include>
                             <include>org.objenesis:objenesis</include>
+                            <include>org.openjdk.jol:jol-core</include>
                             <include>org.reactivestreams:reactive-streams</include>
                             <include>org.roaringbitmap:RoaringBitmap</include>
                             <include>org.roaringbitmap:shims</include>
@@ -692,6 +700,7 @@
                             <include>org.scala-lang.modules:scala-xml_${scala.binary.version}</include>
                             <include>org.slf4j:jcl-over-slf4j</include>
                             <include>org.slf4j:jul-to-slf4j</include>
+                            <include>org.slf4j:slf4j-api</include>
                             <include>org.slf4j:slf4j-reload4j</include>
                             <include>org.threeten:threeten-extra</include>
                             <include>org.threeten:threetenbp</include>


### PR DESCRIPTION
Backports #840 to the Hudi 0.x line (`branch-0.4`) for the 0.4.0 release branch.

- **Bundle fix:** the #822 shade allowlist dropped runtime deps, so the bundled jar failed with `NoClassDefFoundError`. Adds `jol-core` (runtime scope + allowlist — the #736 fix) and `slf4j-api`. `hudi-hadoop-common`/`hudi-io` from #840 are skipped (Hudi 1.x only). Validated end-to-end: HUDI → DELTA, ICEBERG, exit 0.
- **CI:** adds `branch-0.4` to Maven CI Build + License Check triggers.
- **Branch protection:** mirrors `main`'s rule in `.asf.yaml`. Inert until it lands on `main` (ASF reads it from the default branch).

Closes #736