### PR TITLE
[MINOR] Update engine versions in the docs to match the build

### DIFF
--- a/website/docs/features-and-limitations.md
+++ b/website/docs/features-and-limitations.md
@@ -33,7 +33,7 @@ HMS and AWS Glue are the two catalogs supported right now, support for other cat
 - Only Copy-on-Write or Read-Optimized views of tables are currently supported. This means that only the underlying parquet files are synced but log files from Hudi and [delete vectors](https://docs.delta.io/latest/delta-deletion-vectors.html#:~:text=Deletion%20vectors%20indicate%20changes%20to,is%20run%20on%20the%20table.) from Delta and Iceberg are not captured by the sync.
 
 ### Hudi
-- Hudi 0.14.0 is required when reading a Hudi target table. Users will also need to enable 
+- Hudi 0.14.0 or later is required when reading a Hudi target table. Users will also need to enable 
   - the metadata table (`hoodie.metadata.enable=true`) and 
   - hive style partitioning (`hoodie.datasource.write.hive_style_partitioning=true`) wherever applicable when reading the data.
 - Be sure to enable `parquet.avro.write-old-list-structure=false` for proper compatibility with lists when syncing from Hudi to Iceberg.

--- a/website/docs/hms.md
+++ b/website/docs/hms.md
@@ -148,7 +148,7 @@ SELECT * FROM <database_name>.<table_name>;
 <TabItem value="delta">
 
 ```shell md title="shell"
-spark-sql --packages io.delta:delta-core_2.12:2.0.0 \
+spark-sql --packages io.delta:delta-core_2.12:2.4.0 \
 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
 --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
 --conf "spark.sql.catalogImplementation=hive"
@@ -182,7 +182,7 @@ SELECT * FROM delta_db.<table_name>;
 <TabItem value="iceberg">
 
 ```shell md title="shell"
-spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:1.2.1 \
+spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:1.9.2 \
 --conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
 --conf "spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog" \
 --conf "spark.sql.catalog.spark_catalog.type=hive" \

--- a/website/docs/how-to.md
+++ b/website/docs/how-to.md
@@ -55,7 +55,7 @@ values={[
 
 ```shell md title="shell"
 pyspark \
-  --packages org.apache.hudi:hudi-spark3.2-bundle_2.12:0.14.0 \
+  --packages org.apache.hudi:hudi-spark3.4-bundle_2.12:1.2.0 \
   --conf "spark.serializer=org.apache.spark.serializer.KryoSerializer" \
   --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog" \
   --conf "spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension"
@@ -65,7 +65,7 @@ pyspark \
 
 ```shell md title="shell"
 pyspark \
-  --packages io.delta:delta-core_2.12:2.1.0 \
+  --packages io.delta:delta-core_2.12:2.4.0 \
   --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
   --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
 ```
@@ -74,7 +74,7 @@ pyspark \
 
 ```shell md title="shell"
 pyspark \
-  --packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:1.4.1 \
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:1.9.2 \
   --conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
   --conf "spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog"
 ```


### PR DESCRIPTION
The spark-shell examples in `how-to.md` and `hms.md` pinned Spark 3.2-era artifacts (Hudi 0.14.0, Delta 2.0.0/2.1.0, Iceberg 1.2.1/1.4.1). Updates them to the versions the project builds against — Spark 3.4, Hudi 1.2.0, Delta 2.4.0, Iceberg 1.9.2 — and loosens the Hudi reader note to "0.14.0 or later". All coordinates verified to resolve on Maven Central.

*This change was created with AI assistance.*