### PR TITLE
[909] Run the tests in UTC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -756,6 +756,9 @@
                     <skip>${skipUTs}</skip>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <trimStackTrace>false</trimStackTrace>
+                    <!-- Hudi stamps its timeline in UTC, so a JVM on any other zone reads its own
+                         commits as not yet completed. Pin the tests to UTC. -->
+                    <argLine>-Duser.timezone=UTC</argLine>
                     <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                 </configuration>
             </plugin>
@@ -776,7 +779,7 @@
                     <reuseForks>false</reuseForks>
                     <forkCount>6</forkCount>
                     <trimStackTrace>false</trimStackTrace>
-                    <argLine>-Xmx1500m</argLine>
+                    <argLine>-Xmx1500m -Duser.timezone=UTC</argLine>
                     <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixes #909.

## What is the purpose of the pull request

Pins the test JVMs to UTC, so the suite no longer depends on the contributor's timezone. On a machine in any other zone, Hudi's compaction planner reads the test table's own delta commits as not yet completed, drops every log file from the plan, and returns an empty `Option` that `TestAbstractHudiTable#onlyScheduleCompaction` calls `get()` on. #909 has the planner output and the on-disk evidence that the log files were there.

Five tests were affected, all on their MERGE_ON_READ parameters: `ITHudiConversionSource#insertAndUpsertData`, `#testsForClustering`, `#testsForDeleteAllRecordsInPartition`, and `ITConversionController#testConcurrentInsertsAndTableServiceWrites`.

CI already runs UTC, so nothing changes there.

## Brief change log

- Added `-Duser.timezone=UTC` to the surefire and failsafe `argLine` in the root pom.

## Verify this pull request

Verified on Europe/Warsaw with JDK 11: `ITHudiConversionSource` plus `ITConversionController#testConcurrentInsertsAndTableServiceWrites` run 29 tests, all green, where the same command on `main` fails 9 of them. The equivalent check without this change is `TZ=UTC ./mvnw ...`, which also passes.

*This change was created with AI assistance.*
