### PR TITLE
fix(release): exclude xtable-service/examples from source tarball and repair deploy_staging_jars.sh

### DIFF
--- a/release/scripts/create_source_release.sh
+++ b/release/scripts/create_source_release.sh
@@ -63,7 +63,8 @@ rsync -a \
   --exclude ".git" --exclude ".gitignore" --exclude ".gitattributes" --exclude ".travis.yml" \
   --exclude ".github" --exclude "target" --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" \
   --exclude "build-target" --exclude ".rubydeps" --exclude "rfc" --exclude "docker/images" \
-  --exclude "assets" --exclude "demo" --exclude "website" --exclude "style/IDE.png" --exclude "xtable-utilities" . apache-xtable-$RELEASE_VERSION
+  --exclude "assets" --exclude "demo" --exclude "website" --exclude "style/IDE.png" --exclude "xtable-utilities" \
+  --exclude "xtable-service/examples" . apache-xtable-$RELEASE_VERSION
 
 tar czf ${RELEASE_DIR}/apache-xtable-${RELEASE_VERSION}.src.tgz apache-xtable-$RELEASE_VERSION
 gpg --armor --local-user E391B3E8179C4FD9BB8BF72002AB8E945EFD1E91 --detach-sig ${RELEASE_DIR}/apache-xtable-${RELEASE_VERSION}.src.tgz

--- a/release/scripts/deploy_staging_jars.sh
+++ b/release/scripts/deploy_staging_jars.sh
@@ -39,18 +39,19 @@ if [ "${1:-}" == "-h" ]; then
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
-<version option>  One of the version options below
-${joined}
 -h, --help
 "
   exit 0
 fi
 
 
-COMMON_OPTIONS="-DdeployArtifacts=true -DskipTests -DretryFailedDeploymentCount=10"
+# -Dmaven.build.cache.enabled=false: the build cache (.mvn/extensions.xml) restores the
+# cached source:jar-no-fork execution and then re-attaches the sources jar, which fails the
+# release build with "duplicated artifacts attached". Disable it for release deploys.
+COMMON_OPTIONS="-DdeployArtifacts=true -DskipTests -DretryFailedDeploymentCount=10 -Dmaven.build.cache.enabled=false"
 echo "Cleaning everything before any deployment"
 $MVN clean $COMMON_OPTIONS
-echo "Building with options
+echo "Building with options"
 $MVN install $COMMON_OPTIONS
 
 echo "Deploying to repository.apache.org with version options"


### PR DESCRIPTION
## What is the purpose of the pull request

Two fixes to `release/scripts/` found while cutting `0.4.0-incubating-rc1`:

1. **create_source_release.sh — exclude `xtable-service/examples`.** That directory (added in #704) contains binary PNG screenshots, so they landed in the source tarball and failed the project's own `validate_source_binary_files.sh` during `validate_staged_release.sh` (an ASF source release must be source-only). Added `--exclude "xtable-service/examples"` alongside the existing exclusions (`assets`, `demo`, `website`, `style/IDE.png`, …); the screenshots stay in the repo but are kept out of the source release.

2. **deploy_staging_jars.sh — make it actually runnable.** It had an unterminated quote (which swallowed the `install`/`deploy` invocations — `bash -n` failed), referenced an undefined `${joined}` under `set -u`, and was not executable. It also needs `-Dmaven.build.cache.enabled=false`: the Maven build cache (`.mvn/extensions.xml`) restores the cached `source:jar-no-fork` execution and then re-attaches the sources jar, failing the release deploy with "duplicated artifacts attached".

## Verify this pull request

- Ran `create_source_release.sh` with the change; confirmed the produced tarball has no `.png`/`examples` paths and passes `validate_source_binary_files.sh`.
- `bash -n deploy_staging_jars.sh` passes; ran the fixed script end-to-end to stage `0.4.0-incubating-rc1` to Nexus (clean → install → deploy, all green, no duplicate-artifacts error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)