### PR TITLE
[872] Cover 2026 in the NOTICE copyright range and check it at release time (branch-0.4)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache XTable (incubating)
-Copyright 2024-2025 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/release/scripts/validate_source_copyright.sh
+++ b/release/scripts/validate_source_copyright.sh
@@ -40,6 +40,41 @@ if [ ! -f "$noticeFile" ]; then
 fi
 echo -e "\t\tNotice file exists ? [OK]\n"
 
+### Checking NOTICE distribution years
+# The copyright range has to cover the year the release is published, otherwise
+# every release cut after a new year ships a stale NOTICE (see XTABLE-692 and the
+# 0.4.0-incubating-rc1 vote). Checking that the file merely exists is not enough.
+echo "Checking NOTICE distribution years"
+currentYear=$(date +%Y)
+inceptionYear=$(sed -n 's:.*<inceptionYear>\(.*\)</inceptionYear>.*:\1:p' ./pom.xml | head -n 1)
+copyrightLine=$(grep -E '^Copyright [0-9]{4}(-[0-9]{4})? The Apache Software Foundation$' "$noticeFile" | head -n 1)
+
+if [ -z "$copyrightLine" ]; then
+  echo "NOTICE does not contain a well-formed copyright line [ERROR]"
+  echo -e "\t\texpected: Copyright ${inceptionYear:-<inceptionYear>}-${currentYear} The Apache Software Foundation"
+  exit 1
+fi
+
+# Keep this portable: BSD/macOS sed has no GNU-style branch chaining, so split the
+# "YYYY" / "YYYY-YYYY" range with parameter expansion instead.
+noticeYears=$(echo "$copyrightLine" | sed -E 's/^Copyright ([0-9]{4}(-[0-9]{4})?) .*/\1/')
+noticeStartYear="${noticeYears%%-*}"
+noticeEndYear="${noticeYears##*-}"
+
+if [ -n "$inceptionYear" ] && [ "$noticeStartYear" != "$inceptionYear" ]; then
+  echo "NOTICE copyright starts at ${noticeStartYear} but pom.xml <inceptionYear> is ${inceptionYear} [ERROR]"
+  echo -e "\t\tfound: ${copyrightLine}"
+  exit 1
+fi
+
+if [ "$noticeEndYear" != "$currentYear" ]; then
+  echo "NOTICE copyright must cover the release year ${currentYear} but ends at ${noticeEndYear} [ERROR]"
+  echo -e "\t\tfound:    ${copyrightLine}"
+  echo -e "\t\texpected: Copyright ${noticeStartYear}-${currentYear} The Apache Software Foundation"
+  exit 1
+fi
+echo -e "\t\tNOTICE copyright covers ${currentYear} ? [OK]\n"
+
 ### Licensing Check
 echo "Performing custom Licensing Check "
 numfilesWithNoLicense=`find . -iname '*' -type f | grep -v NOTICE | grep -v LICENSE | grep -v '.jpg' | grep -v '.json' | grep -v '.hfile' | grep -v '.data' | grep -v '.commit' | grep -v emptyFile | grep -v DISCLAIMER | grep -v KEYS | grep -v '.mailmap' | grep -v '.sqltemplate' | grep -v 'banner.txt' | grep -v "fixtures" | xargs grep -L "Licensed to the Apache Software Foundation (ASF)" | wc -l`


### PR DESCRIPTION
## What

Backport of #873 to `branch-0.4` so that 0.4.0-incubating RC2 ships a correct `NOTICE`.

Refs #872

## Why

"Checked NOTICE file content and distribution years" was one of the `[KO]` items in the [0.4.0-incubating RC1 vote](https://lists.apache.org/thread/pjl0xgfns56bx219494oc51qnj2mll8b). RC2 is cut from this branch, so the fix has to land here, not only on `main`.

The root `NOTICE` said `Copyright 2024-2025` while the release is being made in 2026. The `NOTICE` inside the jars is generated by `maven-remote-resources-plugin` and already said `2024-2026`, so the source release and the convenience binaries disagreed.

## Changes

Identical to #873, cherry-picked, applied cleanly since both files matched across branches:

- `NOTICE`: copyright range `2024-2025` to `2024-2026`.
- `release/scripts/validate_source_copyright.sh`: also verify the copyright line is well formed, starts at the `pom.xml` `<inceptionYear>`, and ends at the year the release is being cut. Invoked from `validate_staged_release.sh`, so a stale `NOTICE` now fails release validation rather than surfacing during a vote. #692 fixed the same drift by hand for 2025 with nothing to stop it recurring.

## Testing

Same matrix as #873. Accepts `2024-2026`, rejects `2024-2025` (what RC1 shipped), a bare `2024`, a wrong start year, and a malformed line. Verified against the real `NOTICE` and `pom.xml` on this branch, reports `[OK]` and exits 0.