### PR TITLE
[MINOR] Upgrade ASF parent POM from 33 to 39 and fix delombok on modern JDKs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <log4j.version>2.22.0</log4j.version>
         <junit.version>5.11.4</junit.version>
         <junit.platform.runner.version>1.11.4</junit.platform.runner.version>
-        <lombok.version>1.18.36</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <hadoop.version>3.4.1</hadoop.version>
         <hudi.version>1.2.0</hudi.version>
@@ -1058,13 +1058,22 @@
                       which reads ${delombok.output.dir} so that the generated builders, getters
                       and equals/hashCode show up in the javadoc jar. Running it on ordinary
                       builds costs time and forces every contributor through
-                      lombok-maven-plugin, whose last release is 1.18.20.0 (April 2021) and
-                      which cannot delombok on newer JDKs.
+                      lombok-maven-plugin, whose last release is 1.18.20.0 (April 2021).
                     -->
                     <plugin>
                         <groupId>org.projectlombok</groupId>
                         <artifactId>lombok-maven-plugin</artifactId>
                         <version>${lombok-maven-plugin.version}</version>
+                        <dependencies>
+                            <!-- 1.18.20.0 ships lombok 1.18.20, which cannot delombok on
+                                 JDK 21+. Override it with the lombok the build compiles
+                                 against so a release can be cut on a modern JDK. -->
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </dependency>
+                        </dependencies>
                         <configuration>
                             <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
                             <addOutputDirectory>false</addOutputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>33</version>
+        <version>39</version>
     </parent>
 
     <groupId>org.apache.xtable</groupId>
@@ -61,7 +61,7 @@
         <project.version>0.2.0-SNAPSHOT</project.version>
         <!-- To ensure build content is re-producible -->
         <project.build.outputTimestamp>2026-07-21T19:16:22Z</project.build.outputTimestamp>
-        <maven.compiler.target>8</maven.compiler.target>
+        <javaVersion>8</javaVersion>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <avro.version>1.12.0</avro.version>
         <log4j.version>2.22.0</log4j.version>
@@ -707,17 +707,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version> <configuration>
-                <source>${maven.compiler.source}</source>
-                <target>${maven.compiler.target}</target>
-                <annotationProcessorPaths>
-                    <path>
-                        <groupId>org.projectlombok</groupId>
-                        <artifactId>lombok</artifactId>
-                        <version>${lombok.version}</version>
-                    </path>
-                </annotationProcessorPaths>
-            </configuration>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <release>${javaVersion}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -740,13 +740,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>${maven.compiler.target}</release>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What is the purpose of the pull request

Upgrade the ASF parent POM from 33 to 39, and make `delombok` work on JDKs newer than 11 so the project can be built locally on a current JDK.

## Brief change log

**Upgrade ASF parent POM 33 -> 39**

Picks up six releases of the Apache parent, most notably newer managed plugin versions (surefire 3.3.0 -> 3.5.6, compiler 3.13.0 -> 3.15.0, enforcer 3.5.0 -> 3.6.3, javadoc 3.7.0 -> 3.12.0) and `minimalMavenBuildVersion` raised from 3.6.3 to 3.9.

Parent 36 replaced the `maven.compiler.source` / `maven.compiler.target` properties with a single `javaVersion` property, so the compiler configuration has to move with it:

- `maven.compiler.target=8` becomes `javaVersion=8`
- `<source>${maven.compiler.source}</source>` and `<target>${maven.compiler.target}</target>` are dropped. After the upgrade `${maven.compiler.source}` no longer resolves and appears verbatim in the effective POM; it was inert only because a second, duplicate `maven-compiler-plugin` declaration set `<release>`.
- `<release>` now reads `${javaVersion}`

`maven-compiler-plugin` was declared twice in `<build><plugins>`, which Maven warns about and which is what let the stale property reference go unnoticed. The two declarations are merged into one.

The Java level stays at 8 and the effective compiler invocation is unchanged: `javac [debug release 8]`.

I also checked the other behaviour changes in this range and they do not affect us: parent 34 moved the `apache.snapshots` repository into a `use-apache-snapshots` profile (we never referenced it), and parent 39 dropped `useReleaseProfile` from the managed release-plugin config (we pin our own release-plugin version and configuration).

**Make delombok work on modern JDKs**

`lombok-maven-plugin` 1.18.20.0 is the last release of that plugin (April 2021), so there is no newer version to move to. It embeds lombok 1.18.20, which throws during delombok on JDK 21+:

```
NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport
does not have member field 'com.sun.tools.javac.tree.JCTree qualid'
```

This overrides the plugin's lombok dependency with the version the project already uses elsewhere, and bumps that from 1.18.36 to 1.18.46 so JDK support extends past 21. CI is unaffected — it stays on Java 11 — but a contributor with a current JDK can now build without hitting this.

## Verify this pull request

This pull request is already covered by existing tests.

Verified locally with the project's own wrapper on Temurin 11, matching the `Maven CI Build` workflow:

- `./mvnw clean install -ntp -B -DskipTests` — all 10 modules build cleanly
- Effective POM diffed before and after the parent upgrade; the only compiler-relevant change is the removal of the unresolved `${maven.compiler.source}`, with `<release>8</release>` intact
- The duplicate-plugin-declaration warning is gone
- `delombok` plus compilation verified on JDK 21, 25 and 26, all three of which failed before the lombok change

These are build configuration changes only and touch no production code, so the existing suite running in CI is the real gate.

The two commits are independent, so I am happy to split the lombok change into its own PR if that is preferred for review.
