### PR TITLE
[864] Make the source release build with mvn package

### DIFF
--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -43,30 +43,15 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      # Anyone building the source release runs `mvn package` without a prior
+      # `mvn install`, so xtable-service has to resolve xtable-core from the
+      # reactor rather than from a repository. Delete locally installed XTable
+      # artifacts first, otherwise the ~/.m2 restored by `cache: maven` hides
+      # such a failure.
+      - name: Verify xtable-service builds without installed XTable artifacts
+        run: |
+          rm -rf ~/.m2/repository/org/apache/xtable
+          ./mvnw clean package -pl xtable-service -am -DskipTests -ntp -B
+
       - name: Build all module with Maven
         run: ./mvnw clean install -ntp -B
-
-  package:
-    name: Maven CI Build (package only)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: maven
-
-      # Anyone building the source release runs `mvn package` without a prior
-      # `mvn install`, so no XTable artifact of this version is available from a
-      # repository and every inter-module dependency has to resolve from the
-      # reactor. Drop locally installed XTable artifacts so the cached ~/.m2 from
-      # the install job above cannot hide such a failure.
-      - name: Remove locally installed XTable artifacts
-        run: rm -rf ~/.m2/repository/org/apache/xtable
-
-      - name: Build all modules without installing them
-        run: ./mvnw clean package -ntp -B -DskipTests

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -45,3 +45,28 @@ jobs:
 
       - name: Build all module with Maven
         run: ./mvnw clean install -ntp -B
+
+  package:
+    name: Maven CI Build (package only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v5
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      # Anyone building the source release runs `mvn package` without a prior
+      # `mvn install`, so no XTable artifact of this version is available from a
+      # repository and every inter-module dependency has to resolve from the
+      # reactor. Drop locally installed XTable artifacts so the cached ~/.m2 from
+      # the install job above cannot hide such a failure.
+      - name: Remove locally installed XTable artifacts
+        run: rm -rf ~/.m2/repository/org/apache/xtable
+
+      - name: Build all modules without installing them
+        run: ./mvnw clean package -ntp -B -DskipTests

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -45,13 +45,16 @@ jobs:
 
       # Anyone building the source release runs `mvn package` without a prior
       # `mvn install`, so xtable-service has to resolve xtable-core from the
-      # reactor rather than from a repository. Delete locally installed XTable
-      # artifacts first, otherwise the ~/.m2 restored by `cache: maven` hides
-      # such a failure.
+      # reactor rather than from a repository. Both caches have to be out of the
+      # way for that to be what is actually exercised: delete locally installed
+      # XTable artifacts, which `cache: maven` would otherwise restore, and
+      # disable the build cache extension, which would otherwise be able to
+      # serve a module from a previous build instead of building it here.
       - name: Verify xtable-service builds without installed XTable artifacts
         run: |
           rm -rf ~/.m2/repository/org/apache/xtable
-          ./mvnw clean package -pl xtable-service -am -DskipTests -ntp -B
+          ./mvnw clean package -pl xtable-service -am -DskipTests -ntp -B \
+            -Dmaven.build.cache.enabled=false
 
       - name: Build all module with Maven
         run: ./mvnw clean install -ntp -B

--- a/.github/workflows/source-build-check.yml
+++ b/.github/workflows/source-build-check.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-name: Maven CI Build
+name: Source Build Check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,7 +30,15 @@ on:
       - "main"
 
 jobs:
-  build:
+  # Whoever builds the source release runs `mvn package` without a prior
+  # `mvn install`, so every inter-module dependency has to resolve from the
+  # reactor. This job reproduces that, and it only does so while nothing can
+  # supply a previously built XTable artifact, hence no `cache: maven` here,
+  # the build cache extension disabled, and the local repository cleared of
+  # XTable artifacts. Adding any form of caching to this job would let it pass
+  # against a source release that does not build.
+  package:
+    name: Build xtable-service without installed XTable artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -41,7 +49,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
 
-      - name: Build all module with Maven
-        run: ./mvnw clean install -ntp -B
+      - name: Build with package only
+        run: |
+          rm -rf ~/.m2/repository/org/apache/xtable
+          ./mvnw clean package -pl xtable-service -am -DskipTests -ntp -B \
+            -Dmaven.build.cache.enabled=false

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dquarkus.bootstrap.effective-model-builder=true

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 -Dquarkus.bootstrap.effective-model-builder=true

--- a/xtable-service/pom.xml
+++ b/xtable-service/pom.xml
@@ -251,13 +251,11 @@
     <build>
         <plugins>
             <!--
-              The quarkus-maven-plugin bootstraps the application to generate code, which means it
-              resolves this module's dependencies on its own. Its default workspace discovery reads
-              the raw poms, so it cannot match xtable-core_${scala.binary.version} against the
-              reactor and falls back to the remote repositories, where that artifact only exists
-              once a release has been published. That makes `mvn package` fail on a source release
-              unless quarkus.bootstrap.effective-model-builder is enabled, so it is set for every
-              build from .mvn/maven.config (Quarkus only reads it as a system property).
+              This plugin resolves the module's dependencies itself, and its workspace discovery
+              only matches xtable-core_${scala.binary.version} against the reactor with
+              quarkus.bootstrap.effective-model-builder enabled. It is a system property, so it is
+              set in .mvn/maven.config rather than here.
+              https://quarkus.io/guides/maven-tooling#bootstrap-maven-properties
             -->
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>

--- a/xtable-service/pom.xml
+++ b/xtable-service/pom.xml
@@ -250,6 +250,15 @@
     </dependencies>
     <build>
         <plugins>
+            <!--
+              The quarkus-maven-plugin bootstraps the application to generate code, which means it
+              resolves this module's dependencies on its own. Its default workspace discovery reads
+              the raw poms, so it cannot match xtable-core_${scala.binary.version} against the
+              reactor and falls back to the remote repositories, where that artifact only exists
+              once a release has been published. That makes `mvn package` fail on a source release
+              unless quarkus.bootstrap.effective-model-builder is enabled, so it is set for every
+              build from .mvn/maven.config (Quarkus only reads it as a system property).
+            -->
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>


### PR DESCRIPTION
Fixes #864

## What is the purpose of the pull request

A source release has to build from its own artifact, and right now it does not. While validating `0.4.0-incubating-rc1`, `./mvnw clean package` on the extracted source tarball fails in `xtable-service`:

```
Failed to execute goal io.quarkus.platform:quarkus-maven-plugin:3.2.12.Final:generate-code-tests
  (default) on project xtable-service: Quarkus code generation phase has failed:
  Failed to bootstrap application in TEST mode: Failed to resolve dependencies for
  org.apache.xtable:xtable-service:jar:0.4.0-incubating: The following artifacts could not be
  resolved: org.apache.xtable:xtable-core_2.12:jar:0.4.0-incubating (absent),
  org.apache.xtable:xtable-core_2.12:jar:tests:0.4.0-incubating (absent)
```

`quarkus-maven-plugin` bootstraps the application in order to generate code, which means it resolves this module's dependencies through Quarkus' own bootstrap resolver instead of through the reactor. That resolver discovers the workspace from the raw poms, without interpolating properties, so the module declaring

```xml
<artifactId>xtable-core_${scala.binary.version}</artifactId>
```

is never matched against the `xtable-core_2.12` dependency. Quarkus then falls back to the remote repositories, where that artifact only exists once a release has been published, so the build of an unpublished release fails. The error names only `xtable-core_2.12`; `xtable-api` and `xtable-hudi-support-utils` have literal artifactIds and resolve from the reactor without trouble.

This stayed invisible because every build path we have runs `mvn install`, which puts `xtable-core` in the local repository and lets Quarkus' repository fallback succeed. Plain `mvn package`, which is what a release validator runs, is the one path never exercised.

## Brief change log

- Set `-Dquarkus.bootstrap.effective-model-builder=true` in `.mvn/maven.config` so Quarkus' workspace discovery uses the effective model and resolves the property. Quarkus reads this only as a JVM system property, so a pom `<properties>` entry has no effect, and `.mvn/` already ships inside the source release tarball so the setting travels with the release. The file carries the ASF header that spotless requires for `**/*.config`; Maven ignores the comment lines.
- Documented the reason above the `quarkus-maven-plugin` declaration in `xtable-service/pom.xml`, with a link to the Quarkus maven tooling guide, since `maven.config` cannot carry comments.
- Added a `Source Build Check` workflow that builds `-pl xtable-service -am` with `package` only. It reports as its own check and runs in parallel with the rest of CI, rather than aborting the main build before any tests run.

The new job deliberately keeps three things out of its way, because any one of them would let it pass against a source release that does not build:

- no `cache: maven`, so no `~/.m2/repository` is restored
- `-Dmaven.build.cache.enabled=false`, since `maven-build-cache-extension` is active from `.mvn/extensions.xml` and can otherwise serve a module from an earlier build instead of building it
- `rm -rf ~/.m2/repository/org/apache/xtable`, kept as insurance so the check cannot quietly stop checking anything if caching is ever added to the job

## Verify this pull request

Verified by building with `package` only, in a tree whose version cannot be resolved from Maven Central or from a stale `~/.m2`:

| Build | Result |
| --- | --- |
| rc1 source tarball, `clean package` | fails, reproduces #864 |
| rc1 source tarball with the property as a pom `<properties>` entry | fails, confirming it has to be a system property |
| rc1 source tarball with `-Dquarkus.bootstrap.effective-model-builder=true` on the command line | succeeds |
| rc1 source tarball with `.mvn/maven.config` | succeeds |
| this branch with `.mvn/maven.config` removed | fails |
| this branch as is | succeeds |

Also confirmed that Maven still applies the property once the ASF header is in `maven.config`: `help:evaluate -Dexpression=quarkus.bootstrap.effective-model-builder` prints `true`.

#868 is the matching PR against `branch-0.4`, where this blocks the 0.4.0 release candidate.
