### PR TITLE
asf: protect the main-hudi-0x release branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,9 @@ github:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 1
+    main-hudi-0x:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
 notifications:
     commits:      commits@xtable.apache.org
     issues:       commits@xtable.apache.org


### PR DESCRIPTION
Adds branch protection for **`main-hudi-0x`**, mirroring `main`'s rule (1 required approving review).

### Why
Per the [[DISCUSS] rc1 for XTable 0.4.0 thread](https://lists.apache.org/thread/dd020pzf1lkdjpko83rz0hx231m6yrzk), **0.4.0 is cut from the Hudi 0.x line (`main-hudi-0x`)** while v9 (#834) + indexing head to 0.5.0 on `main`. That release branch should have the same protection as `main`.

### Why this is a separate PR against `main`
ASF INFRA reads `.asf.yaml` from the repository's **default branch (`main`)** only. The companion change on the branch itself (#841) is inert for protection purposes, so this one-line change to `main` is what actually enables it. INFRA applies it within a couple of minutes of merge.

Follow-up option: once #841's CI reports on `main-hudi-0x`, we can add `required_status_checks` here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)