### PR TITLE
[855] Add the 0.4.0 release blog post and widen the blog layout

### DIFF
--- a/website/blog/apache-xtable-0.4.0-release.mdx
+++ b/website/blog/apache-xtable-0.4.0-release.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Apache XTable™ (Incubating) 0.4.0 Release"
-excerpt: "Apache XTable™ (Incubating) 0.4.0 adds a Spark runtime jar, Apache Paimon and Apache Parquet sources, and Delta Kernel."
+description: "Apache XTable™ (Incubating) 0.4.0 adds a Spark runtime jar, Apache Paimon and Apache Parquet sources, and Delta Kernel."
 author: Apache XTable Community
 category: blog
 image: /images/xtable-write-anywhere.png

--- a/website/blog/apache-xtable-0.4.0-release.mdx
+++ b/website/blog/apache-xtable-0.4.0-release.mdx
@@ -1,0 +1,79 @@
+---
+title: "Apache XTable™ (Incubating) 0.4.0 Release"
+excerpt: "Apache XTable™ (Incubating) 0.4.0 adds a Spark runtime jar, Apache Paimon and Apache Parquet sources, and Delta Kernel."
+author: Apache XTable Community
+category: blog
+image: /images/blog/XTable/xtable-cover.png
+tags:
+- apache xtable
+- release
+- spark
+- paimon
+- parquet
+- delta kernel
+date: 2026-08-25
+---
+
+The Apache XTable™ (Incubating) community is pleased to announce the release of 0.4.0-incubating,
+which lands 45 commits from 19 contributors.
+See the [release notes](/releases/release-0.4.0-incubating) for the complete list of changes.
+
+<!--truncate-->
+
+Apache XTable™ (Incubating) converts metadata between Apache Hudi, Apache Iceberg and Delta Lake
+without rewriting any data files. With this release it also supports Apache Paimon and Apache
+Parquet tables as sources.
+
+## Release Highlights
+
+### Run a sync on Apache Spark
+
+This release introduces `xtable-spark-runtime`, a runtime jar that runs a sync on a Spark cluster
+you already have. Add it to an existing job with `--jars` and call the sync right after your write,
+or submit it on its own with `spark-submit`.
+
+```shell
+$SPARK_HOME/bin/spark-submit \
+  --jars xtable-spark-runtime_2.12-0.4.0-incubating.jar \
+  --class com.example.OrdersJob \
+  orders-job.jar
+```
+
+Every engine dependency is `provided`, so the jar reuses the Hudi, Iceberg and Delta libraries
+already on your cluster. The jar supports Spark 3.4 and 3.5. See
+[Run an XTable sync on Apache Spark](/docs/how-to-spark-runtime) for the full guide.
+
+### New source formats
+
+* **Apache Paimon source**, with incremental sync and column statistics.
+* **Apache Parquet source**, with schema conversion, column statistics, partition extraction and
+  incremental sync.
+
+### Delta Kernel
+
+This release adds a Delta Kernel conversion source and target. Neither one depends on Spark for
+the conversion itself.
+
+## Getting the release
+
+Download the source release, its signature and its checksum from the
+[Downloads](/releases/downloads) page. Always verify the signature before you use the release.
+
+The binary artifacts are on Maven Central under the `org.apache.xtable` group. For example, add the
+Spark runtime jar as `org.apache.xtable:xtable-spark-runtime_2.12:0.4.0-incubating`.
+
+## Getting involved
+
+Apache XTable™ (Incubating) grows through its contributors. We track work in
+[GitHub issues](https://github.com/apache/incubator-xtable/issues) and we discuss it on the
+[dev mailing list](mailto:dev@xtable.apache.org).
+
+The easiest way to start is to:
+
+1. Try 0.4.0-incubating on your own tables and tell us how it goes.
+2. Join the [community sync](/community/sync) and the dev mailing list.
+3. Pick up a [good first issue](https://github.com/apache/incubator-xtable/contribute).
+
+For more information, visit the [documentation](/docs/setup) or the
+[GitHub repository](https://github.com/apache/incubator-xtable). If you want to grow into a
+committer role, read [Becoming a committer](/community/becoming-a-committer).

--- a/website/blog/apache-xtable-0.4.0-release.mdx
+++ b/website/blog/apache-xtable-0.4.0-release.mdx
@@ -3,7 +3,7 @@ title: "Apache XTable™ (Incubating) 0.4.0 Release"
 excerpt: "Apache XTable™ (Incubating) 0.4.0 adds a Spark runtime jar, Apache Paimon and Apache Parquet sources, and Delta Kernel."
 author: Apache XTable Community
 category: blog
-image: /images/blog/XTable/xtable-cover.png
+image: /images/xtable-write-anywhere.png
 tags:
 - apache xtable
 - release
@@ -14,8 +14,8 @@ tags:
 date: 2026-08-25
 ---
 
-The Apache XTable™ (Incubating) community is pleased to announce the release of 0.4.0-incubating,
-which lands 45 commits from 19 contributors.
+We are pleased to announce the release of 0.4.0-incubating, which lands 45 commits from
+19 contributors.
 See the [release notes](/releases/release-0.4.0-incubating) for the complete list of changes.
 
 <!--truncate-->
@@ -26,11 +26,11 @@ Parquet tables as sources.
 
 ## Release Highlights
 
-### Run a sync on Apache Spark
+### Spark runtime
 
-This release introduces `xtable-spark-runtime`, a runtime jar that runs a sync on a Spark cluster
-you already have. Add it to an existing job with `--jars` and call the sync right after your write,
-or submit it on its own with `spark-submit`.
+A new runtime jar, `xtable-spark-runtime`, runs a sync on a Spark cluster you already have. Add it
+to an existing job with `--jars` and call `XTableSyncService` right after your write, or submit
+`XTableSparkSync` on its own with `spark-submit`.
 
 ```shell
 $SPARK_HOME/bin/spark-submit \
@@ -43,16 +43,20 @@ Every engine dependency is `provided`, so the jar reuses the Hudi, Iceberg and D
 already on your cluster. The jar supports Spark 3.4 and 3.5. See
 [Run an XTable sync on Apache Spark](/docs/how-to-spark-runtime) for the full guide.
 
-### New source formats
+### Apache Paimon
 
-* **Apache Paimon source**, with incremental sync and column statistics.
-* **Apache Parquet source**, with schema conversion, column statistics, partition extraction and
-  incremental sync.
+A new conversion source reads Paimon tables, with incremental sync and column statistics.
+
+### Apache Parquet
+
+A new conversion source reads Parquet tables, with schema conversion, column statistics, partition
+extraction and incremental sync.
 
 ### Delta Kernel
 
-This release adds a Delta Kernel conversion source and target. Neither one depends on Spark for
-the conversion itself.
+A new conversion source and target read and write Delta tables through the `delta-kernel-api`
+library, and neither one needs a `SparkSession`. The older Delta source and target call `DeltaLog`
+and `OptimisticTransaction` from `delta-core`, which ties them to Spark.
 
 ## Getting the release
 

--- a/website/homepage/index.html
+++ b/website/homepage/index.html
@@ -77,7 +77,7 @@
     <div class="w-layout-blockcontainer hero-container w-container">
       <div class="left-hero">
         <img src="images/xtable-words-white.png" loading="lazy" alt="" class="xtable-title">
-        <div class="hero-textblock">Seamlessly interoperate cross-table between Apache Hudi, Delta Lake, and Apache Iceberg</div>
+        <div class="hero-textblock">Seamlessly interoperate cross-table between Apache Hudi, Delta Lake, and Apache Iceberg. Sync from Apache Paimon and Apache Parquet.</div>
         <div class="button-group">
           <a href="https://github.com/apache/incubator-xtable" class="primary-button w-button">Try it on GitHub</a>
           <a href="https://xtable.apache.org/docs/setup/" class="secondary-button w-button">Learn More</a>

--- a/website/homepage/index.html
+++ b/website/homepage/index.html
@@ -77,7 +77,7 @@
     <div class="w-layout-blockcontainer hero-container w-container">
       <div class="left-hero">
         <img src="images/xtable-words-white.png" loading="lazy" alt="" class="xtable-title">
-        <div class="hero-textblock">Seamlessly interoperate cross-table between Apache Hudi, Delta Lake, and Apache Iceberg. Sync from Apache Paimon and Apache Parquet.</div>
+        <div class="hero-textblock">Seamlessly interoperate cross-table between Apache Hudi, Delta Lake, and Apache Iceberg</div>
         <div class="button-group">
           <a href="https://github.com/apache/incubator-xtable" class="primary-button w-button">Try it on GitHub</a>
           <a href="https://xtable.apache.org/docs/setup/" class="secondary-button w-button">Learn More</a>

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -129,3 +129,10 @@ html[data-theme='dark'] {
     width: 100%;
   }
 }
+
+/* Blog list thumbnails differ in aspect ratio. Most are 2:1 and fill the column
+   at about 365px tall, so cap every thumbnail there: a near-square image then
+   stands as tall as its neighbours instead of pushing its title far below. */
+.blog-image {
+  max-height: 365px;
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -132,7 +132,9 @@ html[data-theme='dark'] {
 
 /* Blog list thumbnails differ in aspect ratio. Most are 2:1 and fill the column
    at about 365px tall, so cap every thumbnail there: a near-square image then
-   stands as tall as its neighbours instead of pushing its title far below. */
-.blog-image {
+   stands as tall as its neighbours instead of pushing its title far below.
+   The same image is the hero on the single-post page, where there is no
+   neighbour to line up with, so scope the cap to the list cards. */
+.blogPostCard .blog-image {
   max-height: 365px;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -37,6 +37,11 @@
   --ifm-spacing-horizontal: 1.5rem;
   --ifm-navbar-padding-horizontal: 0.75rem;
 
+  /* Infima defaults to 1140px, which leaves a wide monitor mostly empty on the
+     blog and release pages. */
+  --ifm-container-width: 1600px;
+  --ifm-container-width-xl: 1600px;
+
   --ifm-font-family-base: 'Inter', system-ui, -apple-system, Segoe UI, Roboto,
     Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI',
     Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
@@ -109,4 +114,18 @@ html[data-theme='dark'] {
 .blogThumbnail {
     padding-left: 0;
     padding-right: 48px;
+}
+
+/* Blog list cards: two per row on wide screens, one per row on narrow ones.
+   This replaces an inline width:50% on the post container, which no stylesheet
+   could override, held at every breakpoint, and also applied to the single-post
+   page. See src/theme/BlogPostItem/Container/index.js. */
+.blogPostCard {
+  width: 50%;
+}
+
+@media (max-width: 996px) {
+  .blogPostCard {
+    width: 100%;
+  }
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -37,11 +37,6 @@
   --ifm-spacing-horizontal: 1.5rem;
   --ifm-navbar-padding-horizontal: 0.75rem;
 
-  /* Infima defaults to 1140px, which leaves a wide monitor mostly empty on the
-     blog and release pages. */
-  --ifm-container-width: 1600px;
-  --ifm-container-width-xl: 1600px;
-
   --ifm-font-family-base: 'Inter', system-ui, -apple-system, Segoe UI, Roboto,
     Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI',
     Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
@@ -114,6 +109,17 @@ html[data-theme='dark'] {
 .blogThumbnail {
     padding-left: 0;
     padding-right: 48px;
+}
+
+/* BlogLayout wraps the blog list and the single-post page in Infima's
+   .container, which caps at --ifm-container-width. That defaults to 1140px and
+   leaves a wide monitor mostly empty. Infima reads the variable on the element,
+   so setting it here widens only the blog pages and leaves the docs, the
+   release notes and the home page at the default line length. See
+   src/theme/BlogLayout/index.js. */
+.blogLayoutContainer {
+  --ifm-container-width: 1600px;
+  --ifm-container-width-xl: 1600px;
 }
 
 /* Blog list cards: two per row on wide screens, one per row on narrow ones.

--- a/website/src/theme/BlogLayout/index.js
+++ b/website/src/theme/BlogLayout/index.js
@@ -7,7 +7,7 @@ export default function BlogLayout(props) {
   const hasSidebar = false;
   return (
     <Layout {...layoutProps}>
-      <div className="container margin-vert--lg">
+      <div className="container blogLayoutContainer margin-vert--lg">
         <div className="row">
           <main
             className={clsx('col row')}

--- a/website/src/theme/BlogPostItem/Container/index.js
+++ b/website/src/theme/BlogPostItem/Container/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {useLocation} from 'react-router-dom';
 import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
@@ -8,6 +9,7 @@ export default function BlogPostItemContainer({children, className}) {
   const {
     frontMatter,
     assets,
+    isBlogPostPage,
     metadata: {description, permalink},
   } = useBlogPost();
   const location = useLocation();
@@ -17,8 +19,7 @@ export default function BlogPostItemContainer({children, className}) {
 
   return (
     <article
-      className={className}
-      style={{ width: "50%" }}
+      className={clsx(className, !isBlogPostPage && 'blogPostCard')}
       itemProp="blogPost"
       itemScope
       itemType="https://schema.org/BlogPosting">

--- a/website/src/theme/BlogPostItem/Container/index.js
+++ b/website/src/theme/BlogPostItem/Container/index.js
@@ -29,9 +29,7 @@ export default function BlogPostItemContainer({children, className}) {
           {location.pathname.startsWith('/blog') ? (
             <Link itemProp="url" to={permalink}>
               <img
-                src={withBaseUrl(image, {
-                  absolute: true,
-                })}
+                src={withBaseUrl(image)}
                 className="blog-image"
               />
             </Link>


### PR DESCRIPTION
Part of #855.

## What is the purpose of the pull request

Add the 0.4.0-incubating release blog post to the website, and fix two layout
caps that were keeping the blog pages narrow.

The post is the last website piece of the 0.4.0 release. The release notes page
and the downloads entries already landed in #913, so this is what remains before
the announcement mail goes out.

## Brief change log

- Added `website/blog/apache-xtable-0.4.0-release.mdx`. It covers the three
  headline items, the Spark runtime jar, the Paimon and Parquet sources, and
  Delta Kernel, then links to `/releases/release-0.4.0-incubating` for the full
  change list rather than duplicating it.
- Raised `--ifm-container-width` and `--ifm-container-width-xl` to 1600px on
  the blog pages. `BlogLayout` wraps the page in Infima's `.container`, which
  caps at `--ifm-container-width`. That defaults to 1140px and nothing overrode
  it, so the blog stopped growing on any monitor wider than that. The override
  sits on a `.blogLayoutContainer` class that `BlogLayout` adds to that div, so
  the docs, the release notes and the home page keep the default width.
- Moved the `width: 50%` on `BlogPostItem/Container` out of an inline style and
  into a `.blogPostCard` class. As an inline style no stylesheet could override
  it, it held at every breakpoint, and it applied to the single-post page as
  well as the list, because both views render the same container. It is now
  applied only when `isBlogPostPage` is false, and drops to one card per row
  under 996px.
- Dropped `absolute: true` from the thumbnail `withBaseUrl` call in the same
  component. With it, the `src` resolved against the configured site `url`, so
  every card image loaded from the production site even under a local
  `npm run start`, and a new cover image could not be previewed before it was
  deployed. The `src` is now relative to the site root.

The single-post page being squeezed to half width was the more visible of the
two, and it is fixed as a side effect of the second change.

## Verify this pull request

This pull request is a website-only change with no test coverage.

Verified by running the site locally with `npm run start` in `website/` and
checking, at both wide and narrow viewports:

- `/blog/` renders two cards per row above 996px and one below it.
- `/blog/apache-xtable-0.4.0-release` renders at full column width, and its
  release-notes link resolves.
- The existing blog posts and the `/releases/downloads` page still render.
- `/docs/setup`, `/releases/downloads` and the home page stay at the default
  1140px width; only `/blog/` pages carry the `blogLayoutContainer` class in
  the `npm run build` output.

## Note for reviewers

This carries two separable things: the release post, which belongs to #855, and
the layout fix, which does not. I kept them in one PR because both are
website-only and the layout problem is most visible on the new post. If you
would rather review them apart, say so and I will split the layout change into
its own `[MINOR]` PR.

