### PR TITLE
Add committer/PMC guidelines to the community website

### DIFF
--- a/website/community/becoming-a-committer.md
+++ b/website/community/becoming-a-committer.md
@@ -98,4 +98,5 @@ documentation:
 - [Apache Hudi](https://hudi.apache.org/contribute/how-to-contribute)
 - [Apache Spark](https://spark.apache.org/committers.html)
 - [ASF Becoming a Committer](https://community.apache.org/contributors/becomingacommitter.html)
+- [ASF Adding Committers](https://community.apache.org/pmc/adding-committers.html)
 - [ASF Voting Process](https://www.apache.org/foundation/voting.html)

--- a/website/community/becoming-a-committer.md
+++ b/website/community/becoming-a-committer.md
@@ -1,0 +1,101 @@
+---
+title: Becoming a Committer
+sidebar_position: 2
+---
+
+# The Path from Contributor to Committer
+
+Apache XTable™ (Incubating) grows through the people who contribute to it. This
+page describes how a contributor becomes a committer, and how a committer
+becomes a PPMC (Podling Project Management Committee) member.
+
+These are guidelines, not a checklist. In the Apache Way, committership is
+earned through sustained, high-quality contribution and is based on merit. It
+is not a reward, a title, or something that can be requested. It reflects the
+trust the community places in someone to help steward the project. Merit does
+not expire.
+
+## Ways to Contribute
+
+Contribution is not limited to code. All of the following build merit in the
+community:
+
+- Submitting pull requests, filing well-scoped bugs, and adding tests.
+- Reviewing others' pull requests and giving thoughtful, constructive
+  feedback. This matters more than ever, as LLMs generate a growing share of
+  the code, careful human review is what safeguards the correctness, quality,
+  and maintainability of the project.
+- Authoring or reviewing design proposals (RFCs) and participating in design
+  discussions.
+- Helping users on the mailing lists, Slack, and GitHub issues, and triaging
+  incoming issues.
+- Improving documentation, the website, and examples.
+- Contributing to releases, testing release candidates, and helping with
+  project infrastructure.
+
+## Becoming a Committer
+
+The PPMC nominates and votes on new committers. When evaluating a candidate,
+the PPMC looks for the following qualities. No single item is required on its
+own; the PPMC weighs them together.
+
+- **Sustained contribution.** A consistent history of meaningful contributions
+  over time, rather than a single large or one-off effort.
+- **Quality.** Contributions are well-tested, well-designed, and maintainable,
+  and generally do not require major rework. The number of contributions
+  matters less than their quality.
+- **Reviewing.** Reviewing is a core responsibility of a committer. A candidate
+  should be able to evaluate others' changes, know the areas where they are
+  qualified to review, and know when to bring in other opinions.
+- **Ownership.** Demonstrated ownership of a component or area, to the point
+  that other contributors naturally route related changes to them.
+- **Community involvement.** An active, helpful, and constructive presence on
+  the mailing lists, Slack, GitHub issues, and community syncs, including helping
+  newer contributors.
+- **Conduct and the Apache Way.** Follows the [ASF Code of
+  Conduct](https://www.apache.org/foundation/policies/conduct), understands
+  Lazy Consensus and project independence, and acts as a good representative of
+  the project.
+
+There is no minimum tenure or minimum number of commits. What matters is that
+the contributor has demonstrated the judgment and reliability expected of a
+committer.
+
+## Becoming a PPMC Member
+
+PPMC members carry the committer responsibilities above, plus responsibility
+for the governance of the project. A committer is typically invited to the PPMC
+after demonstrating good judgment over time and a willingness to take on these
+duties:
+
+- Voting on releases and helping produce them.
+- Upholding the project's legal, license, and trademark responsibilities.
+- Mentoring contributors and helping grow a healthy, vendor-neutral community.
+- Ensuring the project follows Apache norms and processes.
+
+## Nomination and Voting Process
+
+Following Apache convention:
+
+1. Any PPMC member may nominate a candidate.
+2. The discussion and the vote are held on the project's private list
+   (`private@xtable.apache.org`). Discussion of individuals is kept private.
+3. The candidate is confirmed by a majority vote of the PPMC. The vote is held
+   open for at least 72 hours.
+4. If confirmed, the candidate is invited to accept. For new PPMC members, the
+   addition is carried out following the incubator process.
+
+A candidacy is a holistic decision made by the PPMC. Meeting some or all of the
+guidelines above does not guarantee an invitation, and feedback from those who
+have worked most closely with a candidate carries significant weight.
+
+## References
+
+These guidelines are modeled on established Apache projects and ASF community
+documentation:
+
+- [Apache Iceberg](https://iceberg.apache.org/community/)
+- [Apache Hudi](https://hudi.apache.org/contribute/how-to-contribute)
+- [Apache Spark](https://spark.apache.org/committers.html)
+- [ASF Becoming a Committer](https://community.apache.org/contributors/becomingacommitter.html)
+- [ASF Voting Process](https://www.apache.org/foundation/voting.html)

--- a/website/community/sync.md
+++ b/website/community/sync.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Community
 
 We have set up the following regular syncs for community users and developers to meet, interact and exchange ideas. Meetings will be recorded and made available after every sync.


### PR DESCRIPTION
## What

Adds a **Becoming a Committer** page to the community section of the website, documenting the path from contributor to committer and PPMC member.

The page covers:
- Ways to contribute (code, reviews, RFCs, community support, docs, releases)
- Committer criteria — sustained contribution, quality over quantity, reviewing, ownership, community involvement, and conduct
- PPMC member criteria — the governance responsibilities layered on top
- The nomination and voting process, following ASF convention

It also adds a `sidebar_position` to the existing community page so ordering stays stable.

## Why

XTable does not currently document how contributors progress to committer/PPMC. Publishing clear, merit-based guidelines makes the process transparent and fair, and gives contributors a concrete target. This mirrors how established ASF data projects publish theirs (Apache Iceberg, Hudi, Spark).

## Notes for reviewers
- Uses **PPMC** terminology since XTable is incubating (to be updated to PMC at graduation).
- The voting threshold is written as **majority vote, open ≥72 hours** (matching Hudi and the common ASF default). Happy to switch to consensus if the community prefers.
- Verified with `npm run build`; the page renders at `/community/becoming-a-committer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)