### PR TITLE
[MINOR] Fix compilation on JDK 21+

### DIFF
--- a/xtable-core/src/main/java/org/apache/xtable/hudi/BaseFileUpdatesExtractor.java
+++ b/xtable-core/src/main/java/org/apache/xtable/hudi/BaseFileUpdatesExtractor.java
@@ -315,7 +315,8 @@ public class BaseFileUpdatesExtractor {
                   -1L,
                   valueMetadata);
             })
-        .collect(Collectors.toMap(HoodieColumnRangeMetadata::getColumnName, Function.identity()));
+        .collect(
+            Collectors.toMap(HoodieColumnRangeMetadata::getColumnName, columnStat -> columnStat));
   }
 
   /** Holds the information needed to create a "replace" commit in the Hudi table. */


### PR DESCRIPTION
javac on JDK 21 and 25 fails to infer the generic type of the `Collectors.toMap(HoodieColumnRangeMetadata::getColumnName, Function.identity())` call in `BaseFileUpdatesExtractor` and the build breaks; an explicit lambda compiles everywhere. The release build on JDK 11 is unaffected.

Verified: `mvn test-compile` on Temurin 11, Temurin 21.0.11 and Zulu 25.0.4 → all green (21/25 fail without this change).

*This change was created with AI assistance.*
