### PR TITLE
[872] Cover 2026 in the NOTICE copyright range and check it at release time

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache XTable (incubating)
-Copyright 2024-2025 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/release/scripts/validate_source_copyright.sh
+++ b/release/scripts/validate_source_copyright.sh
@@ -40,6 +40,41 @@ if [ ! -f "$noticeFile" ]; then
 fi
 echo -e "\t\tNotice file exists ? [OK]\n"
 
+### Checking NOTICE distribution years
+# The copyright range has to cover the year the release is published, otherwise
+# every release cut after a new year ships a stale NOTICE (see XTABLE-692 and the
+# 0.4.0-incubating-rc1 vote). Checking that the file merely exists is not enough.
+echo "Checking NOTICE distribution years"
+currentYear=$(date +%Y)
+inceptionYear=$(sed -n 's:.*<inceptionYear>\(.*\)</inceptionYear>.*:\1:p' ./pom.xml | head -n 1)
+copyrightLine=$(grep -E '^Copyright [0-9]{4}(-[0-9]{4})? The Apache Software Foundation$' "$noticeFile" | head -n 1)
+
+if [ -z "$copyrightLine" ]; then
+  echo "NOTICE does not contain a well-formed copyright line [ERROR]"
+  echo -e "\t\texpected: Copyright ${inceptionYear:-<inceptionYear>}-${currentYear} The Apache Software Foundation"
+  exit 1
+fi
+
+# Keep this portable: BSD/macOS sed has no GNU-style branch chaining, so split the
+# "YYYY" / "YYYY-YYYY" range with parameter expansion instead.
+noticeYears=$(echo "$copyrightLine" | sed -E 's/^Copyright ([0-9]{4}(-[0-9]{4})?) .*/\1/')
+noticeStartYear="${noticeYears%%-*}"
+noticeEndYear="${noticeYears##*-}"
+
+if [ -n "$inceptionYear" ] && [ "$noticeStartYear" != "$inceptionYear" ]; then
+  echo "NOTICE copyright starts at ${noticeStartYear} but pom.xml <inceptionYear> is ${inceptionYear} [ERROR]"
+  echo -e "\t\tfound: ${copyrightLine}"
+  exit 1
+fi
+
+if [ "$noticeEndYear" != "$currentYear" ]; then
+  echo "NOTICE copyright must cover the release year ${currentYear} but ends at ${noticeEndYear} [ERROR]"
+  echo -e "\t\tfound:    ${copyrightLine}"
+  echo -e "\t\texpected: Copyright ${noticeStartYear}-${currentYear} The Apache Software Foundation"
+  exit 1
+fi
+echo -e "\t\tNOTICE copyright covers ${currentYear} ? [OK]\n"
+
 ### Licensing Check
 echo "Performing custom Licensing Check "
 numfilesWithNoLicense=`find . -iname '*' -type f | grep -v NOTICE | grep -v LICENSE | grep -v '.jpg' | grep -v '.json' | grep -v '.hfile' | grep -v '.data' | grep -v '.commit' | grep -v emptyFile | grep -v DISCLAIMER | grep -v KEYS | grep -v '.mailmap' | grep -v '.sqltemplate' | grep -v 'banner.txt' | grep -v "fixtures" | xargs grep -L "Licensed to the Apache Software Foundation (ASF)" | wc -l`


### PR DESCRIPTION
## What

The source `NOTICE` at the repository root still said `Copyright 2024-2025` while 0.4.0-incubating is being released in 2026. Bumps it to `2024-2026` and, more importantly, makes release validation catch this class of drift.

Closes #872

## Why

Raised in the [0.4.0-incubating RC1 vote](https://lists.apache.org/thread/pjl0xgfns56bx219494oc51qnj2mll8b), where "Checked NOTICE file content and distribution years" came back `[KO]`.

Only the hand-maintained root file was stale. The `NOTICE` inside the jars is generated by `maven-remote-resources-plugin` from the current year and already said `2024-2026`, so the source release and the convenience binaries disagreed with each other.

This is the second occurrence: #692 fixed exactly the same thing for 2025. `release/scripts/validate_source_copyright.sh` asserted that `NOTICE` exists but never read it, so nothing stopped a stale copyright range from reaching a vote.

## Changes

- `NOTICE`: copyright range `2024-2025` to `2024-2026`.
- `release/scripts/validate_source_copyright.sh`: after the existing existence check, also verify that the copyright line is well formed, that it **starts** at the `pom.xml` `<inceptionYear>`, and that it **ends** at the year the release is being cut. This script is invoked from `validate_staged_release.sh`, so a stale `NOTICE` now fails release validation instead of surfacing during a vote.

## Testing

Exercised the new check against several `NOTICE` variants:

- `Copyright 2024-2026` (this PR) accepted
- `Copyright 2024-2025` (what RC1 shipped) rejected, "must cover the release year 2026 but ends at 2025"
- `Copyright 2024` rejected, same reason
- `Copyright 2023-2026` rejected, "starts at 2023 but pom.xml `<inceptionYear>` is 2024"
- `(c) 2024-2026 ASF` rejected, "does not contain a well-formed copyright line"

Also ran it against the real `NOTICE` and `pom.xml` in the tree, which reports `[OK]` and exits 0.

Note on portability: the year range is split with bash parameter expansion rather than a GNU `sed` branch, since release managers and verifiers run these scripts on both macOS and Linux.