### PR TITLE
fix(build): restore delombok execution so release builds generate javadoc jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -715,6 +715,25 @@
             </configuration>
             </plugin>
             <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>${lombok-maven-plugin.version}</version>
+                <configuration>
+                    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+                    <addOutputDirectory>false</addOutputDirectory>
+                    <outputDirectory>${delombok.output.dir}</outputDirectory>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>delombok</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
## What is the purpose of the pull request

`#728` accidentally removed the `lombok-maven-plugin` / `delombok` build execution from the root pom (unrelated to that PR's parquet-source change). The `maven-javadoc-plugin` in the `release` profile documents from `${delombok.output.dir}`; with no delombok step that directory is empty, so `javadoc:jar` produces nothing and **no `-javadoc.jar` artifacts are generated** — a regression from 0.3.0 (which shipped javadoc jars).

This restores the plugin exactly as it was in 0.3.0.

Found while cutting `0.4.0-incubating`: `validate_staged_bundles.sh` failed because the staged Nexus bundle was missing javadoc jars. This targets `branch-0.4` so the 0.4.0 release candidate produces javadoc jars again (a matching PR targets `main` for 0.5.0).

## Verify this pull request

Built `xtable-api` with the release profile and confirmed `delombok` runs and `xtable-api-<version>-javadoc.jar` (~950 KB, real content) is produced; previously no javadoc jar was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)