### PR TITLE
[MINOR] Drop the duplicate xtable-core test-jar dependency

### DIFF
--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -245,14 +245,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.xtable</groupId>
-            <artifactId>xtable-core_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
-            <classifier>tests</classifier>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-spark${spark.version.prefix}-bundle_${scala.binary.version}</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## What is the purpose of the pull request

`xtable-utilities` declared the `xtable-core` test-jar dependency twice, identically. Maven warns about it and says future versions may stop accepting it.

## Brief change log

- Removed the duplicate `org.apache.xtable:xtable-core_${scala.binary.version}:test-jar:tests` declaration.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

`./mvnw validate` no longer prints `'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique`. `spotless:check` passes across the reactor.

Three `'artifactId' contains an expression but should be a constant` warnings remain, for `xtable-core`, `xtable-utilities` and `xtable-hudi-support-extensions`. Those are the `_${scala.binary.version}` suffixes, and fixing them would change published coordinates, so they are deliberately left alone here — see #529 for the earlier discussion.

*This change was created with AI assistance.*
