### PR TITLE
[860] Reuse the Delta snapshot across an incremental backlog

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
@@ -57,12 +57,32 @@ public class DeltaActionsConverter {
       boolean includeColumnStats,
       DeltaPartitionExtractor partitionExtractor,
       DeltaStatsExtractor fileStatsExtractor) {
+    return convertAddActionToInternalDataFile(
+        addFile,
+        tableBasePath(deltaSnapshot),
+        fileFormat,
+        partitionFields,
+        fields,
+        includeColumnStats,
+        partitionExtractor,
+        fileStatsExtractor);
+  }
+
+  public InternalDataFile convertAddActionToInternalDataFile(
+      AddFile addFile,
+      String tableBasePath,
+      FileFormat fileFormat,
+      List<InternalPartitionField> partitionFields,
+      List<InternalField> fields,
+      boolean includeColumnStats,
+      DeltaPartitionExtractor partitionExtractor,
+      DeltaStatsExtractor fileStatsExtractor) {
     FileStats fileStats = fileStatsExtractor.getColumnStatsForFile(addFile, fields);
     List<ColumnStat> columnStats =
         includeColumnStats ? fileStats.getColumnStats() : Collections.emptyList();
     long recordCount = fileStats.getNumRecords();
     return InternalDataFile.builder()
-        .physicalPath(getFullPathToFile(deltaSnapshot, addFile.path()))
+        .physicalPath(getFullPathToFile(tableBasePath, addFile.path()))
         .fileFormat(fileFormat)
         .fileSizeBytes(addFile.size())
         .lastModified(addFile.modificationTime())
@@ -79,8 +99,18 @@ public class DeltaActionsConverter {
       FileFormat fileFormat,
       List<InternalPartitionField> partitionFields,
       DeltaPartitionExtractor partitionExtractor) {
+    return convertRemoveActionToInternalDataFile(
+        removeFile, tableBasePath(deltaSnapshot), fileFormat, partitionFields, partitionExtractor);
+  }
+
+  public InternalDataFile convertRemoveActionToInternalDataFile(
+      RemoveFile removeFile,
+      String tableBasePath,
+      FileFormat fileFormat,
+      List<InternalPartitionField> partitionFields,
+      DeltaPartitionExtractor partitionExtractor) {
     return InternalDataFile.builder()
-        .physicalPath(getFullPathToFile(deltaSnapshot, removeFile.path()))
+        .physicalPath(getFullPathToFile(tableBasePath, removeFile.path()))
         .fileFormat(fileFormat)
         .partitionValues(
             partitionExtractor.partitionValueExtraction(
@@ -99,11 +129,18 @@ public class DeltaActionsConverter {
   }
 
   static String getFullPathToFile(Snapshot snapshot, String dataFilePath) {
-    String tableBasePath = snapshot.deltaLog().dataPath().toUri().toString();
+    return getFullPathToFile(tableBasePath(snapshot), dataFilePath);
+  }
+
+  static String getFullPathToFile(String tableBasePath, String dataFilePath) {
     if (dataFilePath.startsWith(tableBasePath)) {
       return dataFilePath;
     }
     return tableBasePath + Path.SEPARATOR + dataFilePath;
+  }
+
+  private static String tableBasePath(Snapshot snapshot) {
+    return snapshot.deltaLog().dataPath().toUri().toString();
   }
 
   /**
@@ -117,12 +154,21 @@ public class DeltaActionsConverter {
    *     is present
    */
   public String extractDeletionVectorFile(Snapshot snapshot, AddFile addFile) {
+    // Check for the deletion vector before resolving the base path, so an add file without one
+    // never touches the snapshot.
+    if (addFile.deletionVector() == null) {
+      return null;
+    }
+    return extractDeletionVectorFile(tableBasePath(snapshot), addFile);
+  }
+
+  public String extractDeletionVectorFile(String tableBasePath, AddFile addFile) {
     DeletionVectorDescriptor deletionVector = addFile.deletionVector();
     if (deletionVector == null) {
       return null;
     }
 
     String dataFilePath = addFile.path();
-    return getFullPathToFile(snapshot, dataFilePath);
+    return getFullPathToFile(tableBasePath, dataFilePath);
   }
 }

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaActionsConverter.java
@@ -154,11 +154,6 @@ public class DeltaActionsConverter {
    *     is present
    */
   public String extractDeletionVectorFile(Snapshot snapshot, AddFile addFile) {
-    // Check for the deletion vector before resolving the base path, so an add file without one
-    // never touches the snapshot.
-    if (addFile.deletionVector() == null) {
-      return null;
-    }
     return extractDeletionVectorFile(tableBasePath(snapshot), addFile);
   }
 

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -38,6 +38,9 @@ import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.actions.Action;
 import org.apache.spark.sql.delta.actions.AddFile;
+import org.apache.spark.sql.delta.actions.CommitInfo;
+import org.apache.spark.sql.delta.actions.Metadata;
+import org.apache.spark.sql.delta.actions.Protocol;
 import org.apache.spark.sql.delta.actions.RemoveFile;
 
 import scala.Option;
@@ -78,6 +81,13 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   private final String tableName;
   private final String basePath;
 
+  // Cache the version-stable snapshot/table/format across an incremental backlog to avoid
+  // reconstructing the Delta snapshot (a full checkpoint read) on every commit. Invalidated
+  // whenever a commit carries a metadata/protocol change (see getTableChangeForCommit).
+  private Snapshot cachedSnapshot;
+  private InternalTable cachedTable;
+  private FileFormat cachedFileFormat;
+
   @Override
   public InternalTable getTable(Long version) {
     return tableExtractor.table(deltaLog, tableName, version);
@@ -103,10 +113,28 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   @Override
   public TableChange getTableChangeForCommit(Long versionNumber) {
     List<Action> actionsForVersion = getChangesState().getActionsForVersion(versionNumber);
-    Snapshot snapshotAtVersion = deltaLog.getSnapshotAt(versionNumber, Option.empty());
-    InternalTable tableAtVersion = tableExtractor.table(snapshotAtVersion, tableName);
-    FileFormat fileFormat =
-        actionsConverter.convertToFileFormat(snapshotAtVersion.metadata().format().provider());
+    // Reconstructing the snapshot per commit reloads the table checkpoint each time, which is
+    // expensive when the checkpoint is large. Reuse it across the backlog and reload only when a
+    // commit changes schema or protocol.
+    boolean metadataMayHaveChanged =
+        actionsForVersion.stream()
+            .anyMatch(action -> (action instanceof Metadata) || (action instanceof Protocol));
+    if (cachedSnapshot == null || metadataMayHaveChanged) {
+      cachedSnapshot = deltaLog.getSnapshotAt(versionNumber, Option.empty());
+      cachedTable = tableExtractor.table(cachedSnapshot, tableName);
+      cachedFileFormat =
+          actionsConverter.convertToFileFormat(cachedSnapshot.metadata().format().provider());
+    }
+    Snapshot snapshotAtVersion = cachedSnapshot;
+    // The cached snapshot supplies version-stable schema/partitioning/format/base path, but
+    // latestCommitTime is persisted as the incremental-sync watermark, so it must reflect this
+    // commit rather than the (possibly older) cached reload version. Read it from the commit's
+    // CommitInfo, which is already present in the loaded actions.
+    InternalTable tableAtVersion =
+        cachedTable.toBuilder()
+            .latestCommitTime(getCommitTimestamp(versionNumber, actionsForVersion))
+            .build();
+    FileFormat fileFormat = cachedFileFormat;
 
     // All 3 of the following data structures use data file's absolute path as the key
     Map<String, InternalDataFile> addedFiles = new HashMap<>();
@@ -171,6 +199,23 @@ public class DeltaConversionSource implements ConversionSource<Long> {
         .filesDiff(internalFilesDiff)
         .sourceIdentifier(getCommitIdentifier(versionNumber))
         .build();
+  }
+
+  /**
+   * Returns the timestamp of the given commit for use as the incremental-sync watermark. Prefers
+   * the commit's CommitInfo (already loaded in the incremental actions, so no extra checkpoint
+   * read); falls back to the snapshot timestamp only when the commit carries no CommitInfo.
+   */
+  private Instant getCommitTimestamp(long versionNumber, List<Action> actionsForVersion) {
+    for (Action action : actionsForVersion) {
+      if (action instanceof CommitInfo) {
+        Timestamp commitTimestamp = ((CommitInfo) action).timestamp();
+        if (commitTimestamp != null) {
+          return commitTimestamp.toInstant();
+        }
+      }
+    }
+    return Instant.ofEpochMilli(deltaLog.getSnapshotAt(versionNumber, Option.empty()).timestamp());
   }
 
   @Override

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -38,9 +38,7 @@ import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.actions.Action;
 import org.apache.spark.sql.delta.actions.AddFile;
-import org.apache.spark.sql.delta.actions.CommitInfo;
 import org.apache.spark.sql.delta.actions.Metadata;
-import org.apache.spark.sql.delta.actions.Protocol;
 import org.apache.spark.sql.delta.actions.RemoveFile;
 
 import scala.Option;
@@ -81,12 +79,13 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   private final String tableName;
   private final String basePath;
 
-  // Cache the version-stable snapshot/table/format across an incremental backlog to avoid
-  // reconstructing the Delta snapshot (a full checkpoint read) on every commit. Invalidated
-  // whenever a commit carries a metadata/protocol change (see getTableChangeForCommit).
-  private Snapshot cachedSnapshot;
-  private InternalTable cachedTable;
-  private FileFormat cachedFileFormat;
+  // When enabled (default), the table metadata is carried across an incremental backlog instead
+  // of reconstructing the Delta snapshot (a full checkpoint read) on every commit. The baseline
+  // comes from one snapshot read; a commit carrying a Metadata action refreshes the cache from
+  // the action itself (see getTableChangeForCommit).
+  @Builder.Default private final boolean reuseMetadataAcrossCommits = true;
+
+  private Metadata cachedMetadata;
 
   @Override
   public InternalTable getTable(Long version) {
@@ -114,27 +113,34 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   public TableChange getTableChangeForCommit(Long versionNumber) {
     List<Action> actionsForVersion = getChangesState().getActionsForVersion(versionNumber);
     // Reconstructing the snapshot per commit reloads the table checkpoint each time, which is
-    // expensive when the checkpoint is large. Reuse it across the backlog and reload only when a
-    // commit changes schema or protocol.
-    boolean metadataMayHaveChanged =
-        actionsForVersion.stream()
-            .anyMatch(action -> (action instanceof Metadata) || (action instanceof Protocol));
-    if (cachedSnapshot == null || metadataMayHaveChanged) {
-      cachedSnapshot = deltaLog.getSnapshotAt(versionNumber, Option.empty());
-      cachedTable = tableExtractor.table(cachedSnapshot, tableName);
-      cachedFileFormat =
-          actionsConverter.convertToFileFormat(cachedSnapshot.metadata().format().provider());
+    // expensive when the checkpoint is large. Everything the commit conversion needs from the
+    // snapshot derives from the table metadata, so carry that across the backlog instead: one
+    // snapshot read supplies the baseline, and a commit carrying a Metadata action refreshes the
+    // cache from the action itself (mirroring InMemoryLogReplay, the last one in a commit wins).
+    Metadata metadataInCommit = null;
+    for (Action action : actionsForVersion) {
+      if (action instanceof Metadata) {
+        metadataInCommit = (Metadata) action;
+      }
     }
-    Snapshot snapshotAtVersion = cachedSnapshot;
-    // The cached snapshot supplies version-stable schema/partitioning/format/base path, but
-    // latestCommitTime is persisted as the incremental-sync watermark, so it must reflect this
-    // commit rather than the (possibly older) cached reload version. Read it from the commit's
-    // CommitInfo, which is already present in the loaded actions.
+    if (cachedMetadata == null || !reuseMetadataAcrossCommits) {
+      // baseline (or reuse disabled); the snapshot is read for its metadata and not retained
+      cachedMetadata = deltaLog.getSnapshotAt(versionNumber, Option.empty()).metadata();
+    } else if (metadataInCommit != null) {
+      cachedMetadata = metadataInCommit;
+    }
+    String tableBasePath = deltaLog.dataPath().toUri().toString();
+    // latestCommitTime is persisted as the incremental-sync watermark and is matched against
+    // commit-file modification times on the next run (getCommitsBacklog), so it must come from
+    // the same clock: the commit file's mtime, which the changes state already carries.
     InternalTable tableAtVersion =
-        cachedTable.toBuilder()
-            .latestCommitTime(getCommitTimestamp(versionNumber, actionsForVersion))
-            .build();
-    FileFormat fileFormat = cachedFileFormat;
+        tableExtractor.table(
+            cachedMetadata,
+            deltaLog,
+            tableName,
+            getChangesState().getCommitTimestamp(versionNumber));
+    FileFormat fileFormat =
+        actionsConverter.convertToFileFormat(cachedMetadata.format().provider());
 
     // All 3 of the following data structures use data file's absolute path as the key
     Map<String, InternalDataFile> addedFiles = new HashMap<>();
@@ -147,7 +153,7 @@ public class DeltaConversionSource implements ConversionSource<Long> {
         InternalDataFile dataFile =
             actionsConverter.convertAddActionToInternalDataFile(
                 (AddFile) action,
-                snapshotAtVersion,
+                tableBasePath,
                 fileFormat,
                 tableAtVersion.getPartitioningFields(),
                 tableAtVersion.getReadSchema().getAllFields(),
@@ -156,7 +162,7 @@ public class DeltaConversionSource implements ConversionSource<Long> {
                 DeltaStatsExtractor.getInstance());
         addedFiles.put(dataFile.getPhysicalPath(), dataFile);
         String deleteVectorPath =
-            actionsConverter.extractDeletionVectorFile(snapshotAtVersion, (AddFile) action);
+            actionsConverter.extractDeletionVectorFile(tableBasePath, (AddFile) action);
         if (deleteVectorPath != null) {
           deletionVectors.add(deleteVectorPath);
         }
@@ -164,7 +170,7 @@ public class DeltaConversionSource implements ConversionSource<Long> {
         InternalDataFile dataFile =
             actionsConverter.convertRemoveActionToInternalDataFile(
                 (RemoveFile) action,
-                snapshotAtVersion,
+                tableBasePath,
                 fileFormat,
                 tableAtVersion.getPartitioningFields(),
                 DeltaPartitionExtractor.getInstance());
@@ -199,23 +205,6 @@ public class DeltaConversionSource implements ConversionSource<Long> {
         .filesDiff(internalFilesDiff)
         .sourceIdentifier(getCommitIdentifier(versionNumber))
         .build();
-  }
-
-  /**
-   * Returns the timestamp of the given commit for use as the incremental-sync watermark. Prefers
-   * the commit's CommitInfo (already loaded in the incremental actions, so no extra checkpoint
-   * read); falls back to the snapshot timestamp only when the commit carries no CommitInfo.
-   */
-  private Instant getCommitTimestamp(long versionNumber, List<Action> actionsForVersion) {
-    for (Action action : actionsForVersion) {
-      if (action instanceof CommitInfo) {
-        Timestamp commitTimestamp = ((CommitInfo) action).timestamp();
-        if (commitTimestamp != null) {
-          return commitTimestamp.toInstant();
-        }
-      }
-    }
-    return Instant.ofEpochMilli(deltaLog.getSnapshotAt(versionNumber, Option.empty()).timestamp());
   }
 
   @Override

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -43,6 +43,8 @@ import org.apache.spark.sql.delta.actions.RemoveFile;
 
 import scala.Option;
 
+import com.google.common.base.Preconditions;
+
 import io.delta.tables.DeltaTable;
 
 import org.apache.xtable.exception.ReadException;
@@ -79,13 +81,12 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   private final String tableName;
   private final String basePath;
 
-  // When enabled (default), the table metadata is carried across an incremental backlog instead
-  // of reconstructing the Delta snapshot (a full checkpoint read) on every commit. The baseline
-  // comes from one snapshot read; a commit carrying a Metadata action refreshes the cache from
-  // the action itself (see getTableChangeForCommit).
-  @Builder.Default private final boolean reuseMetadataAcrossCommits = true;
+  // See DeltaConversionSourceConfig#REUSE_METADATA_ACROSS_COMMITS.
+  @Builder.Default private final boolean reuseMetadataAcrossCommits = false;
 
+  // Scoped to a single backlog; cleared by resetState.
   private Metadata cachedMetadata;
+  private Long lastProcessedVersion;
 
   @Override
   public InternalTable getTable(Long version) {
@@ -112,35 +113,52 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   @Override
   public TableChange getTableChangeForCommit(Long versionNumber) {
     List<Action> actionsForVersion = getChangesState().getActionsForVersion(versionNumber);
-    // Reconstructing the snapshot per commit reloads the table checkpoint each time, which is
-    // expensive when the checkpoint is large. Everything the commit conversion needs from the
-    // snapshot derives from the table metadata, so carry that across the backlog instead: one
-    // snapshot read supplies the baseline, and a commit carrying a Metadata action refreshes the
-    // cache from the action itself (mirroring InMemoryLogReplay, the last one in a commit wins).
-    Metadata metadataInCommit = null;
-    for (Action action : actionsForVersion) {
-      if (action instanceof Metadata) {
-        metadataInCommit = (Metadata) action;
-      }
-    }
-    if (cachedMetadata == null || !reuseMetadataAcrossCommits) {
-      // baseline (or reuse disabled); the snapshot is read for its metadata and not retained
-      cachedMetadata = deltaLog.getSnapshotAt(versionNumber, Option.empty()).metadata();
-    } else if (metadataInCommit != null) {
-      cachedMetadata = metadataInCommit;
-    }
     String tableBasePath = deltaLog.dataPath().toUri().toString();
-    // latestCommitTime is persisted as the incremental-sync watermark and is matched against
-    // commit-file modification times on the next run (getCommitsBacklog), so it must come from
-    // the same clock: the commit file's mtime, which the changes state already carries.
-    InternalTable tableAtVersion =
-        tableExtractor.table(
-            cachedMetadata,
-            deltaLog,
-            tableName,
-            getChangesState().getCommitTimestamp(versionNumber));
-    FileFormat fileFormat =
-        actionsConverter.convertToFileFormat(cachedMetadata.format().provider());
+    InternalTable tableAtVersion;
+    FileFormat fileFormat;
+    if (reuseMetadataAcrossCommits) {
+      // Everything the conversion needs from the snapshot derives from the table metadata, so
+      // carry that across the backlog rather than re-reading the checkpoint per commit. Walking
+      // backwards would convert a commit with metadata the table did not have yet, and nothing
+      // would correct it, so pin the ordering the SPI does not state.
+      Preconditions.checkArgument(
+          lastProcessedVersion == null || versionNumber >= lastProcessedVersion,
+          String.format(
+              "Version %s is before the last processed version %s. A backlog must be walked in "
+                  + "non-decreasing version order when %s is enabled.",
+              versionNumber,
+              lastProcessedVersion,
+              DeltaConversionSourceConfig.REUSE_METADATA_ACROSS_COMMITS));
+      lastProcessedVersion = versionNumber;
+      Metadata metadataInCommit = null;
+      for (Action action : actionsForVersion) {
+        if (action instanceof Metadata) {
+          // last one in a commit wins, mirroring InMemoryLogReplay
+          metadataInCommit = (Metadata) action;
+        }
+      }
+      if (cachedMetadata == null) {
+        // baseline; the snapshot is read for its metadata and not retained
+        cachedMetadata = deltaLog.getSnapshotAt(versionNumber, Option.empty()).metadata();
+      } else if (metadataInCommit != null) {
+        cachedMetadata = metadataInCommit;
+      }
+      // latestCommitTime is persisted as the sync watermark and matched against commit-file mtimes
+      // on the next run, so it must come from that clock. Snapshot.timestamp() is the same mtime;
+      // the changes state carries it without the read.
+      tableAtVersion =
+          tableExtractor.table(
+              cachedMetadata,
+              deltaLog,
+              tableName,
+              getChangesState().getCommitTimestamp(versionNumber));
+      fileFormat = actionsConverter.convertToFileFormat(cachedMetadata.format().provider());
+    } else {
+      Snapshot snapshotAtVersion = deltaLog.getSnapshotAt(versionNumber, Option.empty());
+      tableAtVersion = tableExtractor.table(snapshotAtVersion, tableName);
+      fileFormat =
+          actionsConverter.convertToFileFormat(snapshotAtVersion.metadata().format().provider());
+    }
 
     // All 3 of the following data structures use data file's absolute path as the key
     Map<String, InternalDataFile> addedFiles = new HashMap<>();
@@ -248,11 +266,17 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   }
 
   private void resetState(long versionToStartFrom) {
+    // The cache is scoped to one backlog, not to the source instance: an embedder holding a source
+    // across syncs can start a later backlog at an earlier version, which would otherwise convert
+    // those commits with newer metadata. Clearing costs one snapshot read per backlog.
+    cachedMetadata = null;
+    lastProcessedVersion = null;
     deltaIncrementalChangesState =
         Optional.of(
             DeltaIncrementalChangesState.builder()
                 .deltaLog(deltaLog)
                 .versionToStartFrom(versionToStartFrom)
+                .loadCommitTimestamps(reuseMetadataAcrossCommits)
                 .build());
   }
 

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSource.java
@@ -117,42 +117,17 @@ public class DeltaConversionSource implements ConversionSource<Long> {
     InternalTable tableAtVersion;
     FileFormat fileFormat;
     if (reuseMetadataAcrossCommits) {
-      // Everything the conversion needs from the snapshot derives from the table metadata, so
-      // carry that across the backlog rather than re-reading the checkpoint per commit. Walking
-      // backwards would convert a commit with metadata the table did not have yet, and nothing
-      // would correct it, so pin the ordering the SPI does not state.
-      Preconditions.checkArgument(
-          lastProcessedVersion == null || versionNumber >= lastProcessedVersion,
-          String.format(
-              "Version %s is before the last processed version %s. A backlog must be walked in "
-                  + "non-decreasing version order when %s is enabled.",
-              versionNumber,
-              lastProcessedVersion,
-              DeltaConversionSourceConfig.REUSE_METADATA_ACROSS_COMMITS));
-      lastProcessedVersion = versionNumber;
-      Metadata metadataInCommit = null;
-      for (Action action : actionsForVersion) {
-        if (action instanceof Metadata) {
-          // last one in a commit wins, mirroring InMemoryLogReplay
-          metadataInCommit = (Metadata) action;
-        }
-      }
-      if (cachedMetadata == null) {
-        // baseline; the snapshot is read for its metadata and not retained
-        cachedMetadata = deltaLog.getSnapshotAt(versionNumber, Option.empty()).metadata();
-      } else if (metadataInCommit != null) {
-        cachedMetadata = metadataInCommit;
-      }
+      Metadata metadataAtVersion = resolveMetadataForCommit(versionNumber, actionsForVersion);
       // latestCommitTime is persisted as the sync watermark and matched against commit-file mtimes
       // on the next run, so it must come from that clock. Snapshot.timestamp() is the same mtime;
       // the changes state carries it without the read.
       tableAtVersion =
           tableExtractor.table(
-              cachedMetadata,
+              metadataAtVersion,
               deltaLog,
               tableName,
               getChangesState().getCommitTimestamp(versionNumber));
-      fileFormat = actionsConverter.convertToFileFormat(cachedMetadata.format().provider());
+      fileFormat = actionsConverter.convertToFileFormat(metadataAtVersion.format().provider());
     } else {
       Snapshot snapshotAtVersion = deltaLog.getSnapshotAt(versionNumber, Option.empty());
       tableAtVersion = tableExtractor.table(snapshotAtVersion, tableName);
@@ -258,6 +233,40 @@ public class DeltaConversionSource implements ConversionSource<Long> {
   @Override
   public String getCommitIdentifier(Long commit) {
     return String.valueOf(commit);
+  }
+
+  /**
+   * Returns the table metadata as of the given commit, reading a snapshot only for the first commit
+   * of a backlog. Everything the conversion needs from the snapshot derives from the table
+   * metadata, so it is carried across the backlog rather than re-read from the checkpoint per
+   * commit, and refreshed from the commit's own metadata action when the schema evolves.
+   */
+  private Metadata resolveMetadataForCommit(Long versionNumber, List<Action> actionsForVersion) {
+    // Walking backwards would convert a commit with metadata the table did not have yet, and
+    // nothing would correct it, so pin the ordering the SPI does not state.
+    Preconditions.checkArgument(
+        lastProcessedVersion == null || versionNumber >= lastProcessedVersion,
+        String.format(
+            "Version %s is before the last processed version %s. A backlog must be walked in "
+                + "non-decreasing version order when %s is enabled.",
+            versionNumber,
+            lastProcessedVersion,
+            DeltaConversionSourceConfig.REUSE_METADATA_ACROSS_COMMITS));
+    lastProcessedVersion = versionNumber;
+    Metadata metadataInCommit = null;
+    for (Action action : actionsForVersion) {
+      if (action instanceof Metadata) {
+        // last one in a commit wins, mirroring InMemoryLogReplay
+        metadataInCommit = (Metadata) action;
+      }
+    }
+    if (cachedMetadata == null) {
+      // baseline; the snapshot is read for its metadata and not retained
+      cachedMetadata = deltaLog.getSnapshotAt(versionNumber, Option.empty()).metadata();
+    } else if (metadataInCommit != null) {
+      cachedMetadata = metadataInCommit;
+    }
+    return cachedMetadata;
   }
 
   private DeltaIncrementalChangesState getChangesState() {

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSourceConfig.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSourceConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.delta;
+
+import java.util.Properties;
+
+import lombok.Value;
+
+/**
+ * Configuration of the Delta source format for the sync process.
+ *
+ * <p>Read from the source table's additional properties, mirroring {@link
+ * DeltaConversionTargetConfig} on the target side.
+ */
+@Value
+public class DeltaConversionSourceConfig {
+  /**
+   * When {@code true}, an incremental backlog carries the table metadata across commits instead of
+   * reconstructing the Delta snapshot for every commit. Defaults to {@code false}.
+   *
+   * <p>Enabling it also moves {@code latestCommitTime} to the commit file's modification time
+   * carried by {@link DeltaIncrementalChangesState} (the same value {@code Snapshot.timestamp()}
+   * returns), at the cost of a second listing of the log per backlog. Setting it back to {@code
+   * false} reverts all three.
+   */
+  public static final String REUSE_METADATA_ACROSS_COMMITS =
+      "xtable.delta.source.reuse_metadata_across_commits";
+
+  boolean reuseMetadataAcrossCommits;
+
+  public static DeltaConversionSourceConfig fromProperties(Properties properties) {
+    boolean reuseMetadataAcrossCommits =
+        properties != null
+            && Boolean.parseBoolean(
+                properties.getProperty(REUSE_METADATA_ACROSS_COMMITS, Boolean.FALSE.toString()));
+    return new DeltaConversionSourceConfig(reuseMetadataAcrossCommits);
+  }
+}

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSourceProvider.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSourceProvider.java
@@ -27,31 +27,19 @@ import org.apache.xtable.conversion.SourceTable;
 
 /** A concrete implementation of {@link ConversionSourceProvider} for Delta Lake table format. */
 public class DeltaConversionSourceProvider extends ConversionSourceProvider<Long> {
-  /**
-   * When true (default), an incremental backlog carries the table metadata across commits instead
-   * of reconstructing the Delta snapshot (a full checkpoint read) for every commit. Set to false to
-   * restore the per-commit snapshot reconstruction.
-   */
-  static final String REUSE_METADATA_ACROSS_COMMITS =
-      "xtable.delta.source.reuse_metadata_across_commits";
-
   @Override
   public DeltaConversionSource getConversionSourceInstance(SourceTable sourceTable) {
     SparkSession sparkSession = DeltaConversionUtils.buildSparkSession(hadoopConf);
     DeltaTable deltaTable = DeltaTable.forPath(sparkSession, sourceTable.getBasePath());
-    boolean reuseMetadataAcrossCommits =
-        sourceTable.getAdditionalProperties() == null
-            || Boolean.parseBoolean(
-                sourceTable
-                    .getAdditionalProperties()
-                    .getProperty(REUSE_METADATA_ACROSS_COMMITS, "true"));
+    DeltaConversionSourceConfig sourceConfig =
+        DeltaConversionSourceConfig.fromProperties(sourceTable.getAdditionalProperties());
     return DeltaConversionSource.builder()
         .sparkSession(sparkSession)
         .tableName(sourceTable.getName())
         .basePath(sourceTable.getBasePath())
         .deltaTable(deltaTable)
         .deltaLog(deltaTable.deltaLog())
-        .reuseMetadataAcrossCommits(reuseMetadataAcrossCommits)
+        .reuseMetadataAcrossCommits(sourceConfig.isReuseMetadataAcrossCommits())
         .build();
   }
 }

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSourceProvider.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaConversionSourceProvider.java
@@ -27,16 +27,31 @@ import org.apache.xtable.conversion.SourceTable;
 
 /** A concrete implementation of {@link ConversionSourceProvider} for Delta Lake table format. */
 public class DeltaConversionSourceProvider extends ConversionSourceProvider<Long> {
+  /**
+   * When true (default), an incremental backlog carries the table metadata across commits instead
+   * of reconstructing the Delta snapshot (a full checkpoint read) for every commit. Set to false to
+   * restore the per-commit snapshot reconstruction.
+   */
+  static final String REUSE_METADATA_ACROSS_COMMITS =
+      "xtable.delta.source.reuse_metadata_across_commits";
+
   @Override
   public DeltaConversionSource getConversionSourceInstance(SourceTable sourceTable) {
     SparkSession sparkSession = DeltaConversionUtils.buildSparkSession(hadoopConf);
     DeltaTable deltaTable = DeltaTable.forPath(sparkSession, sourceTable.getBasePath());
+    boolean reuseMetadataAcrossCommits =
+        sourceTable.getAdditionalProperties() == null
+            || Boolean.parseBoolean(
+                sourceTable
+                    .getAdditionalProperties()
+                    .getProperty(REUSE_METADATA_ACROSS_COMMITS, "true"));
     return DeltaConversionSource.builder()
         .sparkSession(sparkSession)
         .tableName(sourceTable.getName())
         .basePath(sourceTable.getBasePath())
         .deltaTable(deltaTable)
         .deltaLog(deltaTable.deltaLog())
+        .reuseMetadataAcrossCommits(reuseMetadataAcrossCommits)
         .build();
   }
 }

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaIncrementalChangesState.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaIncrementalChangesState.java
@@ -18,6 +18,7 @@
  
 package org.apache.xtable.delta;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -25,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 
 import lombok.Builder;
+
+import org.apache.hadoop.fs.FileStatus;
 
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.actions.Action;
@@ -41,6 +44,7 @@ public class DeltaIncrementalChangesState {
   private final Long endVersion;
 
   private final Map<Long, List<Action>> incrementalChangesByVersion = new HashMap<>();
+  private final Map<Long, Instant> commitTimestampByVersion = new HashMap<>();
 
   /**
    * Reloads the cache store with incremental changes. Intentionally thread safety is the
@@ -60,6 +64,19 @@ public class DeltaIncrementalChangesState {
       incrementalChangesByVersion.put(versionNumber, actions);
       maxSeenVersion =
           maxSeenVersion == null ? versionNumber : Math.max(maxSeenVersion, versionNumber);
+    }
+    // Carry each commit's file modification time alongside its actions. This is the same clock
+    // Snapshot.timestamp() reads and the same one getCommitsBacklog matches the persisted
+    // watermark against, so it stays consistent regardless of the writer's clock. The log has
+    // already been listed once for getChanges above; this second pass reads no file contents.
+    Iterator<Tuple2<Object, FileStatus>> logFiles =
+        JavaConverters.asJavaIteratorConverter(
+                deltaLog.getChangeLogFiles(versionToStartFrom, false))
+            .asJava();
+    while (logFiles.hasNext()) {
+      Tuple2<Object, FileStatus> logFile = logFiles.next();
+      commitTimestampByVersion.put(
+          (Long) logFile._1(), Instant.ofEpochMilli(logFile._2().getModificationTime()));
     }
     startVersion = versionToStartFrom;
     endVersion = maxSeenVersion;
@@ -83,6 +100,14 @@ public class DeltaIncrementalChangesState {
         incrementalChangesByVersion.containsKey(version),
         String.format("Version %s not found in the DeltaIncrementalChangesState.", version));
     return incrementalChangesByVersion.get(version);
+  }
+
+  /** Returns the commit-file modification time of the given version. */
+  public Instant getCommitTimestamp(Long version) {
+    Preconditions.checkArgument(
+        commitTimestampByVersion.containsKey(version),
+        String.format("Version %s not found in the DeltaIncrementalChangesState.", version));
+    return commitTimestampByVersion.get(version);
   }
 
   private List<Tuple2<Long, List<Action>>> getChangesList(

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaIncrementalChangesState.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaIncrementalChangesState.java
@@ -52,9 +52,13 @@ public class DeltaIncrementalChangesState {
    *
    * @param deltaLog The DeltaLog instance.
    * @param versionToStartFrom The version to start from.
+   * @param loadCommitTimestamps whether to also collect each commit file's modification time for
+   *     {@link #getCommitTimestamp(Long)}. Costs a second listing of the log, so callers that
+   *     resolve a snapshot per commit leave it off and read {@code Snapshot.timestamp()}.
    */
   @Builder
-  public DeltaIncrementalChangesState(DeltaLog deltaLog, Long versionToStartFrom) {
+  public DeltaIncrementalChangesState(
+      DeltaLog deltaLog, Long versionToStartFrom, boolean loadCommitTimestamps) {
     List<Tuple2<Long, List<Action>>> changesList =
         getChangesList(deltaLog.getChanges(versionToStartFrom, false));
     Long maxSeenVersion = null;
@@ -65,18 +69,18 @@ public class DeltaIncrementalChangesState {
       maxSeenVersion =
           maxSeenVersion == null ? versionNumber : Math.max(maxSeenVersion, versionNumber);
     }
-    // Carry each commit's file modification time alongside its actions. This is the same clock
-    // Snapshot.timestamp() reads and the same one getCommitsBacklog matches the persisted
-    // watermark against, so it stays consistent regardless of the writer's clock. The log has
-    // already been listed once for getChanges above; this second pass reads no file contents.
-    Iterator<Tuple2<Object, FileStatus>> logFiles =
-        JavaConverters.asJavaIteratorConverter(
-                deltaLog.getChangeLogFiles(versionToStartFrom, false))
-            .asJava();
-    while (logFiles.hasNext()) {
-      Tuple2<Object, FileStatus> logFile = logFiles.next();
-      commitTimestampByVersion.put(
-          (Long) logFile._1(), Instant.ofEpochMilli(logFile._2().getModificationTime()));
+    if (loadCommitTimestamps) {
+      // The same clock Snapshot.timestamp() reads and getCommitsBacklog matches the watermark
+      // against, so it holds regardless of the writer's clock. This pass reads no file contents.
+      Iterator<Tuple2<Object, FileStatus>> logFiles =
+          JavaConverters.asJavaIteratorConverter(
+                  deltaLog.getChangeLogFiles(versionToStartFrom, false))
+              .asJava();
+      while (logFiles.hasNext()) {
+        Tuple2<Object, FileStatus> logFile = logFiles.next();
+        commitTimestampByVersion.put(
+            (Long) logFile._1(), Instant.ofEpochMilli(logFile._2().getModificationTime()));
+      }
     }
     startVersion = versionToStartFrom;
     endVersion = maxSeenVersion;
@@ -102,11 +106,17 @@ public class DeltaIncrementalChangesState {
     return incrementalChangesByVersion.get(version);
   }
 
-  /** Returns the commit-file modification time of the given version. */
+  /**
+   * Returns the commit-file modification time of the given version. Only available when the state
+   * was built with {@code loadCommitTimestamps}.
+   */
   public Instant getCommitTimestamp(Long version) {
     Preconditions.checkArgument(
         commitTimestampByVersion.containsKey(version),
-        String.format("Version %s not found in the DeltaIncrementalChangesState.", version));
+        String.format(
+            "Version %s not found in the DeltaIncrementalChangesState. Timestamps are only "
+                + "collected when the state is built with loadCommitTimestamps.",
+            version));
     return commitTimestampByVersion.get(version);
   }
 

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaTableExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaTableExtractor.java
@@ -25,6 +25,7 @@ import lombok.Builder;
 
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.Snapshot;
+import org.apache.spark.sql.delta.actions.Metadata;
 
 import scala.Option;
 
@@ -76,6 +77,44 @@ public class DeltaTableExtractor {
         .readSchema(schema)
         .latestCommitTime(Instant.ofEpochMilli(snapshot.timestamp()))
         .latestMetadataPath(snapshot.deltaLog().logPath().toString())
+        .build();
+  }
+
+  /**
+   * Builds an {@link InternalTable} from the table's {@link Metadata} directly, without a resolved
+   * {@link Snapshot}. Everything an InternalTable carries is either constant for the table (paths)
+   * or derived from the metadata, so callers that already know the metadata at a version — e.g. an
+   * incremental backlog reusing it across commits — can avoid reconstructing the snapshot.
+   *
+   * @param metadata the table metadata in effect at the commit
+   * @param deltaLog the delta log, used only for the table and log paths
+   * @param tableName name of the table
+   * @param commitTimestamp the commit-file modification time of the commit, used as the
+   *     incremental-sync watermark
+   * @return the internal representation of the table at the commit
+   */
+  public InternalTable table(
+      Metadata metadata, DeltaLog deltaLog, String tableName, Instant commitTimestamp) {
+    if (metadata == null || metadata.schema() == null) {
+      throw new IllegalStateException("Missing metadata/schema for table: " + tableName);
+    }
+    InternalSchema schema = schemaExtractor.toInternalSchema(metadata.schema());
+    List<InternalPartitionField> partitionFields =
+        DeltaPartitionExtractor.getInstance()
+            .convertFromDeltaPartitionFormat(schema, metadata.partitionSchema());
+    DataLayoutStrategy dataLayoutStrategy =
+        !partitionFields.isEmpty()
+            ? DataLayoutStrategy.HIVE_STYLE_PARTITION
+            : DataLayoutStrategy.FLAT;
+    return InternalTable.builder()
+        .tableFormat(TableFormat.DELTA)
+        .basePath(deltaLog.dataPath().toString())
+        .name(tableName)
+        .layoutStrategy(dataLayoutStrategy)
+        .partitioningFields(partitionFields)
+        .readSchema(schema)
+        .latestCommitTime(commitTimestamp)
+        .latestMetadataPath(deltaLog.logPath().toString())
         .build();
   }
 

--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaTableExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaTableExtractor.java
@@ -58,26 +58,11 @@ public class DeltaTableExtractor {
    */
   public InternalTable table(Snapshot snapshot, String tableName) {
     requireMetadata(snapshot, tableName);
-    InternalSchema schema = schemaExtractor.toInternalSchema(snapshot.metadata().schema());
-    List<InternalPartitionField> partitionFields =
-        DeltaPartitionExtractor.getInstance()
-            .convertFromDeltaPartitionFormat(schema, snapshot.metadata().partitionSchema());
-    // Delta follows Hive Style partitioning layout
-    // (https://delta.io/blog/2023-01-18-add-remove-partition-delta-lake/)
-    DataLayoutStrategy dataLayoutStrategy =
-        !partitionFields.isEmpty()
-            ? DataLayoutStrategy.HIVE_STYLE_PARTITION
-            : DataLayoutStrategy.FLAT;
-    return InternalTable.builder()
-        .tableFormat(TableFormat.DELTA)
-        .basePath(snapshot.deltaLog().dataPath().toString())
-        .name(tableName)
-        .layoutStrategy(dataLayoutStrategy)
-        .partitioningFields(partitionFields)
-        .readSchema(schema)
-        .latestCommitTime(Instant.ofEpochMilli(snapshot.timestamp()))
-        .latestMetadataPath(snapshot.deltaLog().logPath().toString())
-        .build();
+    return table(
+        snapshot.metadata(),
+        snapshot.deltaLog(),
+        tableName,
+        Instant.ofEpochMilli(snapshot.timestamp()));
   }
 
   /**
@@ -102,6 +87,8 @@ public class DeltaTableExtractor {
     List<InternalPartitionField> partitionFields =
         DeltaPartitionExtractor.getInstance()
             .convertFromDeltaPartitionFormat(schema, metadata.partitionSchema());
+    // Delta follows Hive Style partitioning layout
+    // (https://delta.io/blog/2023-01-18-add-remove-partition-delta-lake/)
     DataLayoutStrategy dataLayoutStrategy =
         !partitionFields.isEmpty()
             ? DataLayoutStrategy.HIVE_STYLE_PARTITION

--- a/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
@@ -25,6 +25,11 @@ import static org.apache.xtable.testutil.ITTestUtils.validateTable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -54,6 +59,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import org.apache.spark.sql.delta.DeltaLog;
 
 import io.delta.tables.DeltaTable;
 
@@ -828,5 +835,134 @@ public class ITDeltaConversionSource {
             .map(oneDf -> oneDf.getPhysicalPath())
             .collect(Collectors.toSet());
     return filePathsRemoved.contains(activePath);
+  }
+
+  @Test
+  public void getTableChangeForCommitReconstructsSnapshotOnceForAppendOnlyBacklog() {
+    String tableName = GenericTable.getTableName();
+    TestSparkDeltaTable testSparkDeltaTable =
+        new TestSparkDeltaTable(tableName, tempDir, sparkSession, null, false);
+    List<List<String>> allActiveFiles = new ArrayList<>();
+    testSparkDeltaTable.insertRows(50);
+    Long timestamp1 = testSparkDeltaTable.getLastCommitTimestamp();
+    allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
+    testSparkDeltaTable.insertRows(50);
+    allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
+    testSparkDeltaTable.insertRows(50);
+    allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
+    testSparkDeltaTable.insertRows(50);
+    allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
+
+    // Spy the DeltaLog so we can count how many times a snapshot is reconstructed (each
+    // reconstruction reads the table checkpoint from storage).
+    DeltaLog spiedDeltaLog =
+        spy(DeltaLog.forTable(sparkSession, testSparkDeltaTable.getBasePath()));
+    DeltaConversionSource conversionSource =
+        DeltaConversionSource.builder()
+            .sparkSession(sparkSession)
+            .deltaLog(spiedDeltaLog)
+            .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
+            .tableName(tableName)
+            .basePath(testSparkDeltaTable.getBasePath())
+            .build();
+
+    InstantsForIncrementalSync instantsForIncrementalSync =
+        InstantsForIncrementalSync.builder()
+            .lastSyncInstant(Instant.ofEpochMilli(timestamp1))
+            .build();
+    CommitsBacklog<Long> commitsBacklog =
+        conversionSource.getCommitsBacklog(instantsForIncrementalSync);
+    List<TableChange> allTableChanges = new ArrayList<>();
+    for (Long version : commitsBacklog.getCommitsToProcess()) {
+      allTableChanges.add(conversionSource.getTableChangeForCommit(version));
+    }
+
+    // Behaviour is unchanged relative to reconstructing the snapshot per commit.
+    ValidationTestHelper.validateTableChanges(allActiveFiles, allTableChanges);
+    // The backlog spans multiple commits with no schema/protocol change, so the snapshot is
+    // reconstructed exactly once and reused (previously: once per commit).
+    assertTrue(
+        commitsBacklog.getCommitsToProcess().size() >= 2,
+        "backlog must span multiple commits for this assertion to be meaningful");
+    verify(spiedDeltaLog, times(1)).getSnapshotAt(anyLong(), any());
+  }
+
+  @Test
+  public void incrementalSyncWatermarkAdvancesAndDoesNotReprocessSyncedCommits() {
+    String tableName = GenericTable.getTableName();
+    TestSparkDeltaTable testSparkDeltaTable =
+        new TestSparkDeltaTable(tableName, tempDir, sparkSession, null, false);
+    testSparkDeltaTable.insertRows(50);
+    Long syncStart = testSparkDeltaTable.getLastCommitTimestamp();
+    // First backlog: several append-only commits (no schema/protocol change), so the snapshot is
+    // cached and reused across all of them.
+    testSparkDeltaTable.insertRows(50);
+    testSparkDeltaTable.insertRows(50);
+    testSparkDeltaTable.insertRows(50);
+
+    DeltaConversionSource firstRun =
+        DeltaConversionSource.builder()
+            .sparkSession(sparkSession)
+            .deltaLog(DeltaLog.forTable(sparkSession, testSparkDeltaTable.getBasePath()))
+            .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
+            .tableName(tableName)
+            .basePath(testSparkDeltaTable.getBasePath())
+            .build();
+    List<Long> firstVersions =
+        firstRun
+            .getCommitsBacklog(
+                InstantsForIncrementalSync.builder()
+                    .lastSyncInstant(Instant.ofEpochMilli(syncStart))
+                    .build())
+            .getCommitsToProcess();
+    assertTrue(firstVersions.size() >= 3, "first backlog should span multiple commits");
+
+    Instant firstCommitTime = null;
+    Instant watermark = null;
+    for (Long version : firstVersions) {
+      Instant commitTime =
+          firstRun.getTableChangeForCommit(version).getTableAsOfChange().getLatestCommitTime();
+      if (firstCommitTime == null) {
+        firstCommitTime = commitTime;
+      }
+      watermark = commitTime;
+    }
+    // Regression guard: latestCommitTime feeds the persisted sync watermark, so it must advance per
+    // commit even though the snapshot is cached. If it came from the cached reload snapshot, every
+    // commit would report the first version's timestamp and the watermark would not move.
+    assertTrue(
+        !firstCommitTime.equals(watermark),
+        "latestCommitTime did not advance across the cached backlog (watermark stuck at first version)");
+
+    // Append more commits, then sync again from the watermark the first run would have persisted.
+    testSparkDeltaTable.insertRows(50);
+    testSparkDeltaTable.insertRows(50);
+    DeltaConversionSource secondRun =
+        DeltaConversionSource.builder()
+            .sparkSession(sparkSession)
+            .deltaLog(DeltaLog.forTable(sparkSession, testSparkDeltaTable.getBasePath()))
+            .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
+            .tableName(tableName)
+            .basePath(testSparkDeltaTable.getBasePath())
+            .build();
+    List<Long> secondVersions =
+        secondRun
+            .getCommitsBacklog(
+                InstantsForIncrementalSync.builder().lastSyncInstant(watermark).build())
+            .getCommitsToProcess();
+
+    // The second run must not re-process the already-synced tail. (At most the boundary commit may
+    // reappear, since CommitInfo timestamps are the writer's wall-clock rather than the commit
+    // file's mtime; the stuck-watermark bug would instead re-include the whole synced tail.)
+    List<Long> reprocessed = new ArrayList<>(firstVersions);
+    reprocessed.retainAll(secondVersions);
+    assertTrue(
+        reprocessed.size() <= 1,
+        "second run reprocessed already-synced commits: reprocessed="
+            + reprocessed
+            + " first="
+            + firstVersions
+            + " second="
+            + secondVersions);
   }
 }

--- a/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
@@ -26,7 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -864,6 +866,7 @@ public class ITDeltaConversionSource {
             .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
             .tableName(tableName)
             .basePath(testSparkDeltaTable.getBasePath())
+            .reuseMetadataAcrossCommits(true)
             .build();
 
     InstantsForIncrementalSync instantsForIncrementalSync =
@@ -913,6 +916,7 @@ public class ITDeltaConversionSource {
             .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
             .tableName(tableName)
             .basePath(testSparkDeltaTable.getBasePath())
+            .reuseMetadataAcrossCommits(true)
             .build();
 
     CommitsBacklog<Long> commitsBacklog =
@@ -979,10 +983,11 @@ public class ITDeltaConversionSource {
     }
 
     ValidationTestHelper.validateTableChanges(allActiveFiles, allTableChanges);
-    // With reuse disabled, the pre-optimization behaviour is restored: one snapshot
-    // reconstruction per commit.
+    // With reuse disabled the pre-optimization behaviour is restored in full: one snapshot
+    // reconstruction per commit, and no second listing of the log for commit-file mtimes.
     verify(spiedDeltaLog, times(commitsBacklog.getCommitsToProcess().size()))
         .getSnapshotAt(anyLong(), any());
+    verify(spiedDeltaLog, never()).getChangeLogFiles(anyLong(), anyBoolean());
   }
 
   @Test
@@ -1005,6 +1010,7 @@ public class ITDeltaConversionSource {
             .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
             .tableName(tableName)
             .basePath(testSparkDeltaTable.getBasePath())
+            .reuseMetadataAcrossCommits(true)
             .build();
     List<Long> firstVersions =
         firstRun
@@ -1042,6 +1048,7 @@ public class ITDeltaConversionSource {
             .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
             .tableName(tableName)
             .basePath(testSparkDeltaTable.getBasePath())
+            .reuseMetadataAcrossCommits(true)
             .build();
     List<Long> secondVersions =
         secondRun
@@ -1049,9 +1056,12 @@ public class ITDeltaConversionSource {
                 InstantsForIncrementalSync.builder().lastSyncInstant(watermark).build())
             .getCommitsToProcess();
 
-    // The second run must not re-process the already-synced tail. (At most the boundary commit may
-    // reappear, since CommitInfo timestamps are the writer's wall-clock rather than the commit
-    // file's mtime; the stuck-watermark bug would instead re-include the whole synced tail.)
+    // The second run must not re-process the already-synced tail; the stuck-watermark bug would
+    // re-include all of it. The bound is <= 1 rather than 0 because the boundary commit can
+    // legitimately reappear: getActiveCommitAtTime compares against monotonizeCommitTimestamps
+    // output while we persist the raw mtime, so a commit whose mtime tied with its predecessor
+    // resolves to an earlier version. Unchanged from main, where Snapshot.timestamp() is the same
+    // raw mtime. Tightening to isEmpty() would flake on coarse mtime granularity.
     List<Long> reprocessed = new ArrayList<>(firstVersions);
     reprocessed.retainAll(secondVersions);
     assertTrue(

--- a/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/ITDeltaConversionSource.java
@@ -879,12 +879,110 @@ public class ITDeltaConversionSource {
 
     // Behaviour is unchanged relative to reconstructing the snapshot per commit.
     ValidationTestHelper.validateTableChanges(allActiveFiles, allTableChanges);
-    // The backlog spans multiple commits with no schema/protocol change, so the snapshot is
-    // reconstructed exactly once and reused (previously: once per commit).
+    // The backlog spans multiple commits with no schema change, so the baseline snapshot is read
+    // exactly once and its metadata reused (previously: one snapshot reconstruction per commit).
     assertTrue(
         commitsBacklog.getCommitsToProcess().size() >= 2,
         "backlog must span multiple commits for this assertion to be meaningful");
     verify(spiedDeltaLog, times(1)).getSnapshotAt(anyLong(), any());
+  }
+
+  @Test
+  public void schemaChangeMidBacklogRefreshesCachedMetadataWithoutSnapshotReload() {
+    String tableName = GenericTable.getTableName();
+    TestSparkDeltaTable testSparkDeltaTable =
+        new TestSparkDeltaTable(tableName, tempDir, sparkSession, null, false);
+    testSparkDeltaTable.insertRows(50);
+    Long timestamp1 = testSparkDeltaTable.getLastCommitTimestamp();
+    testSparkDeltaTable.insertRows(50);
+    // A metaData action lands mid-backlog in its own commit. Unlike includeAdditionalColumns
+    // (a creation-time flag), this evolves the schema while a single source instance holds a
+    // populated metadata cache.
+    sparkSession.sql(
+        String.format(
+            "ALTER TABLE delta.`%s` ADD COLUMNS (street string)",
+            testSparkDeltaTable.getBasePath()));
+    testSparkDeltaTable.insertRows(50);
+
+    DeltaLog spiedDeltaLog =
+        spy(DeltaLog.forTable(sparkSession, testSparkDeltaTable.getBasePath()));
+    DeltaConversionSource conversionSource =
+        DeltaConversionSource.builder()
+            .sparkSession(sparkSession)
+            .deltaLog(spiedDeltaLog)
+            .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
+            .tableName(tableName)
+            .basePath(testSparkDeltaTable.getBasePath())
+            .build();
+
+    CommitsBacklog<Long> commitsBacklog =
+        conversionSource.getCommitsBacklog(
+            InstantsForIncrementalSync.builder()
+                .lastSyncInstant(Instant.ofEpochMilli(timestamp1))
+                .build());
+    List<Long> versions = commitsBacklog.getCommitsToProcess();
+    // insert, ALTER, insert — in ascending version order
+    assertEquals(3, versions.size(), "expected backlog of insert, alter, insert");
+
+    for (int i = 0; i < versions.size(); i++) {
+      TableChange tableChange = conversionSource.getTableChangeForCommit(versions.get(i));
+      boolean hasNewColumn =
+          tableChange.getTableAsOfChange().getReadSchema().getAllFields().stream()
+              .anyMatch(field -> "street".equals(field.getName()));
+      if (i == 0) {
+        assertFalse(hasNewColumn, "commit before the schema change must not carry the new column");
+      } else {
+        assertTrue(
+            hasNewColumn,
+            String.format("commit at index %d must carry the schema added mid-backlog", i));
+      }
+    }
+    // The refresh comes from the commit's own metaData action, not a snapshot reload: the only
+    // snapshot read is the baseline at the first commit.
+    verify(spiedDeltaLog, times(1)).getSnapshotAt(anyLong(), any());
+  }
+
+  @Test
+  public void reuseMetadataDisabledReconstructsSnapshotPerCommit() {
+    String tableName = GenericTable.getTableName();
+    TestSparkDeltaTable testSparkDeltaTable =
+        new TestSparkDeltaTable(tableName, tempDir, sparkSession, null, false);
+    List<List<String>> allActiveFiles = new ArrayList<>();
+    testSparkDeltaTable.insertRows(50);
+    Long timestamp1 = testSparkDeltaTable.getLastCommitTimestamp();
+    allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
+    testSparkDeltaTable.insertRows(50);
+    allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
+    testSparkDeltaTable.insertRows(50);
+    allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
+
+    DeltaLog spiedDeltaLog =
+        spy(DeltaLog.forTable(sparkSession, testSparkDeltaTable.getBasePath()));
+    DeltaConversionSource conversionSource =
+        DeltaConversionSource.builder()
+            .sparkSession(sparkSession)
+            .deltaLog(spiedDeltaLog)
+            .deltaTable(DeltaTable.forPath(sparkSession, testSparkDeltaTable.getBasePath()))
+            .tableName(tableName)
+            .basePath(testSparkDeltaTable.getBasePath())
+            .reuseMetadataAcrossCommits(false)
+            .build();
+
+    CommitsBacklog<Long> commitsBacklog =
+        conversionSource.getCommitsBacklog(
+            InstantsForIncrementalSync.builder()
+                .lastSyncInstant(Instant.ofEpochMilli(timestamp1))
+                .build());
+    List<TableChange> allTableChanges = new ArrayList<>();
+    for (Long version : commitsBacklog.getCommitsToProcess()) {
+      allTableChanges.add(conversionSource.getTableChangeForCommit(version));
+    }
+
+    ValidationTestHelper.validateTableChanges(allActiveFiles, allTableChanges);
+    // With reuse disabled, the pre-optimization behaviour is restored: one snapshot
+    // reconstruction per commit.
+    verify(spiedDeltaLog, times(commitsBacklog.getCommitsToProcess().size()))
+        .getSnapshotAt(anyLong(), any());
   }
 
   @Test
@@ -894,8 +992,8 @@ public class ITDeltaConversionSource {
         new TestSparkDeltaTable(tableName, tempDir, sparkSession, null, false);
     testSparkDeltaTable.insertRows(50);
     Long syncStart = testSparkDeltaTable.getLastCommitTimestamp();
-    // First backlog: several append-only commits (no schema/protocol change), so the snapshot is
-    // cached and reused across all of them.
+    // First backlog: several append-only commits (no schema change), so the metadata is cached
+    // and reused across all of them.
     testSparkDeltaTable.insertRows(50);
     testSparkDeltaTable.insertRows(50);
     testSparkDeltaTable.insertRows(50);
@@ -928,8 +1026,8 @@ public class ITDeltaConversionSource {
       watermark = commitTime;
     }
     // Regression guard: latestCommitTime feeds the persisted sync watermark, so it must advance per
-    // commit even though the snapshot is cached. If it came from the cached reload snapshot, every
-    // commit would report the first version's timestamp and the watermark would not move.
+    // commit even though the metadata is cached. If it came from the baseline reload version, every
+    // commit would report that version's timestamp and the watermark would not move.
     assertTrue(
         !firstCommitTime.equals(watermark),
         "latestCommitTime did not advance across the cached backlog (watermark stuck at first version)");

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaActionsConverter.java
@@ -45,6 +45,9 @@ class TestDeltaActionsConverter {
     String filePath = "https://container.blob.core.windows.net/tablepath/file_path";
     Snapshot snapshot = Mockito.mock(Snapshot.class);
     DeltaLog deltaLog = Mockito.mock(DeltaLog.class);
+    Mockito.when(snapshot.deltaLog()).thenReturn(deltaLog);
+    Mockito.when(deltaLog.dataPath())
+        .thenReturn(new Path("https://container.blob.core.windows.net/tablepath"));
 
     DeletionVectorDescriptor deletionVector = null;
     AddFile addFileAction =
@@ -58,9 +61,6 @@ class TestDeltaActionsConverter {
     addFileAction =
         new AddFile(filePath, null, size, time, dataChange, stats, null, deletionVector);
 
-    Mockito.when(snapshot.deltaLog()).thenReturn(deltaLog);
-    Mockito.when(deltaLog.dataPath())
-        .thenReturn(new Path("https://container.blob.core.windows.net/tablepath"));
     Assertions.assertEquals(
         filePath, actionsConverter.extractDeletionVectorFile(snapshot, addFileAction));
   }

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaConversionSourceConfig.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaConversionSourceConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.xtable.delta;
+
+import static org.apache.xtable.delta.DeltaConversionSourceConfig.REUSE_METADATA_ACROSS_COMMITS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestDeltaConversionSourceConfig {
+
+  @Test
+  public void nullPropertiesUsesDefault() {
+    assertFalse(DeltaConversionSourceConfig.fromProperties(null).isReuseMetadataAcrossCommits());
+  }
+
+  @Test
+  public void absentKeyUsesDefault() {
+    assertFalse(
+        DeltaConversionSourceConfig.fromProperties(new Properties())
+            .isReuseMetadataAcrossCommits());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "true, true",
+    "TRUE, true",
+    "True, true",
+    "false, false",
+    "FALSE, false",
+    // Boolean.parseBoolean treats anything that is not "true" as false
+    "yes, false"
+  })
+  public void reuseMetadataAcrossCommitsIsParsedFromProperties(String value, boolean expected) {
+    Properties properties = new Properties();
+    properties.setProperty(REUSE_METADATA_ACROSS_COMMITS, value);
+    assertEquals(
+        expected,
+        DeltaConversionSourceConfig.fromProperties(properties).isReuseMetadataAcrossCommits());
+  }
+}


### PR DESCRIPTION
Closes #860.

getTableChangeForCommit reconstructs the table snapshot (deltaLog.getSnapshotAt) for every commit,
which re-reads the Delta checkpoint each time. It's fine when the checkpoint is small, but on a table
with a large checkpoint it becomes the bottleneck for incremental catch-up (see #860).

This caches the snapshot, along with the table and file format derived from it, and reloads it only
when a commit carries a Metadata or Protocol action. Apart from those, the snapshot is only used for
schema, partitioning, file format, and the table base path, which don't change between commits.
getActionsForVersion returns the unfiltered action list, so a schema/protocol change is visible to
the check and forces a reload for that version onward.

The one thing that varies per commit and comes from the snapshot is InternalTable.latestCommitTime
(snapshot.timestamp()). With reuse, intermediate commits report the timestamp of the last reload
rather than their own. If keeping that exact matters, it can come from the commit's CommitInfo
instead — happy to change it if you'd prefer.

Testing:
- Existing ITDeltaConversionSource passes unchanged (15 tests). testAddColumns is the relevant one:
  it adds a column mid-backlog, so if the cache weren't invalidated on the metadata change the later
  commits would carry the old schema and it would fail.
- Added getTableChangeForCommitReconstructsSnapshotOnceForAppendOnlyBacklog: runs a multi-commit
  append backlog through a source built with a spied DeltaLog, checks the table changes still
  validate, and asserts getSnapshotAt is called once rather than once per commit.

On the ~45M-file table from the issue, incremental catch-up went from ~2-3 min/commit to ~3 s/commit
(around 210 commits in ~10 min), with driver memory flat.