### PR TITLE
Mirror GitHub Discussions to dev@xtable.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,4 +39,4 @@ notifications:
     commits:      commits@xtable.apache.org
     issues:       commits@xtable.apache.org
     pullrequests: commits@xtable.apache.org
-    discussions:  commits@xtable.apache.org
+    discussions:  dev@xtable.apache.org


### PR DESCRIPTION
## What

Route the `discussions` notification stream in `.asf.yaml` from `commits@xtable.apache.org` to `dev@xtable.apache.org`.

## Why

ASF Infra's GitHub→mailing-list bridge is driven entirely by the `notifications:` block in `.asf.yaml`. Sending GitHub Discussions to `dev@` makes those threads reflect on [lists.apache.org](https://lists.apache.org/list.html?dev@xtable.apache.org) and become part of the archived, on-list community conversation — the same convention Apache Hudi uses (`discussions → dev@hudi.apache.org`).

Commits, issues, and pull request notifications intentionally stay on `commits@` to keep high-volume bot/label/close/comment traffic off the dev list.

## Notes

- `.asf.yaml` is only read from the default branch, so this takes effect once merged to `main`; Infra reprocesses it automatically (no INFRA ticket required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)