### PR TITLE
[MINOR] Persist the Maven build cache between CI runs

### DIFF
--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -43,10 +43,10 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      # Restore only. License Check writes this cache: it resolves every
-      # dependency to inspect each jar's license, so it populates exactly what
-      # this job needs, it finishes in a couple of minutes, and it stops at
-      # `package` so the entry never carries this project's own artifacts.
+      # Restore only. License Check writes this cache, and only on `main`: it
+      # resolves every dependency to inspect each jar's license, so it populates
+      # exactly what this job needs, it finishes in a couple of minutes, and it
+      # stops at `package` so the entry never carries this project's artifacts.
       # Previously both jobs used setup-java's `cache: maven`, which gave them
       # the same key, and whichever finished first reserved it - this job then
       # logged "Unable to reserve cache with key" on every single run. Making

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -32,7 +32,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # A cold build is ~27 min, which left no headroom under the previous 30.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v7
 
@@ -48,20 +49,46 @@ jobs:
       # so without this it starts empty on every run and never restores a module.
       # Only `main` writes an entry, so pull requests warm up from `main` instead
       # of each branch filling the repository-wide cache budget.
+      #
+      # The modules producing large bundled jars opt out of the cache entirely
+      # with <maven.build.cache.enabled>false</maven.build.cache.enabled> in their
+      # own poms, which keeps this entry around 15 MB. Without that opt-out the
+      # entry is 1.2 GB, 97% of it three shaded jars that account for only ~3 of
+      # the 27 minutes a cold build takes.
+      #
+      # Note: a cache-restored xtable-service does not reproduce
+      # target/quarkus-app. No step consumes that directory today; anything added
+      # later that does must not rely on it being present.
       - name: Restore Maven build cache
         uses: actions/cache/restore@v6
         with:
           path: ~/.m2/build-cache
-          key: maven-build-cache-${{ runner.os }}-${{ github.sha }}
+          key: maven-build-cache-${{ runner.os }}-jdk11-${{ github.sha }}
           restore-keys: |
-            maven-build-cache-${{ runner.os }}-
+            maven-build-cache-${{ runner.os }}-jdk11-
 
       - name: Build all module with Maven
         run: ./mvnw clean install -ntp -B
 
+      # Guard against a module starting to cache large artifacts again: warn and
+      # skip the save rather than churn the repository-wide 10 GB cache budget,
+      # which is otherwise mostly the ~/.m2/repository entries above. Checking the
+      # size rather than specific paths keeps this working across module renames.
+      - name: Check Maven build cache size
+        id: build-cache-size
+        if: success() && github.ref == 'refs/heads/main'
+        run: |
+          size_mb=$(du -sm ~/.m2/build-cache 2>/dev/null | cut -f1)
+          size_mb=${size_mb:-0}
+          echo "size_mb=${size_mb}" >> "$GITHUB_OUTPUT"
+          echo "~/.m2/build-cache is ${size_mb} MB"
+          if [ "${size_mb}" -gt 100 ]; then
+            echo "::warning title=Maven build cache not saved::~/.m2/build-cache is ${size_mb} MB (limit 100 MB). A module is caching large artifacts; opt it out with <maven.build.cache.enabled>false</maven.build.cache.enabled> in its pom."
+          fi
+
       - name: Save Maven build cache
-        if: github.ref == 'refs/heads/main' && success()
+        if: success() && github.ref == 'refs/heads/main' && steps.build-cache-size.outputs.size_mb < 100
         uses: actions/cache/save@v6
         with:
           path: ~/.m2/build-cache
-          key: maven-build-cache-${{ runner.os }}-${{ github.sha }}
+          key: maven-build-cache-${{ runner.os }}-jdk11-${{ github.sha }}

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -50,13 +50,17 @@ jobs:
           distribution: 'temurin'
 
       # Restore only. License Check writes this cache, and only on `main`: it
-      # resolves every dependency to inspect each jar's license, so it populates
-      # exactly what this job needs, it finishes in a couple of minutes, and it
-      # stops at `package` so the entry never carries this project's artifacts.
+      # finishes in a couple of minutes against this job's 27, and it stops at
+      # `package` so the entry never carries this project's artifacts. It
+      # resolves the reactor explicitly for this job's benefit; its own license
+      # steps reach only part of it.
       # Previously both jobs used setup-java's `cache: maven`, which gave them
       # the same key, and whichever finished first reserved it - this job then
       # logged "Unable to reserve cache with key" on every single run. Making
       # the reader explicit removes the race rather than winning it.
+      #
+      # A warm start, not a guarantee: `install` here runs plugins that a build
+      # stopping at `package` never resolves, so expect a delta every run.
       - name: Restore Maven repository cache
         uses: actions/cache/restore@v6
         with:

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -83,7 +83,7 @@ jobs:
       #
       # The modules producing large bundled jars opt out of the cache entirely
       # with <maven.build.cache.enabled>false</maven.build.cache.enabled> in their
-      # own poms, which keeps this entry around 15 MB. Without that opt-out the
+      # own poms, which keeps this entry around 12 MB. Without that opt-out the
       # entry is 1.2 GB, 97% of it three shaded jars that account for only ~3 of
       # the 27 minutes a cold build takes.
       #
@@ -91,6 +91,7 @@ jobs:
       # target/quarkus-app. No step consumes that directory today; anything added
       # later that does must not rely on it being present.
       - name: Restore Maven build cache
+        id: build-cache
         uses: actions/cache/restore@v6
         with:
           path: ~/.m2/build-cache
@@ -113,12 +114,24 @@ jobs:
           size_mb=${size_mb:-0}
           echo "size_mb=${size_mb}" >> "$GITHUB_OUTPUT"
           echo "~/.m2/build-cache is ${size_mb} MB"
-          if [ "${size_mb}" -gt 100 ]; then
+          # The two bounds below are what the save step gates on, so they have to
+          # cover the whole range between them: 0 means the extension wrote
+          # nothing and there is no path for the save action to read.
+          if [ "${size_mb}" -eq 0 ]; then
+            echo "::warning title=Maven build cache not saved::~/.m2/build-cache is empty or absent. The build cache extension did not write anything; check that .mvn/extensions.xml is still in effect."
+          elif [ "${size_mb}" -ge 100 ]; then
             echo "::warning title=Maven build cache not saved::~/.m2/build-cache is ${size_mb} MB (limit 100 MB). A module is caching large artifacts; opt it out with <maven.build.cache.enabled>false</maven.build.cache.enabled> in its pom."
           fi
 
+      # Skipped when the exact key already hit on restore - a re-run of the same
+      # commit would otherwise try to write over an immutable entry and log the
+      # "Unable to reserve cache with key" that splitting these jobs removed.
       - name: Save Maven build cache
-        if: success() && github.ref == 'refs/heads/main' && steps.build-cache-size.outputs.size_mb < 100
+        if: >
+          success() && github.ref == 'refs/heads/main'
+          && steps.build-cache.outputs.cache-hit != 'true'
+          && steps.build-cache-size.outputs.size_mb > 0
+          && steps.build-cache-size.outputs.size_mb < 100
         uses: actions/cache/save@v6
         with:
           path: ~/.m2/build-cache

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -92,3 +92,17 @@ jobs:
         with:
           path: ~/.m2/build-cache
           key: maven-build-cache-${{ runner.os }}-jdk11-${{ github.sha }}
+
+      # `install` above puts this project's own artifacts into ~/.m2/repository,
+      # including the bundled jars (~1.2 GB, xtable-utilities alone is ~1 GB).
+      # actions/setup-java caches that whole directory with no way to exclude a
+      # path, so drop them before its post step runs. They are rebuilt from
+      # source on every run and can never produce a useful cache hit, and a
+      # stale SNAPSHOT left in the local repository can shadow a reactor build.
+      #
+      # In practice License Check wins the cache key first and it only runs
+      # `package`, so today's entry already excludes these. This keeps that true
+      # if this job ever becomes the one that saves.
+      - name: Drop this project's own artifacts from the Maven repository cache
+        if: always()
+        run: rm -rf ~/.m2/repository/org/apache/xtable

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -42,11 +42,32 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
 
-      # `cache: maven` above only persists ~/.m2/repository. The build cache
-      # extension configured in .mvn/extensions.xml writes to ~/.m2/build-cache,
-      # so without this it starts empty on every run and never restores a module.
+      # Restore only. License Check writes this cache: it resolves every
+      # dependency to inspect each jar's license, so it populates exactly what
+      # this job needs, it finishes in a couple of minutes, and it stops at
+      # `package` so the entry never carries this project's own artifacts.
+      # Previously both jobs used setup-java's `cache: maven`, which gave them
+      # the same key, and whichever finished first reserved it - this job then
+      # logged "Unable to reserve cache with key" on every single run. Making
+      # the reader explicit removes the race rather than winning it.
+      - name: Restore Maven repository cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.m2/repository
+          key: m2-repository-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
+          restore-keys: |
+            m2-repository-${{ runner.os }}-jdk11-
+
+      - name: Restore Maven wrapper cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.m2/wrapper/dists
+          key: m2-wrapper-${{ runner.os }}-${{ hashFiles('**/.mvn/wrapper/maven-wrapper.properties') }}
+
+      # A separate cache from the repository above: the build cache extension
+      # configured in .mvn/extensions.xml writes to ~/.m2/build-cache, so
+      # without this it starts empty every run and never restores a module.
       # Only `main` writes an entry, so pull requests warm up from `main` instead
       # of each branch filling the repository-wide cache budget.
       #
@@ -99,10 +120,11 @@ jobs:
       # path, so drop them before its post step runs. They are rebuilt from
       # source on every run and can never produce a useful cache hit, and a
       # stale SNAPSHOT left in the local repository can shadow a reactor build.
+      # Source Build Check clears the same path for the same reason.
       #
-      # In practice License Check wins the cache key first and it only runs
-      # `package`, so today's entry already excludes these. This keeps that true
-      # if this job ever becomes the one that saves.
-      - name: Drop this project's own artifacts from the Maven repository cache
+      # This job no longer saves that cache, so nothing depends on this today.
+      # It is kept so the invariant holds by construction rather than by which
+      # step happens to write last.
+      - name: Drop this project's own artifacts from the Maven repository
         if: always()
         run: rm -rf ~/.m2/repository/org/apache/xtable

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -29,6 +29,12 @@ on:
     branches:
       - "main"
 
+# The build cache extension does not hash the JDK, so it is part of every cache
+# key below. Defined once here rather than repeated, so that changing the JDK
+# cannot leave a key asserting the old one.
+env:
+  JDK_VERSION: '11'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,10 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
 
       # Restore only. License Check writes this cache, and only on `main`: it
@@ -55,9 +61,9 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ~/.m2/repository
-          key: m2-repository-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
+          key: m2-repository-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
           restore-keys: |
-            m2-repository-${{ runner.os }}-jdk11-
+            m2-repository-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-
 
       - name: Restore Maven wrapper cache
         uses: actions/cache/restore@v6
@@ -84,9 +90,9 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ~/.m2/build-cache
-          key: maven-build-cache-${{ runner.os }}-jdk11-${{ github.sha }}
+          key: maven-build-cache-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-${{ github.sha }}
           restore-keys: |
-            maven-build-cache-${{ runner.os }}-jdk11-
+            maven-build-cache-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-
 
       - name: Build all module with Maven
         run: ./mvnw clean install -ntp -B
@@ -112,7 +118,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ~/.m2/build-cache
-          key: maven-build-cache-${{ runner.os }}-jdk11-${{ github.sha }}
+          key: maven-build-cache-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-${{ github.sha }}
 
       # `install` above puts this project's own artifacts into ~/.m2/repository,
       # including the bundled jars (~1.2 GB, xtable-utilities alone is ~1 GB).

--- a/.github/workflows/mvn-ci-build.yml
+++ b/.github/workflows/mvn-ci-build.yml
@@ -43,5 +43,25 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      # `cache: maven` above only persists ~/.m2/repository. The build cache
+      # extension configured in .mvn/extensions.xml writes to ~/.m2/build-cache,
+      # so without this it starts empty on every run and never restores a module.
+      # Only `main` writes an entry, so pull requests warm up from `main` instead
+      # of each branch filling the repository-wide cache budget.
+      - name: Restore Maven build cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.m2/build-cache
+          key: maven-build-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            maven-build-cache-${{ runner.os }}-
+
       - name: Build all module with Maven
         run: ./mvnw clean install -ntp -B
+
+      - name: Save Maven build cache
+        if: github.ref == 'refs/heads/main' && success()
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.m2/build-cache
+          key: maven-build-cache-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -52,11 +52,16 @@ jobs:
       # every job re-download the whole dependency tree from Central. The prefix
       # fallback below warms from the previous entry and downloads just the delta.
       #
-      # This job is the writer for that cache, and deliberately the only one.
-      # It has to resolve every dependency in order to inspect each jar's
-      # license, so it populates exactly what the other jobs need, and it stops
-      # at `package`, so this project's own artifacts never enter the entry.
-      # Maven CI Build restores the same key read-only.
+      # This job is the writer for that cache, and deliberately the only one:
+      # it is the short job, so making it the writer costs the least, and it
+      # stops at `package`, so this project's own artifacts never enter the
+      # entry. Maven CI Build restores the same key read-only.
+      #
+      # Being the only writer means this job has to resolve what the readers
+      # need, which the license steps below do not do on their own - they build
+      # the shaded modules and their `-am` closure, which excludes the two
+      # leaves, xtable-utilities and xtable-service. The explicit resolve step
+      # after them covers the rest of the reactor.
       #
       # Restore and save are split so that only `main` writes. The entry is
       # ~1 GB against a repository-wide 10 GB budget, so letting every branch
@@ -100,6 +105,24 @@ jobs:
 
       - name: Validate Bundled License Texts
         run: python3 release/scripts/validate_bundled_license_texts.py
+
+      # Nothing above this line resolves xtable-utilities or xtable-service:
+      # `apache-rat:check` requires no dependency resolution, `dependency:tree`
+      # collects poms rather than jars, and the shaded-bundle build reaches only
+      # the `-am` closure of the three modules it names, which excludes both
+      # leaves. Without this step the entry never gains the Quarkus stack or
+      # xtable-utilities' bundled dependencies, and Maven CI Build - which
+      # cannot write the cache - would re-download them from Central on every
+      # run, permanently. This job exists to warm the cache for that one, so it
+      # has to cover the whole reactor even where a license check does not.
+      #
+      # Failure here must not fail a license check, hence `|| true`: an
+      # incomplete cache entry costs download time on the next run and nothing
+      # else. `go-offline` does not catch plugin dependencies resolved at
+      # execution time, so expect a small delta regardless.
+      - name: Resolve the rest of the reactor for the cache
+        if: success() && github.ref == 'refs/heads/main'
+        run: ./mvnw -B -ntp -q dependency:go-offline -Dmaven.build.cache.enabled=false || true
 
       # This job writes the repository cache, so the invariant that the entry
       # holds third-party dependencies only is enforced here. The steps above

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -40,7 +40,34 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
+
+      # ~/.m2/repository is cached here rather than via setup-java's
+      # `cache: maven`, which restores on an exact key match only - it sets no
+      # restore-keys by design (actions/setup-java#269), so any pom change made
+      # every job re-download the whole dependency tree from Central. The prefix
+      # fallback below warms from the previous entry and downloads just the delta.
+      #
+      # This job is the writer for that cache, and deliberately the only one.
+      # It has to resolve every dependency in order to inspect each jar's
+      # license, so it populates exactly what the other jobs need, and it stops
+      # at `package`, so this project's own artifacts never enter the entry.
+      # Maven CI Build restores the same key read-only.
+      - name: Cache Maven repository
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: m2-repository-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
+          restore-keys: |
+            m2-repository-${{ runner.os }}-jdk11-
+
+      # Replaces the separate wrapper cache that setup-java's `cache: maven`
+      # used to provide. Keyed only on the wrapper properties, which change
+      # rarely, so it survives the pom changes that rotate the key above.
+      - name: Cache Maven wrapper
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/wrapper/dists
+          key: m2-wrapper-${{ runner.os }}-${{ hashFiles('**/.mvn/wrapper/maven-wrapper.properties') }}
 
       - name: Apache License Check
         run: ./mvnw apache-rat:check -B
@@ -61,3 +88,12 @@ jobs:
 
       - name: Validate Bundled License Texts
         run: python3 release/scripts/validate_bundled_license_texts.py
+
+      # This job writes the repository cache, so the invariant that the entry
+      # holds third-party dependencies only is enforced here. The steps above
+      # stop at `package`, so this is a no-op today; it exists so that adding
+      # an `install` later cannot silently add ~1.2 GB of bundled jars to the
+      # entry. Runs before actions/cache's post-job save.
+      - name: Drop this project's own artifacts from the Maven repository
+        if: always()
+        run: rm -rf ~/.m2/repository/org/apache/xtable

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -52,8 +52,14 @@ jobs:
       # license, so it populates exactly what the other jobs need, and it stops
       # at `package`, so this project's own artifacts never enter the entry.
       # Maven CI Build restores the same key read-only.
-      - name: Cache Maven repository
-        uses: actions/cache@v6
+      #
+      # Restore and save are split so that only `main` writes. The entry is
+      # ~1 GB against a repository-wide 10 GB budget, so letting every branch
+      # write one would crowd out the entry they all restore from. Pull requests
+      # warm from `main` via the prefix and re-download only their own delta.
+      - name: Restore Maven repository cache
+        id: m2-repository
+        uses: actions/cache/restore@v6
         with:
           path: ~/.m2/repository
           key: m2-repository-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
@@ -62,7 +68,8 @@ jobs:
 
       # Replaces the separate wrapper cache that setup-java's `cache: maven`
       # used to provide. Keyed only on the wrapper properties, which change
-      # rarely, so it survives the pom changes that rotate the key above.
+      # rarely, so it survives the pom changes that rotate the key above. Left
+      # unsplit unlike the repository cache: at ~9 MB it is not worth gating.
       - name: Cache Maven wrapper
         uses: actions/cache@v6
         with:
@@ -93,7 +100,19 @@ jobs:
       # holds third-party dependencies only is enforced here. The steps above
       # stop at `package`, so this is a no-op today; it exists so that adding
       # an `install` later cannot silently add ~1.2 GB of bundled jars to the
-      # entry. Runs before actions/cache's post-job save.
+      # entry. Must stay ahead of the save below.
       - name: Drop this project's own artifacts from the Maven repository
         if: always()
         run: rm -rf ~/.m2/repository/org/apache/xtable
+
+      # Only when the exact key missed - entries are immutable, so saving over
+      # an existing key just fails. This is what actions/cache does internally
+      # when restore and save are not split.
+      - name: Save Maven repository cache
+        if: >
+          success() && github.ref == 'refs/heads/main'
+          && steps.m2-repository.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.m2/repository
+          key: m2-repository-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}

--- a/.github/workflows/mvn-license-check.yml
+++ b/.github/workflows/mvn-license-check.yml
@@ -29,16 +29,21 @@ on:
     branches:
       - "main"
 
+# Kept in step with mvn-ci-build.yml: this job writes the cache that job reads,
+# and the JDK is part of the key on both sides.
+env:
+  JDK_VERSION: '11'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
 
       # ~/.m2/repository is cached here rather than via setup-java's
@@ -62,9 +67,9 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ~/.m2/repository
-          key: m2-repository-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
+          key: m2-repository-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
           restore-keys: |
-            m2-repository-${{ runner.os }}-jdk11-
+            m2-repository-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-
 
       # Replaces the separate wrapper cache that setup-java's `cache: maven`
       # used to provide. Keyed only on the wrapper properties, which change
@@ -115,4 +120,4 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ~/.m2/repository
-          key: m2-repository-${{ runner.os }}-jdk11-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}
+          key: m2-repository-${{ runner.os }}-jdk${{ env.JDK_VERSION }}-${{ hashFiles('**/pom.xml', '**/.mvn/extensions.xml') }}

--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Set Version
         run: ./mvnw versions:set -DnewVersion="$VERSION"
       - name: Publish package
-        run: ./mvnw -ntp --batch-mode deploy -DskipTests
+        # Never build a release from cached module output. `versions:set` above has
+        # just rewritten the version, while cache restoration is version-agnostic —
+        # it stamps the current project version onto whatever it restores. This
+        # runner keeps no build-cache directory today, so the flag is a guard
+        # against that changing, and it also saves checksumming every module for a
+        # cache that can never hit. Same reasoning as source-build-check.yml.
+        run: ./mvnw -ntp --batch-mode deploy -DskipTests -Dmaven.build.cache.enabled=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -20,6 +20,6 @@
     <extension>
         <groupId>org.apache.maven.extensions</groupId>
         <artifactId>maven-build-cache-extension</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.3</version>
     </extension>
 </extensions>

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -53,6 +53,47 @@
                         <reconcile propertyName="testFailureIgnore"/>
                     </reconciles>
                 </plugin>
+                <!--
+                  Failsafe is bound in the parent POM to integration-test and verify,
+                  and CI runs `install`, so integration tests run on every build and a
+                  restored module skips them exactly as it skips unit tests. -DskipITs
+                  is a command line flag, so the same gap applies. Reconciles are
+                  matched per goal, hence both entries; the parameter lists differ
+                  because testFailureIgnore exists on verify only, and naming a
+                  parameter a goal does not have earns a warning on every build.
+                -->
+                <plugin artifactId="maven-failsafe-plugin" goal="integration-test">
+                    <reconciles>
+                        <reconcile propertyName="skip"/>
+                        <reconcile propertyName="skipExec"/>
+                        <reconcile propertyName="skipITs"/>
+                        <reconcile propertyName="skipTests"/>
+                    </reconciles>
+                </plugin>
+                <plugin artifactId="maven-failsafe-plugin" goal="verify">
+                    <reconciles>
+                        <reconcile propertyName="skip"/>
+                        <reconcile propertyName="skipExec"/>
+                        <reconcile propertyName="skipITs"/>
+                        <reconcile propertyName="skipTests"/>
+                        <reconcile propertyName="testFailureIgnore"/>
+                    </reconciles>
+                </plugin>
+                <!--
+                  -Dmaven.test.skip=true never reaches surefire in this build: the
+                  parent POM pins <skip>${skipUTs}</skip>, and explicit plugin
+                  configuration wins over the user property, so surefire's skip
+                  parameter reads identically whether the flag is present or not.
+                  What the flag actually suppresses is test compilation. Without
+                  this entry the module checksum is byte-identical across the two,
+                  and a cache seeded by a `-Dmaven.test.skip=true` build restores
+                  into a plain `install` with the tests never having run.
+                -->
+                <plugin artifactId="maven-compiler-plugin" goal="testCompile">
+                    <reconciles>
+                        <reconcile propertyName="skip"/>
+                    </reconciles>
+                </plugin>
             </plugins>
         </reconcile>
     </executionControl>

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.3.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.3.0 https://maven.apache.org/xsd/build-cache-config-1.3.0.xsd">
+    <configuration>
+        <enabled>true</enabled>
+        <remote enabled="false"/>
+        <local>
+            <!--
+              One generation per module. The default of 3 accumulates generations,
+              which matters because CI persists this directory between runs; a
+              single generation keeps the saved entry at one build's size.
+            -->
+            <maxBuildsCached>1</maxBuildsCached>
+        </local>
+    </configuration>
+    <executionControl>
+        <reconcile>
+            <plugins>
+                <!--
+                  Command line flags are not part of a module's checksum, so without
+                  this a build that skipped tests and one that ran them are
+                  indistinguishable to the cache. Listing a property makes any
+                  difference between the cached build and the current run a cache
+                  miss, in both directions.
+
+                  Deliberately no skipValue attribute: skipValue is a relaxation, not
+                  a guard. It tells the cache to tolerate a mismatch when the current
+                  run is the one skipping, which is exactly the exemption we do not
+                  want on a release build.
+                -->
+                <plugin artifactId="maven-surefire-plugin" goal="test">
+                    <reconciles>
+                        <reconcile propertyName="skip"/>
+                        <reconcile propertyName="skipExec"/>
+                        <reconcile propertyName="skipTests"/>
+                        <reconcile propertyName="testFailureIgnore"/>
+                    </reconciles>
+                </plugin>
+            </plugins>
+        </reconcile>
+    </executionControl>
+</cache>

--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,8 @@
                         </excludes>
                         <licenseHeader>
                             <file>style/xml-license-header</file>
-                            <delimiter>^&lt;project|^&lt;configuration|^&lt;Configuration|^&lt;extensions|^&lt;component</delimiter>
+                            <!-- ^&lt;cache is the root element of .mvn/maven-build-cache-config.xml -->
+                            <delimiter>^&lt;project|^&lt;configuration|^&lt;Configuration|^&lt;extensions|^&lt;component|^&lt;cache</delimiter>
                             <skipLinesMatching>^&lt;.*xml.+?$</skipLinesMatching>
                         </licenseHeader>
                     </pom>

--- a/xtable-aws/pom.xml
+++ b/xtable-aws/pom.xml
@@ -27,6 +27,17 @@
 
     <artifactId>xtable-aws</artifactId>
     <name>XTable AWS</name>
+    <properties>
+        <!--
+          This module produces a large bundled jar (~42 MB). Keep it out of the
+          maven-build-cache entirely: the property disables both restore and save
+          for this project, so the artifact never enters the cache directory that
+          CI persists between runs. Shading is cheap relative to the test suites
+          the cache is there to skip, so there is nothing worth caching here.
+          See .mvn/maven-build-cache-config.xml.
+        -->
+        <maven.build.cache.enabled>false</maven.build.cache.enabled>
+    </properties>
 
     <dependencies>
 

--- a/xtable-hive-metastore/pom.xml
+++ b/xtable-hive-metastore/pom.xml
@@ -27,6 +27,17 @@
 
     <artifactId>xtable-hive-metastore</artifactId>
     <name>XTable HMS</name>
+    <properties>
+        <!--
+          This module produces a large bundled jar (~125 MB). Keep it out of the
+          maven-build-cache entirely: the property disables both restore and save
+          for this project, so the artifact never enters the cache directory that
+          CI persists between runs. Shading is cheap relative to the test suites
+          the cache is there to skip, so there is nothing worth caching here.
+          See .mvn/maven-build-cache-config.xml.
+        -->
+        <maven.build.cache.enabled>false</maven.build.cache.enabled>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -27,6 +27,17 @@
 
     <artifactId>xtable-utilities_${scala.binary.version}</artifactId>
     <name>XTable Project Utilities</name>
+    <properties>
+        <!--
+          This module produces a large bundled jar (~1 GB). Keep it out of the
+          maven-build-cache entirely: the property disables both restore and save
+          for this project, so the artifact never enters the cache directory that
+          CI persists between runs. Shading is cheap relative to the test suites
+          the cache is there to skip, so there is nothing worth caching here.
+          See .mvn/maven-build-cache-config.xml.
+        -->
+        <maven.build.cache.enabled>false</maven.build.cache.enabled>
+    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## What is the purpose of the pull request

`.mvn/extensions.xml` enables `maven-build-cache-extension`, but the cache never survives a CI run, so it currently costs us the bookkeeping and buys nothing. Fixing that turned up two further problems with how CI caches Maven state, both addressed here.

Reviewing this commit-by-commit is easier than as a single diff.

## Brief change log

**1. Persist the build cache** — `actions/setup-java`'s `cache: maven` covers `~/.m2/repository`; the extension writes to `~/.m2/build-cache`, which nothing preserved. Every run logged `Local build was not found by checksum` for all ten modules and rebuilt everything, including for PRs touching only the website or a single leaf module. Only `main` writes an entry; PRs restore from it.

**2. Keep the bundled jars out of that cache** — measured, one generation is **1.2 GB**, and 1.17 GB of it is three bundled jars:

| module | cache | CI time |
| --- | ---: | ---: |
| xtable-core | 1.0 MB | 17:42 |
| xtable-service | 80 KB | 5:05 |
| xtable-hudi-support-extensions | 11 MB | 34 s |
| **xtable-utilities** | **1.0 GB** | 2:30 |
| **xtable-hive-metastore** | **125 MB** | 28 s |
| **xtable-aws** | **42 MB** | 12 s |

(times from run 31226195551 on `main`, 27:11 total)

The three shade modules are 97% of the size and 12% of the time; core and service are 84% of the time and about 1 MB. Saving 1.2 GB per merge into a repository-wide 10 GB budget would evict the very caches it sits beside. They opt out with the extension's per-project property, which disables both restore and save for that module.

Also in this commit: `.mvn/maven-build-cache-config.xml` (`maxBuildsCached=1`, remote cache off, strict surefire reconciliation — command-line flags are not part of a module's checksum, so without it a build that skipped tests and one that ran them are indistinguishable); extension `1.1.0` → `1.2.3` for two invalidation fixes, MBUILDCACHE-87 and MBUILDCACHE-99; a guard that skips the save and warns above 100 MB; `-Dmaven.build.cache.enabled=false` on the release publish, since `versions:set` runs immediately beforehand and cache restoration is version-agnostic; the JDK in the cache key, as the extension does not hash it; and `timeout-minutes` 30 → 40, since a cold build is already 27:11 against it.

**3 and 4. One writer for `~/.m2/repository`** — both jobs used `cache: maven`, which restores on an exact key match only; setup-java sets no restore-keys deliberately ([#269](https://github.com/actions/setup-java/issues/269)), so any pom change made every job re-download the whole dependency tree. Same key in both jobs also meant whichever finished first reserved it and the other's save failed — License Check takes ~2 min against the build's 27, so the build logged `Unable to reserve cache with key` on every run.

That outcome is the right one, so this makes it explicit rather than racing for it: License Check must resolve every dependency to inspect each jar's license, and it stops at `package`, so it populates exactly what the other jobs need without ever putting this project's own artifacts in the entry. It is now the sole writer; Maven CI Build restores read-only. A prefix fallback warms from the previous entry after a pom change, and both jobs clear `~/.m2/repository/org/apache/xtable` before the post-job save, as Source Build Check already does.

## Verify this pull request

Build/CI infrastructure only; no production code touched.

Verified locally on Temurin 11 that the build-cache change does what it claims:

| | cold | warm |
| --- | --- | --- |
| Result | `BUILD SUCCESS` | `BUILD SUCCESS` |
| `~/.m2/build-cache` | **12 MB** (was 1.2 GB) | 12 MB |
| Modules restored | 0 | **7 of 7** cacheable |
| `Cache is explicitly disabled on project level` | 3 modules | 3 modules |

`buildinfo.xml` confirms the four surefire flags recorded as `tracked="true"`.

Two notes for reviewers. The extension bump renames the cache directory `v1` → `v1.1`, and this PR touches poms and `extensions.xml`, which rotates the repository cache key — so the first run after merge is cold on both counts, once. And a cache-restored `xtable-service` does not reproduce `target/quarkus-app`; nothing consumes that directory today, and there is a comment in the workflow saying so.

The saving depends on what a PR touches: a change to `xtable-core` still rebuilds and retests core and everything downstream, while a website, workflow, or docs-only change should hit on everything cacheable.
