### PR TITLE
ci: aggregate gate job + branch-0.4 required checks for spark-runtime

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,17 @@ github:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 1
+    # NOTE: ASF applies these github settings only from the default branch's
+    # .asf.yaml (main), so this branch-0.4 block documents the intended
+    # protection but takes effect via main's .asf.yaml, not this file.
+    branch-0.4:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_status_checks:
+        contexts:
+          - "Maven CI Build"
+          - "License Check"
+          - "spark-runtime-validation-required"
 notifications:
     commits:      commits@xtable.apache.org
     issues:       commits@xtable.apache.org

--- a/.github/workflows/spark-runtime-validation.yml
+++ b/.github/workflows/spark-runtime-validation.yml
@@ -91,3 +91,21 @@ jobs:
         env:
           SPARK_LOCAL_IP: "127.0.0.1"
         run: ./mvnw verify -ntp -B -pl xtable-spark-runtime
+
+  # Single stable status context that aggregates every matrix leg, so branch
+  # protection can require one check name instead of listing each Spark version.
+  # `if: always()` is required: without it this job is skipped when a leg fails,
+  # and a skipped required check leaves the PR stuck on a pending status.
+  spark-runtime-validation-required:
+    needs: validate-spark-runtime-bundle
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all spark-runtime matrix legs to pass
+        run: |
+          result="${{ needs.validate-spark-runtime-bundle.result }}"
+          echo "Aggregated validate-spark-runtime-bundle matrix result: ${result}"
+          if [[ "${result}" != "success" ]]; then
+            echo "One or more validate-spark-runtime-bundle matrix legs did not succeed."
+            exit 1
+          fi


### PR DESCRIPTION
## What

Adds a single aggregate "gate" job to `spark-runtime-validation.yml` so branch protection can require **one stable status context** for the Spark-runtime bundle validation instead of listing every matrix version, plus a `branch-0.4` protection block in `.asf.yaml`.

Follow-up to the review discussion on #848: `.asf.yaml` / GitHub branch protection match required status checks by exact name (no wildcards), so a matrix job forces you to enumerate `validate-spark-runtime-bundle (3.4.3)` and `(3.5.9)` — and re-edit `.asf.yaml` every time the Spark matrix changes.

## Changes

- **`spark-runtime-validation.yml`** — new job `spark-runtime-validation-required` that `needs: validate-spark-runtime-bundle` and fails unless the aggregated matrix result is `success` (`needs.<job>.result` is `success` only when all legs pass). `if: always()` is used deliberately: without it the gate is *skipped* when a leg fails, and a skipped required check leaves a PR stuck on a pending status. The matrix job is unchanged.
- **`.asf.yaml`** — adds a `branch-0.4` `protected_branches` block requiring `Maven CI Build`, `License Check` and `spark-runtime-validation-required`.

## Important caveat on the `.asf.yaml` block

ASF applies `.asf.yaml` `github:` settings (branch protection included) **only from the default branch (`main`)**. This `branch-0.4` block therefore documents the intended protection but does **not** take effect from this file — the effective registration must also live in **`main`'s** `.asf.yaml` (that's what #848 does). Kept here for parity/self-documentation; a maintainer should ensure `main`'s `.asf.yaml` requires `spark-runtime-validation-required` for `branch-0.4` (see the suggestion left on #848).

## Merge order

Merge this gate job first so the `spark-runtime-validation-required` context exists on `branch-0.4`, then require it in `main`'s `.asf.yaml` (#848).

## Testing

YAML validated locally; job graph confirmed (gate depends on the matrix job, `if: always()`, exits non-zero unless aggregated result is `success`); `.asf.yaml` parses and declares the three required contexts for `branch-0.4`.
