### PR TITLE
[858] Add commit co-author and PR title validation CI checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,6 +38,7 @@ github:
       required_status_checks:
         contexts:
           - validate-commit-coauthor
+          - validate-pr-title
 notifications:
     commits:      commits@xtable.apache.org
     issues:       commits@xtable.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,9 @@ github:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 1
+      required_status_checks:
+        contexts:
+          - validate-commit-coauthor
 notifications:
     commits:      commits@xtable.apache.org
     issues:       commits@xtable.apache.org

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Commit Co-author Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+concurrency:
+  group: commit-coauthor-validation-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+
+jobs:
+  validate-commit-coauthor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commits for Claude co-author trailers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
+          flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:\\s*(claude\\s+(opus|sonnet|haiku|fable|mythos|instant|code|[0-9])|[^\\n]*<noreply@anthropic\\.com>)"; "i")) | .sha')
+
+          if [[ -n "$flagged" ]]; then
+            echo "❌ The following commits contain a Claude co-author trailer:"
+            echo "$flagged"
+            echo ""
+            echo "Commits must not credit Claude as a co-author."
+            echo "Remove the 'Co-authored-by: Claude ...' trailer from the commit message(s),"
+            echo "e.g., by amending the commit or rebasing, and force-push the branch."
+            exit 1
+          fi
+
+          echo "✅ No Claude co-author trailers found."

--- a/.github/workflows/pr_title_validation.yml
+++ b/.github/workflows/pr_title_validation.yml
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: PR Title Validation
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches:
+      - main
+
+concurrency:
+  group: pr-title-validation-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for bracketed PR title format
+        id: check-bracket-format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          title="$PR_TITLE"
+          echo "Checking PR title: $title"
+
+          # GitHub issue reference format: [1234] description
+          if [[ "$title" =~ ^\[[0-9]+\]\ .+ ]]; then
+            echo "✅ Title matches [<issue-number>] format"
+            echo "skip_conventional=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # MINOR format: [MINOR] description
+          if [[ "$title" =~ ^\[MINOR\]\ .+ ]]; then
+            echo "✅ Title matches [MINOR] format"
+            echo "skip_conventional=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Title does not match [<issue-number>]/[MINOR] format, will validate as a conventional commit"
+          echo "skip_conventional=false" >> $GITHUB_OUTPUT
+
+      - name: Validate PR title with Conventional Commits spec
+        if: steps.check-bracket-format.outputs.skip_conventional == 'false'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+          requireScope: false
+          # Be permissive about the subject text itself; only require it be non-empty.
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            is empty. Please provide a meaningful description.
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+          validateSingleCommit: false
+          headerPattern: '^(\w+)(?:\(([^)]+)\))?!?: (.+)$'
+          headerPatternCorrespondence: type,scope,subject


### PR DESCRIPTION
## What

Adds two CI validation workflows (and registers both as required status checks on `main` in `.asf.yaml`), adapted from Apache Hudi's `.github/workflows`:

1. **Commit co-author validation** (`validate-commit-coauthor`)
2. **PR title validation** (`validate-pr-title`)

Closes #858 · adapted from apache/hudi#19134 and apache/hudi `pr_title_validation.yml`.

## Changes

### `.github/workflows/commit_coauthor_validation.yml`
Runs on PRs to `main`, lists the PR's commits via the GitHub API, and fails if any commit message has a `Co-authored-by:` trailer that uses `noreply@anthropic.com` or names a Claude model (opus/sonnet/haiku/fable/mythos/instant/code, or a version number). Prints the offending SHAs and how to fix them. A human co-author with a personal email — even one named "Claude" — is **not** flagged.

### `.github/workflows/pr_title_validation.yml`
Runs on PR open/edit/reopen/synchronize to `main` and accepts a title in any of these forms:
- `[<issue-number>] description` — XTable's common GitHub-issue reference style (e.g. `[858] ...`)
- `[MINOR] description`
- a Conventional Commit — `type(scope): subject` (types: feat, fix, docs, style, refactor, perf, test, build, ci, chore), validated with the pinned `amannn/action-semantic-pull-request` action.

### `.asf.yaml`
Registers both `validate-commit-coauthor` and `validate-pr-title` under `protected_branches.main.required_status_checks.contexts` (this block did not exist before).

## Impact / Risk

CI/process only; no code or user-facing changes. The co-author check is read-only (GitHub API listing of PR commits). Low risk.

## Notes

- The co-author regex is taken from the Hudi PR, verified against positive cases (`Co-authored-by: Claude <noreply@anthropic.com>`, `Claude Opus 4.5`, `claude sonnet`, `Claude 3.7`, `Claude Code`) and negative cases (human co-authors including ones named Claude, and Claude/anthropic mentions outside a trailer).
- XTable PR titles are currently mixed (`[NNN] ...`, `[MINOR] ...`, and Conventional Commits like `fix(delta): ...`); the title check accepts all of these. Titles like dependabot's `Bump X from Y to Z` won't match — apply the `bot`/`ignore-semantic-pull-request` label to skip, or maintainers may prefer to make `validate-pr-title` advisory rather than required.
- Both YAML files were validated locally.
