### PR TITLE
[infra] Unique job names for Maven CI Build and License Check (branch-0.4)

### DIFF
--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   build:
+    name: Maven CI Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   build:
+    name: License Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Both `mvn-ci-build.yml` and `mvn-license-check.yml` used a job named `build`, so both reported the **same** status-check context `build` and couldn't be required distinctly.

This sets unique job names — `Maven CI Build` and `License Check` — so branch protection can require each. Companion to #848 (the `main` `.asf.yaml` change that marks these checks required for `branch-0.4`). Same rename is included in #848 for `main`.

No behavioral change to the builds themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)