### PR TITLE
[MINOR] Require CI status checks to merge (main + branch-0.4)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,19 @@ github:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 1
+      required_status_checks:
+        contexts:
+          - "Maven CI Build"
+          - "License Check"
+    branch-0.4:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_status_checks:
+        contexts:
+          - "Maven CI Build"
+          - "License Check"
+          - "validate-spark-runtime-bundle (3.4.3)"
+          - "validate-spark-runtime-bundle (3.5.9)"
 notifications:
     commits:      commits@xtable.apache.org
     issues:       commits@xtable.apache.org

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -31,6 +31,7 @@ on:
 
 jobs:
   build:
+    name: Maven CI Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -31,6 +31,7 @@ on:
 
 jobs:
   build:
+    name: License Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What

Makes a green build a hard requirement to merge. `.asf.yaml` branch protection is read **only from the default branch (`main`)**. The `main` rules today require only `validate-commit-coauthor` and `validate-pr-title`, so a red Maven build or a failing license check is informational rather than gating. `branch-0.4` has no protection at all.

Required checks after this change:

- **`main`:** `validate-commit-coauthor`, `validate-pr-title` (both existing), plus `Maven CI Build` and `License Check`
- **`branch-0.4`:** `Maven CI Build`, `License Check`, `validate-spark-runtime-bundle (3.4.3)`, `validate-spark-runtime-bundle (3.5.9)`

(The Spark checks are `branch-0.4`-only — there is no spark-runtime module on `main`.)

## Job rename

`Maven CI Build` and `License Check` both used a job named `build`, so both reported the **same** status context `build` and could not be required distinctly. Each now sets a unique job `name`, giving contexts `Maven CI Build` and `License Check`.

## Prerequisites (already met)

- #843 landed on `branch-0.4`, so `spark-runtime-validation.yml` and its `3.4.3` / `3.5.9` matrix exist there.
- The companion `branch-0.4` job rename landed, so the `Maven CI Build` and `License Check` contexts are produced on that branch too.

INFRA applies `.asf.yaml` wholesale on merge, so every context listed above already runs on the branch it is required for.
