### PR TITLE
fix date as parition key parsing issue

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/delta/DeltaValueConverter.java
+++ b/xtable-core/src/main/java/org/apache/xtable/delta/DeltaValueConverter.java
@@ -143,7 +143,7 @@ public class DeltaValueConverter {
     }
     if (partitionTransformType == PartitionTransformType.VALUE) {
       if (fieldType == InternalType.DATE) {
-        return LocalDate.ofEpochDay((int) value).toString();
+        return convertDatePartitionValueToString(value);
       } else {
         return value.toString();
       }
@@ -152,6 +152,35 @@ public class DeltaValueConverter {
       DateFormat formatter = getDateFormat(dateFormat);
       return formatter.format(Date.from(Instant.ofEpochMilli((long) value)));
     }
+  }
+
+  /**
+   * Serializes a DATE partition value to the canonical {@code yyyy-MM-dd} string used in the Delta
+   * partition path/log.
+   *
+   * <p>Different conversion sources surface DATE partition values in different runtime forms: the
+   * Iceberg and Delta sources provide an {@link Integer} epoch-day, whereas the Paimon source
+   * provides an already-formatted {@code yyyy-MM-dd} {@link String} (see {@code
+   * PaimonPartitionExtractor#toPartitionValues}, which derives values from {@code
+   * InternalRowPartitionComputer.generatePartValues}). This helper accepts both so the DATE
+   * partition case no longer fails with a {@link ClassCastException}.
+   */
+  private static String convertDatePartitionValueToString(Object value) {
+    if (value instanceof Number) {
+      return LocalDate.ofEpochDay(((Number) value).longValue()).toString();
+    }
+    if (value instanceof String) {
+      // Already an ISO-8601 date; parse to validate and normalize (also tolerates an epoch-day
+      // encoded as a string).
+      String stringValue = ((String) value).trim();
+      try {
+        return LocalDate.parse(stringValue).toString();
+      } catch (DateTimeParseException ex) {
+        return LocalDate.ofEpochDay(Long.parseLong(stringValue)).toString();
+      }
+    }
+    throw new NotSupportedException(
+        "Unsupported DATE partition value type: " + value.getClass().getName());
   }
 
   public static Object convertFromDeltaPartitionValue(

--- a/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaValueConverter.java
+++ b/xtable-core/src/test/java/org/apache/xtable/delta/TestDeltaValueConverter.java
@@ -74,6 +74,34 @@ public class TestDeltaValueConverter {
     assertEquals(fieldValue, internalRepresentation);
   }
 
+  /**
+   * Reproduces the Paimon-source -> Delta-target DATE partition failure.
+   *
+   * <p>{@link org.apache.xtable.paimon.PaimonPartitionExtractor#toPartitionValues} always emits
+   * partition values as {@link String} (via {@code InternalRowPartitionComputer.generatePartValues},
+   * e.g. {@code "2019-10-12"}). When such a value reaches {@code convertToDeltaPartitionValue} for a
+   * DATE partition field with a VALUE transform, the current code executes {@code (int) value} on a
+   * String, throwing a {@link ClassCastException}. DATE as a regular (non-partition) column works
+   * because it flows through the column-stat path with a real epoch-day int.
+   */
+  @ParameterizedTest
+  @MethodSource("datePartitionValues")
+  void convertDatePartitionValueAcrossSourceRepresentations(Object value, String expected) {
+    // Epoch day 18181 == "2019-10-12". Integer form is produced by the Iceberg/Delta sources; the
+    // String form is produced by the Paimon source (InternalRowPartitionComputer.generatePartValues).
+    String deltaRepresentation =
+        DeltaValueConverter.convertToDeltaPartitionValue(
+            value, InternalType.DATE, PartitionTransformType.VALUE, "");
+    assertEquals(expected, deltaRepresentation);
+  }
+
+  private static Stream<Arguments> datePartitionValues() {
+    return Stream.of(
+        Arguments.of(18181, "2019-10-12"), // Integer epoch-day (Iceberg / Delta source)
+        Arguments.of("2019-10-12", "2019-10-12"), // ISO date String (Paimon source)
+        Arguments.of("18181", "2019-10-12")); // epoch-day encoded as String
+  }
+
   @Test
   void parseWrongDateTime() throws ParseException {
     String dateFormatString = "yyyy-MM-dd HH:mm:ss";


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*
PDP side test is in AppendChangelogXTableConversionIT which expose the bit and thus end up with dt as STRING to by pass it. (not a blocker)

## What is the purpose of the pull request

*(For example: This pull request implements the sync for delta format.)*

## Brief change log

*(for example:)*
- *Fixed JSON parsing error when persisting state*
- *Added unit tests for schema evolution*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end.*
- *Added TestConversionController to verify the change.*
- *Manually verified the change by running a job locally.*
