### PR TITLE
fix(build): restore delombok execution so release builds generate javadoc jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -720,6 +720,25 @@
             </configuration>
             </plugin>
             <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>${lombok-maven-plugin.version}</version>
+                <configuration>
+                    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+                    <addOutputDirectory>false</addOutputDirectory>
+                    <outputDirectory>${delombok.output.dir}</outputDirectory>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>delombok</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
## What is the purpose of the pull request

`#728` accidentally removed the `lombok-maven-plugin` / `delombok` build execution from the root pom. The `maven-javadoc-plugin` in the `release` profile documents from `${delombok.output.dir}`; with no delombok step that directory is empty, so `javadoc:jar` produces nothing and **no `-javadoc.jar` artifacts are generated** — a regression from 0.3.0.

This restores the plugin exactly as it was in 0.3.0. Companion to #853 (same fix on branch-0.4); this one targets main for 0.5.0.

## Verify this pull request

Built `xtable-api` with the release profile and confirmed `delombok` runs and a real `-javadoc.jar` (~950 KB) is produced; previously none was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)