### PR TITLE
[701] Keep exactly one LICENSE and NOTICE in every published jar (branch-0.4)

### DIFF
--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -50,3 +50,9 @@ jobs:
 
       - name: Validate Shaded Dependency License Metadata
         run: release/scripts/validate_shaded_license_coverage.sh
+
+      # Builds the shaded modules itself if their jars are not present, so it also
+      # covers the shape of the jars we actually publish rather than only the
+      # metadata in the source tree.
+      - name: Validate Jar License Layout
+        run: release/scripts/validate_jar_license_layout.sh

--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,26 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <!--
+                          LICENSE-bundled / NOTICE-bundled are inputs for the shade plugin, not
+                          artifacts in their own right: the shaded jar gets their content written
+                          out as META-INF/LICENSE and META-INF/NOTICE by IncludeResourceTransformer.
+                          Leaving them in the jar produced a second, differently named copy of the
+                          licensing information in every jar, and in the non-shaded jars that copy
+                          described dependencies that are not even present. Excluding them here
+                          keeps them out of both jars while still leaving them in target/classes,
+                          which is where the transformer reads them from.
+                        -->
+                        <excludes>
+                            <exclude>META-INF/LICENSE-bundled</exclude>
+                            <exclude>META-INF/NOTICE-bundled</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <executions>
                         <execution>
@@ -669,6 +689,28 @@
                                             <exclude>META-INF/*.DSA</exclude>
                                             <exclude>META-INF/*.RSA</exclude>
                                             <exclude>**/Log4j2Plugins.dat</exclude>
+                                            <!--
+                                              Licensing information for bundled dependencies belongs in
+                                              META-INF/LICENSE and META-INF/licenses/ and nowhere else.
+                                              DontIncludeResourceTransformer only drops the exact names
+                                              LICENSE, NOTICE and NOTICE.txt, so without these excludes
+                                              the shaded jars also carried each dependency's own copy in
+                                              whatever location it happened to ship it, which made the
+                                              licensing of the bundle very hard to review.
+                                            -->
+                                            <exclude>about_files/**</exclude>
+                                            <exclude>license/**</exclude>
+                                            <exclude>licenses/**</exclude>
+                                            <exclude>META-INF/license/**</exclude>
+                                            <exclude>META-INF/*LICENSE*.txt</exclude>
+                                            <exclude>META-INF/*NOTICE*.txt</exclude>
+                                            <exclude>META-INF/LICENSE.md</exclude>
+                                            <exclude>META-INF/NOTICE.md</exclude>
+                                            <exclude>META-INF/NOTICE.markdown</exclude>
+                                            <exclude>LICENSE.txt</exclude>
+                                            <exclude>LICENSE.md</exclude>
+                                            <exclude>NOTICE.txt</exclude>
+                                            <exclude>NOTICE.md</exclude>
                                         </excludes>
                                     </filter>
                                 </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -697,20 +697,26 @@
                                               the shaded jars also carried each dependency's own copy in
                                               whatever location it happened to ship it, which made the
                                               licensing of the bundle very hard to review.
+
+                                              These are deliberately broad rather than an enumeration of
+                                              the suffixes seen so far: dependencies use names like
+                                              LICENSE.txt, LICENSE-junit.txt, META-INF/ASM_LICENSE.txt and
+                                              META-INF/NOTICE.markdown, and which of them show up changes
+                                              with the dependency tree, so branch-0.4 and main did not even
+                                              produce the same set. Our own META-INF/LICENSE and
+                                              META-INF/NOTICE are written by IncludeResourceTransformer, and
+                                              META-INF/licenses/ has a path segment of its own, so none of
+                                              these patterns can match what we ship.
                                             -->
                                             <exclude>about_files/**</exclude>
                                             <exclude>license/**</exclude>
                                             <exclude>licenses/**</exclude>
                                             <exclude>META-INF/license/**</exclude>
-                                            <exclude>META-INF/*LICENSE*.txt</exclude>
-                                            <exclude>META-INF/*NOTICE*.txt</exclude>
-                                            <exclude>META-INF/LICENSE.md</exclude>
-                                            <exclude>META-INF/NOTICE.md</exclude>
-                                            <exclude>META-INF/NOTICE.markdown</exclude>
-                                            <exclude>LICENSE.txt</exclude>
-                                            <exclude>LICENSE.md</exclude>
-                                            <exclude>NOTICE.txt</exclude>
-                                            <exclude>NOTICE.md</exclude>
+                                            <exclude>META-INF/*LICENSE*</exclude>
+                                            <exclude>META-INF/*NOTICE*</exclude>
+                                            <exclude>LICENSE*</exclude>
+                                            <exclude>NOTICE*</exclude>
+                                            <exclude>COPYING*</exclude>
                                         </excludes>
                                     </filter>
                                 </filters>

--- a/release/scripts/validate_jar_license_layout.sh
+++ b/release/scripts/validate_jar_license_layout.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Asserts that every jar we publish carries its licensing information in exactly
+# one canonical place: META-INF/LICENSE, META-INF/NOTICE and, for the shaded
+# bundles, the third party texts under META-INF/licenses/.
+#
+# This exists because the layout regressed silently across several releases
+# (XTABLE-701): every jar shipped a second, differently named copy of the
+# licensing information as META-INF/LICENSE-bundled and META-INF/NOTICE-bundled,
+# and the shaded jars additionally carried each bundled dependency's own license
+# file in whatever location that dependency happened to use, which made the
+# licensing of a bundle very hard to review.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+# Entries a jar is allowed to carry. Anything else that looks like licensing
+# information is a finding: it means the information is duplicated, or filed
+# somewhere a reviewer will not think to look.
+is_allowed_entry() {
+  case "$1" in
+    META-INF/LICENSE|META-INF/NOTICE|META-INF/DISCLAIMER|META-INF/DISCLAIMER-WIP|META-INF/DEPENDENCIES)
+      return 0
+      ;;
+    META-INF/licenses/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# xtable-utilities is not a release artifact: maven-deploy-plugin is skipped for
+# it, and create_source_release.sh leaves it out of the source tarball. Its shaded
+# jar has no META-INF/LICENSE at all, which is worth fixing on its own but is not
+# part of the published set that XTABLE-701 is about. validate_shaded_license_
+# coverage.sh skips it for the same reason.
+SKIPPED_MODULES=(
+  "xtable-utilities"
+)
+
+discover_jars() {
+  local skip_pattern
+  skip_pattern="$(printf '%s\n' "${SKIPPED_MODULES[@]}" | paste -sd'|' -)"
+  find . -type f -name '*.jar' 2>/dev/null \
+    | grep -E '/target/[^/]+\.jar$' \
+    | grep -vE '\-(sources|javadoc)\.jar$' \
+    | grep -vE '/target/original-' \
+    | grep -vE "^\./(${skip_pattern})/" \
+    | sort
+}
+
+# Only the shaded modules, never the whole reactor: xtable-service needs a newer
+# JDK than the one this runs under in CI, and it produces no shaded jar anyway.
+shade_modules() {
+  grep -rl '<artifactId>maven-shade-plugin</artifactId>' --include=pom.xml . \
+    | xargs -n1 dirname \
+    | sed 's|^\./||' \
+    | grep -v '^\.$' \
+    | sort -u \
+    | paste -sd, -
+}
+
+jars=("$@")
+
+if [[ ${#jars[@]} -eq 0 ]]; then
+  while IFS= read -r jar; do
+    jars+=("${jar}")
+  done < <(discover_jars)
+fi
+
+if [[ ${#jars[@]} -eq 0 ]]; then
+  modules="$(shade_modules)"
+  echo "No jars found under */target, building the shaded modules first: ${modules}"
+  ./mvnw -q package -B -DskipTests -Dmaven.build.cache.enabled=false -pl "${modules}" -am
+  while IFS= read -r jar; do
+    jars+=("${jar}")
+  done < <(discover_jars)
+fi
+
+if [[ ${#jars[@]} -eq 0 ]]; then
+  echo "No jars found under */target even after building. Pass jar paths as arguments."
+  exit 1
+fi
+
+overall_status=0
+
+for jar in "${jars[@]}"; do
+  if [[ ! -f "${jar}" ]]; then
+    echo "FAIL ${jar}: not a file."
+    overall_status=1
+    continue
+  fi
+
+  # original-*.jar is the pre-shade copy the shade plugin leaves behind, it is
+  # never published.
+  case "$(basename "${jar}")" in
+    original-*) continue ;;
+  esac
+
+  entries="$(unzip -Z1 "${jar}" | grep -v '/$' || true)"
+
+  # Only consider entries that look like licensing information. Class files that
+  # merely contain the word "license" in their name are not interesting here.
+  # Deliberately matches the words anywhere in the path, not just at a path
+  # boundary: dependencies ship things like META-INF/ASM_LICENSE.txt and
+  # META-INF/CLI-LICENSE.txt, which a boundary-anchored pattern would miss.
+  candidates="$(printf '%s\n' "${entries}" \
+    | grep -vE '\.class$' \
+    | grep -iE '(licen[cs]e|notice|disclaimer|copying)|(^|/)about_files/' \
+    || true)"
+
+  findings=()
+  while IFS= read -r entry; do
+    [[ -z "${entry}" ]] && continue
+    if ! is_allowed_entry "${entry}"; then
+      findings+=("${entry}")
+    fi
+  done < <(printf '%s\n' "${candidates}")
+
+  # Match in the shell rather than piping into "grep -q": grep exits on the first
+  # match, the writer then takes SIGPIPE, and under "set -o pipefail" the whole
+  # pipeline reports failure. That only shows up on the big shaded jars, where the
+  # writer has not finished yet, so it would fail intermittently and only for the
+  # bundles.
+  if [[ $'\n'${entries}$'\n' != *$'\n'"META-INF/LICENSE"$'\n'* ]]; then
+    echo "FAIL $(basename "${jar}"): META-INF/LICENSE is missing."
+    overall_status=1
+    continue
+  fi
+
+  if [[ ${#findings[@]} -gt 0 ]]; then
+    echo "FAIL $(basename "${jar}"): licensing information outside the canonical locations:"
+    printf '  - %s\n' "${findings[@]}"
+    overall_status=1
+  else
+    texts="$(printf '%s\n' "${entries}" | grep -c '^META-INF/licenses/' || true)"
+    echo "OK   $(basename "${jar}"): META-INF/LICENSE, META-INF/NOTICE, ${texts} bundled license text(s)."
+  fi
+done
+
+exit "${overall_status}"


### PR DESCRIPTION
## What

`branch-0.4` copy of #876, so that 0.4.0-incubating RC2 ships the fixed jar layout: exactly one `META-INF/LICENSE`, one `META-INF/NOTICE`, third party texts only under `META-INF/licenses/`.

Refs #701. See #876 for the full root cause writeup.

## Why

Both binding voters hit this in the [RC1 vote](https://lists.apache.org/thread/pjl0xgfns56bx219494oc51qnj2mll8b): Stamatis cited #701 as `[4]` in his `-1`, noting these issues "persist across releases", and JB noted that META-INF carries both LICENSE and LICENSE-bundled and "seems to be redundant". RC2 is cut from this branch, so the fix has to land here too.

## Changes

Identical to #876:

- `maven-jar-plugin` excludes `META-INF/LICENSE-bundled` and `META-INF/NOTICE-bundled` from the jar. They stay in `target/classes`, where `IncludeResourceTransformer` reads them, so bundles keep the dependency listing and non-shaded jars keep the plain Apache-2.0 text.
- Shade filters drop dependency license files that land outside the canonical locations.
- New `release/scripts/validate_jar_license_layout.sh`, wired into the License Check workflow.

Files under `src/main/resources/META-INF` are not moved, so `validate_shaded_license_coverage.sh` is unaffected and this does not overlap #857.

## Verification

Rebuilt every shaded module from clean. Non-shaded jars: bare Apache-2.0, 202 lines, 0 dependency coordinates. Bundles: Apache-2.0 plus the listing, 56 coordinates for aws, 183 for hive-metastore, 13 for hudi-support-extensions, 8 for spark-runtime. No `-bundled` file in any jar, `META-INF/NOTICE` intact, and `hive-metastore-bundled` went from 19 non-canonical license files to zero. Against the real 0.4.0-incubating-rc1 artifacts the new script reports all 21 offending entries.

## Known gaps

Non-shaded jars still carry `META-INF/licenses/`, and `xtable-utilities-bundled` has no `META-INF/LICENSE` at all. Both are described in #876 and are better handled after #857 lands.