### PR TITLE
[site] Fix CSP violations on the 404 page

### DIFF
--- a/website/homepage/404.html
+++ b/website/homepage/404.html
@@ -11,22 +11,18 @@
   <link href="css/normalize.css" rel="stylesheet" type="text/css">
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/onetable-ad267e.webflow.css" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com" rel="preconnect">
-  <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin="anonymous">
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
-  <script type="text/javascript">WebFont.load({  google: {    families: ["Material Icons:regular"]  }});</script>
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/xtable-favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
 </head>
 <body>
   <div class="utility-page-wrap">
-    <div class="utility-page-content"><img src="https://d3e54v103j8qbb.cloudfront.net/static/page-not-found.211a85e40c.svg" alt="">
+    <div class="utility-page-content"><img src="images/page-not-found.svg" alt="">
       <h2>Page Not Found</h2>
       <div>The page you are looking for doesn&#x27;t exist or has been moved</div>
     </div>
   </div>
-  <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=65402b66d39d6454e51fabed" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+  <script src="js/jquery-3.5.1.min.js" type="text/javascript"></script>
   <script src="js/webflow.js" type="text/javascript"></script>
 </body>
 </html>

--- a/website/static/images/page-not-found.svg
+++ b/website/static/images/page-not-found.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="47px" height="59px" viewBox="0 0 47 59" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41 (35326) - http://www.bohemiancoding.com/sketch -->
+    <title>404 icon</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard-Copy-2" transform="translate(-293.000000, -195.000000)" fill="#333333">
+            <path d="M293,195 L323.5,195 L340,211.5 L340,254 L293,254 L293,195 Z M314,214 L319,214 L319,229 L314,229 L314,214 Z M314,234 L319,234 L319,239 L314,239 L314,234 Z" id="404-icon"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## What

The 404 page loads three third-party resources that the ASF Content-Security-Policy blocks. In production it renders with a broken illustration placeholder and console errors.

| Resource | Line | Purpose |
|---|---|---|
| `ajax.googleapis.com/.../webfont.js` + `WebFont.load(...)` | 16-17 | Material Icons loader |
| `fonts.googleapis.com` / `fonts.gstatic.com` preconnects | 14-15 | for the above |
| `d3e54v103j8qbb.cloudfront.net/static/page-not-found...svg` | 24 | "page not found" illustration |
| `d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min...js` | 29 | jQuery |

## Why it came back

#764 removed exactly these from the home page, but it did so by deleting `static/404.html` outright. #863 then reintroduced the page at `homepage/404.html` from the pre-#764 Webflow export, which brought the CDN references back with it.

## Changes

Same treatment #764 gave the home page:

- **Font loader** — deleted. The 404 page has no Material Icons ligatures on it at all (no FAQ accordions), so it was dead weight even before CSP.
- **jQuery** — repointed at `js/jquery-3.5.1.min.js`, the copy #764 already vendored into `static/js/`.
- **Illustration** — vendored the 754-byte SVG to `static/images/page-not-found.svg`. Keeping it as a file rather than inlining it means no layout change, no new CSS, and no inline `style` attribute. RAT excludes `**/website/**` and `Github.svg` / `linkedin.svg` / `twitter.svg` already ship without headers, so this matches existing practice.

The page now loads entirely from the site's own origin — the only remaining `http` string in the file is the Webflow attribution comment on line 1.

## Testing

`npm run build && npm run serve`, then requested a nonexistent path:

- the Webflow "Page Not Found" page renders, now referencing `page-not-found.svg` with no `cloudfront` references in the output
- every asset the page references resolves locally: `css/normalize.css`, `css/webflow.css`, `css/onetable-ad267e.webflow.css`, `images/xtable-favicon.png`, `images/page-not-found.svg`, `js/jquery-3.5.1.min.js`, `js/webflow.js`
- home page output unchanged

## Note, not fixed here

Both `homepage/404.html:16` and `homepage/index.html:23` reference `images/webclip.png` as their `apple-touch-icon`, but that file was deleted in 62ca0c0 ("removed unused images"). It 404s on both pages. Not a CSP issue and it affects the home page equally, so it seemed better left to its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyVF3fyK2VQE7DPd31mRLv