### PR TITLE
[920] Address the review comments on the 0.4.0 Spark runtime docs

### DIFF
--- a/website/docs/how-to-spark-runtime.md
+++ b/website/docs/how-to-spark-runtime.md
@@ -9,11 +9,34 @@ import TabItem from '@theme/TabItem';
 # Run an XTable sync on Apache Spark
 
 `xtable-spark-runtime` is a runtime jar that runs an Apache XTable™ (Incubating) sync on an Apache
-Spark cluster. As with any XTable sync, no data files are rewritten — the sync reads the source
+Spark cluster. As with any XTable sync, no data files are rewritten. The sync reads the source
 table's metadata and writes the target format's metadata alongside the data that is already there.
 
-The jar is meant to be dropped into a Spark job you already run, so you don't need a separate
-process or a separate cluster to keep a table interoperable across formats.
+There are two ways to use it, and this page covers them in that order:
+
+1. **As its own job**, with the `XTableSparkSync` entry point. This is the quickest way to try a
+   sync, and it is the equivalent of `RunSync` for this bundle.
+2. **Inside a Spark job you already run**, by calling `XTableSyncService` right after your write,
+   so a table stays interoperable without a separate process or cluster.
+
+## Prerequisites
+
+- **A source table.** XTable converts the metadata of a table that already exists, so you need one
+  before you can sync anything. If you don't have one, follow
+  [Creating your first interoperable table](/docs/how-to) to create the Hudi table `people` under
+  `file:///tmp/hudi-dataset`, partitioned by `city`. Every example on this page syncs that table.
+- **A Spark 3.4.x or 3.5.x installation** with `$SPARK_HOME` set. See
+  [Spark version support](#spark-version-support) for what each line provides.
+- **Maven**, to resolve the engine libraries in
+  [Getting the engine libraries](#getting-the-engine-libraries).
+
+:::caution Write the source table with Hudi 0.14.0
+`xtable-spark-runtime` `0.4.0-incubating` is built against Hudi `0.14.0`, which reads Hudi table
+version 6. The Quickstart's shell uses `hudi-spark3.4-bundle_2.12:1.2.0`, which writes table
+version 9, and the sync then fails in `HoodieTableMetaClient` with an `IllegalArgumentException`
+from `TimelineLayoutVersion` before it reads any data. Launch that shell with
+`--packages org.apache.hudi:hudi-spark3.4-bundle_2.12:0.14.0` instead.
+:::
 
 ## Getting the jar
 
@@ -24,26 +47,150 @@ The jar is published to Maven Central as
 curl -O https://repo1.maven.org/maven2/org/apache/xtable/xtable-spark-runtime_2.12/0.4.0-incubating/xtable-spark-runtime_2.12-0.4.0-incubating.jar
 ```
 
-Every engine dependency is `provided`, so the jar is about 4 MB and reuses the Hudi, Iceberg and
-Delta libraries your cluster already has. See the [Downloads](/releases/downloads) page for the
-full list of releases.
+Every engine dependency is `provided`, so the jar is about 4 MB: XTable's own code plus the few
+libraries it relocates for internal use. See the [Downloads](/releases/downloads) page for the full
+list of releases.
 
-## Adding the sync to a Spark job
+## Getting the engine libraries
 
-This is what the jar is for. Your job already writes a table in one format, and you want that same
-table to be interoperable with the others as soon as the write finishes.
+Because Hudi, Iceberg and Delta are `provided`, the runtime jar does not carry them. A cluster that
+already runs those engines supplies them and there is nothing more to do. A plain Spark
+distribution does not, so resolve them once from the published POM:
 
-Add the jar to the `spark-submit` you already use, alongside your application jar:
+```shell md title="shell"
+BASE=https://repo1.maven.org/maven2/org/apache/xtable/xtable-spark-runtime_2.12/0.4.0-incubating
+curl -O $BASE/xtable-spark-runtime_2.12-0.4.0-incubating.pom
+
+mvn -q -f xtable-spark-runtime_2.12-0.4.0-incubating.pom dependency:build-classpath \
+  -DincludeScope=provided -Dmdep.outputFile=engine-classpath-raw.txt
+```
+
+That also resolves Spark and Hadoop, which the distribution already has. Keep the engine jars
+only:
+
+```shell md title="shell"
+tr ':' '\n' < engine-classpath-raw.txt \
+  | grep -E '/(hudi-|iceberg-|delta-|avro-|parquet-|jol-core)' \
+  | grep -v 'avro-mapred\|avro-ipc' \
+  | paste -sd: - > engine-classpath.txt
+```
+
+Keep every `parquet-*` jar, `parquet-format-structures` included. If you drop it, the older copy in
+the Spark distribution wins and the read fails with `NoSuchFieldError: size_statistics`.
+
+Every `spark-submit` below passes that file through `spark.driver.extraClassPath` and
+`spark.executor.extraClassPath`. On a cluster that already supplies the engines, drop those two
+settings.
+
+:::note Use a flat classpath, not `--packages`
+The engines have to go on the flat classpath rather than through `--packages` or `--jars`. Those
+load them in a child classloader, separate from the Avro that Spark itself supplies, which breaks
+casts across the boundary such as Iceberg's `PartitionData` to Avro's `IndexedRecord`.
+:::
+
+## Running a sync as its own job
+
+The jar ships a `spark-submit` entry point, `org.apache.xtable.spark.XTableSparkSync`. Pass the jar
+as the application jar rather than with `--jars`. It runs in one of two modes.
+
+### Syncing a single table
+
+Describe the table with command line options. This is the shortest path from a source table to an
+interoperable one:
 
 ```shell md title="shell"
 $SPARK_HOME/bin/spark-submit \
-  --jars xtable-spark-runtime_2.12-0.4.0-incubating.jar \
-  --class com.example.OrdersJob \
-  orders-job.jar
+  --class org.apache.xtable.spark.XTableSparkSync \
+  --master 'local[*]' \
+  --conf spark.driver.extraClassPath="$(cat engine-classpath.txt)" \
+  --conf spark.executor.extraClassPath="$(cat engine-classpath.txt)" \
+  xtable-spark-runtime_2.12-0.4.0-incubating.jar \
+  --basepath file:///tmp/hudi-dataset/people \
+  --sourceformat HUDI \
+  --targets ICEBERG,DELTA \
+  --partitionspec city:VALUE
 ```
 
-Then call `XTableSyncService` after your write. You describe the table with a `TableSyncSpec` and
-hand it the session's Hadoop configuration:
+`--partitionspec` is what carries the source partitioning across. The Quickstart writes `people`
+partitioned by `city`, and without the flag XTable reads an empty partition-field list and creates
+the Iceberg and Delta metadata as unpartitioned.
+
+After this finishes, `/tmp/hudi-dataset/people` carries Iceberg and Delta metadata next to the Hudi
+data files, and all three formats read the same rows.
+
+### Syncing several tables from a config file
+
+To sync more than one table in a single submit, list them in a YAML file and pass
+`--datasetconfig`. It takes the same config that `RunSync` uses, so an existing file works
+unchanged:
+
+```yaml md title="my_config.yaml"
+sourceFormat: HUDI
+targetFormats:
+  - DELTA
+  - ICEBERG
+datasets:
+  -
+    tableBasePath: file:///tmp/hudi-dataset/people
+    tableName: people
+    partitionSpec: city:VALUE
+```
+
+```shell md title="shell"
+$SPARK_HOME/bin/spark-submit \
+  --class org.apache.xtable.spark.XTableSparkSync \
+  --master 'local[*]' \
+  --conf spark.driver.extraClassPath="$(cat engine-classpath.txt)" \
+  --conf spark.executor.extraClassPath="$(cat engine-classpath.txt)" \
+  xtable-spark-runtime_2.12-0.4.0-incubating.jar \
+  --datasetconfig my_config.yaml
+```
+
+Add one entry per table. Every entry has to point at a table that already exists:
+`XTableSparkSync` logs each table that fails, carries on with the rest, then exits nonzero, so one
+missing path fails the whole submit. `datasets` above lists only `people` because that is the one
+table the [Prerequisites](#prerequisites) create. An entry for a table partitioned by a timestamp,
+in its own namespace, looks like this:
+
+```yaml md title="my_config.yaml, a second datasets entry"
+  -
+    tableBasePath: file:///tmp/hudi-dataset/events
+    tableName: events
+    namespace: analytics.raw
+    partitionSpec: event_ts:DAY:yyyy-MM-dd
+```
+
+All the tables in one file share `sourceFormat` and `targetFormats`, so a run covers one source
+format at a time.
+
+Unlike `RunSync`, which reads the file from the local filesystem, `XTableSparkSync` reads it
+through the Spark Hadoop configuration, so the config itself may live on S3, GCS or ABFS.
+
+`--datasetconfig` and `--basepath` are mutually exclusive. Pass one or the other.
+
+| Option | Description |
+| --- | --- |
+| `--basepath` | Base path of the source table. |
+| `--sourceformat` | Source format: `HUDI`, `ICEBERG`, `DELTA`, `PAIMON` or `PARQUET`. |
+| `--targets` | Comma-separated target formats, for example `ICEBERG,DELTA`. |
+| `--datasetconfig` | Path to a YAML config listing several tables. May be local or on cloud storage. |
+| `--datapath` | Path to the data files, when it differs from the base path. |
+| `--tablename` | Table name. Defaults to the last segment of the base path. |
+| `--namespace` | Dot-separated table namespace. |
+| `--partitionspec` | Hudi source partition field spec, for example `city:VALUE`. |
+| `--usedeltakernel` | Force Delta Kernel for a Delta source or target. |
+| `--help` | Print the usage text. |
+
+## Adding the sync to a Spark job
+
+Running the sync as its own job means a second submit every time the table changes. If your job
+already writes the table, you can keep it interoperable in the same run by calling the sync
+directly after your write.
+
+### Writing the job
+
+Call `XTableSyncService` after your write. You describe the table with a `TableSyncSpec` and hand
+it the session's Hadoop configuration:
 
 <Tabs
 groupId="language"
@@ -55,11 +202,11 @@ values={[
 >
 <TabItem value="scala">
 
-```scala md title="OrdersJob.scala"
+```scala md title="PeopleJob.scala"
 import java.util.{Arrays => JArrays}
 import org.apache.xtable.spark.{TableSyncSpec, XTableSyncService}
 
-val basePath = "s3://example-warehouse/db/orders"
+val basePath = "file:///tmp/hudi-dataset/people"
 
 // the write your job already does
 df.write.format("hudi").options(hudiOptions).mode("append").save(basePath)
@@ -67,9 +214,10 @@ df.write.format("hudi").options(hudiOptions).mode("append").save(basePath)
 // the one call you add
 new XTableSyncService().sync(
   TableSyncSpec.builder()
-    .key("orders")
+    .key("people")
     .basePath(basePath)
     .sourceFormat("HUDI")
+    .partitionSpec("city:VALUE")
     .targets(JArrays.asList("ICEBERG", "DELTA"))
     .build(),
   spark.sparkContext.hadoopConfiguration)
@@ -78,12 +226,12 @@ new XTableSyncService().sync(
 </TabItem>
 <TabItem value="java">
 
-```java md title="OrdersJob.java"
+```java md title="PeopleJob.java"
 import java.util.Arrays;
 import org.apache.xtable.spark.TableSyncSpec;
 import org.apache.xtable.spark.XTableSyncService;
 
-String basePath = "s3://example-warehouse/db/orders";
+String basePath = "file:///tmp/hudi-dataset/people";
 
 // the write your job already does
 df.write().format("hudi").options(hudiOptions).mode("append").save(basePath);
@@ -92,9 +240,10 @@ df.write().format("hudi").options(hudiOptions).mode("append").save(basePath);
 new XTableSyncService()
     .sync(
         TableSyncSpec.builder()
-            .key("orders")
+            .key("people")
             .basePath(basePath)
             .sourceFormat("HUDI")
+            .partitionSpec("city:VALUE")
             .targets(Arrays.asList("ICEBERG", "DELTA"))
             .build(),
         spark.sparkContext().hadoopConfiguration());
@@ -103,19 +252,58 @@ new XTableSyncService()
 </TabItem>
 </Tabs>
 
-To compile against these classes, add the same Maven coordinates to your build with `provided`
-scope.
+`partitionSpec` mirrors the `--partitionspec` flag above and carries the source partitioning into
+the targets. Leave it out for an unpartitioned source. Leaving it out for a partitioned one creates
+the targets as unpartitioned.
 
 The sync runs incrementally and tracks its own watermark in the target's sync metadata, falling
-back to a full snapshot whenever an incremental sync isn't safe — the first run, for example. That
-makes it safe to call after every write.
+back to a full snapshot whenever an incremental sync isn't safe, the first run being the obvious
+case. That makes it safe to call after every write.
+
+### Building the job
+
+Add the same Maven coordinates you downloaded above to your build with `provided` scope, so the
+classes compile but are not packaged into your application jar:
+
+```xml md title="pom.xml"
+<dependency>
+  <groupId>org.apache.xtable</groupId>
+  <artifactId>xtable-spark-runtime_2.12</artifactId>
+  <version>0.4.0-incubating</version>
+  <scope>provided</scope>
+</dependency>
+```
+
+Then build your application jar as usual:
+
+```shell md title="shell"
+mvn clean package
+```
+
+### Running the job
+
+Add the runtime jar to the `spark-submit` you already use, alongside your application jar:
+
+```shell md title="shell"
+$SPARK_HOME/bin/spark-submit \
+  --master 'local[*]' \
+  --conf spark.driver.extraClassPath="$(cat engine-classpath.txt)" \
+  --conf spark.executor.extraClassPath="$(cat engine-classpath.txt)" \
+  --jars xtable-spark-runtime_2.12-0.4.0-incubating.jar \
+  --class com.example.PeopleJob \
+  people-job.jar
+```
+
+The runtime jar goes on `--jars`, the way you add it to a job you already run, while the engines go
+on the flat classpath, the way a cluster supplies them. On a cluster that already runs Hudi,
+Iceberg or Delta, drop the two `extraClassPath` settings.
 
 :::note Tables are addressed by path
 The runtime jar identifies tables by path rather than through a catalog, so there is no equivalent
 of the `RunSync` Iceberg catalog config (`-i`) yet. When a table's data files don't sit directly
 under `basePath`, set `dataPath` to wherever they do, because that's the location each target
 writes its metadata to. Iceberg tables often end up at `<basePath>/data`, but nothing in Iceberg
-requires it — `write.data.path` and object-storage layouts can put data files anywhere — so check
+requires it. `write.data.path` and object-storage layouts can put data files anywhere, so check
 where your table actually writes.
 :::
 
@@ -123,68 +311,6 @@ where your table actually writes.
 [`demo/spark-runtime`](https://github.com/apache/incubator-xtable/tree/main/demo/spark-runtime) is
 a complete job that syncs both directions and verifies the row counts.
 :::
-
-## Running a sync as its own job
-
-The jar also ships a `spark-submit` entry point, which is the equivalent of `RunSync` for this
-bundle. Pass the jar as the application jar rather than with `--jars`:
-
-```shell md title="shell"
-$SPARK_HOME/bin/spark-submit \
-  --class org.apache.xtable.spark.XTableSparkSync \
-  --master 'local[*]' \
-  xtable-spark-runtime_2.12-0.4.0-incubating.jar \
-  --basepath /path/to/hudi_table \
-  --sourceformat HUDI \
-  --targets ICEBERG,DELTA
-```
-
-To sync several tables in one submit, use `--datasetconfig`. It takes the same YAML that `RunSync`
-uses, so an existing config works unchanged, and unlike `RunSync` the config itself may live on
-cloud storage:
-
-```yaml md title="my_config.yaml"
-sourceFormat: HUDI
-targetFormats:
-  - DELTA
-  - ICEBERG
-datasets:
-  -
-    tableBasePath: s3://tpc-ds-datasets/1GB/hudi/call_center
-    tableDataPath: s3://tpc-ds-datasets/1GB/hudi/call_center/data
-    tableName: call_center
-    namespace: my.db
-  -
-    tableBasePath: s3://tpc-ds-datasets/1GB/hudi/catalog_sales
-    tableName: catalog_sales
-    partitionSpec: cs_sold_date_sk:VALUE
-  -
-    tableBasePath: s3://hudi/multi-partition-dataset
-    tableName: multi_partition_dataset
-    partitionSpec: time_millis:DAY:yyyy-MM-dd,type:VALUE
-```
-
-```shell md title="shell"
-$SPARK_HOME/bin/spark-submit \
-  --class org.apache.xtable.spark.XTableSparkSync \
-  xtable-spark-runtime_2.12-0.4.0-incubating.jar \
-  --datasetconfig my_config.yaml
-```
-
-`--datasetconfig` and `--basepath` are mutually exclusive — pass one or the other.
-
-| Option | Description |
-| --- | --- |
-| `--basepath` | Base path of the source table. |
-| `--sourceformat` | Source format: `HUDI`, `ICEBERG`, `DELTA`, `PAIMON` or `PARQUET`. |
-| `--targets` | Comma-separated target formats, for example `ICEBERG,DELTA`. |
-| `--datasetconfig` | Path to a YAML config listing several tables. May be local or on cloud storage. |
-| `--datapath` | Path to the data files, when it differs from the base path. |
-| `--tablename` | Table name. Defaults to the last segment of the base path. |
-| `--namespace` | Dot-separated table namespace. |
-| `--partitionspec` | Hudi source partition field spec, for example `level:VALUE`. |
-| `--usedeltakernel` | Force Delta Kernel for a Delta source or target. |
-| `--help` | Print the usage text. |
 
 ## Supported formats
 
@@ -200,18 +326,22 @@ Paimon and Parquet are read-only sources; XTable does not write either format as
 
 ## Spark version support
 
-Converting to and from Hudi and Iceberg doesn't require Spark at all, so those run on any of the
-Spark versions below. Delta is the only engine whose implementation depends on the Spark version,
-and the jar chooses the right one automatically:
+`xtable-spark-runtime` 0.4.0-incubating supports Spark 3.4.x and 3.5.x, on Scala 2.12.
+
+Converting to and from Hudi and Iceberg doesn't require Spark at all, so those run on both lines.
+Delta is the only engine whose implementation depends on the Spark version, and the jar chooses
+the right one automatically:
 
 | Spark version | Hudi and Iceberg | Delta implementation |
 | --- | :---: | --- |
 | 3.4.x | ✅ | Delta Standalone |
-| 3.5.x and newer | ✅ | [Delta Kernel](https://docs.delta.io/latest/delta-kernel.html), selected automatically |
+| 3.5.x | ✅ | [Delta Kernel](https://docs.delta.io/latest/delta-kernel.html), selected automatically |
 
-Delta Standalone doesn't run on Spark 3.5, so on 3.5 and newer a Delta source or target is routed
-through Delta Kernel with no flag needed. If you want Kernel on Spark 3.4 as well, pass
+:::note Which Delta implementation you get
+Delta Standalone doesn't run on Spark 3.5, so on 3.5.x a Delta source or target is routed through
+Delta Kernel with no flag needed. If you want Kernel on Spark 3.4 as well, pass
 `--usedeltakernel`, or set `.useDeltaKernel(true)` on the `TableSyncSpec`.
+:::
 
 ## Next steps
 

--- a/website/releases/downloads.mdx
+++ b/website/releases/downloads.mdx
@@ -1,23 +1,23 @@
 ---
 title: Downloads
-sidebar_position: 1
+sidebar_position: -100
 ---
 
 Apache XTable™ (incubating) releases are available under the Apache License, Version 2.0. See the NOTICE file contained in each release artifact for applicable copyright attribution notices.
 
 To ensure that you have downloaded the true release, you should [verify](https://www.apache.org/info/verification.html) the integrity of the files using the signatures and checksums available in this page. All releases are signed using the [Apache XTable KEYS file](https://downloads.apache.org/incubator/xtable/KEYS).
 
-### Release 0.4.0-incubating
+### [Release 0.4.0-incubating](/releases/release-0.4.0-incubating)
 * Source Release: [Apache XTable 0.4.0-incubating Source Release](https://dlcdn.apache.org/incubator/xtable/0.4.0-incubating/apache-xtable-0.4.0-incubating.src.tgz) ([asc](https://downloads.apache.org/incubator/xtable/0.4.0-incubating/apache-xtable-0.4.0-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/incubator/xtable/0.4.0-incubating/apache-xtable-0.4.0-incubating.src.tgz.sha512))
 * Release Notes: [Release Notes 0.4.0-incubating](release-0.4.0-incubating.mdx)
 * Maven Search: [Apache XTable 0.4.0-incubating](https://central.sonatype.com/search?q=g:org.apache.xtable%20v:0.4.0-incubating&smo=true)
 
-### Release 0.3.0-incubating
+### [Release 0.3.0-incubating](/releases/release-0.3.0-incubating)
 * Source Release: [Apache XTable 0.3.0-incubating Source Release](https://dlcdn.apache.org/incubator/xtable/0.3.0-incubating/apache-xtable-0.3.0-incubating.src.tgz) ([asc](https://downloads.apache.org/incubator/xtable/0.3.0-incubating/apache-xtable-0.3.0-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/incubator/xtable/0.3.0-incubating/apache-xtable-0.3.0-incubating.src.tgz.sha512))
 * Release Notes: [Release Notes 0.3.0-incubating](release-0.3.0-incubating.mdx)
 * Maven Search: [Apache XTable 0.3.0-incubating](https://central.sonatype.com/search?q=g:org.apache.xtable%20v:0.3.0-incubating&smo=true)
 
-### Release 0.2.0-incubating
+### [Release 0.2.0-incubating](/releases/release-0.2.0-incubating)
 * Source Release: [Apache XTable 0.2.0-incubating Source Release](https://dlcdn.apache.org/incubator/xtable/0.2.0-incubating/apache-xtable-0.2.0-incubating.src.tgz) ([asc](https://downloads.apache.org/incubator/xtable/0.2.0-incubating/apache-xtable-0.2.0-incubating.src.tgz.asc), [sha512](https://downloads.apache.org/incubator/xtable/0.2.0-incubating/apache-xtable-0.2.0-incubating.src.tgz.sha512))
 * Release Notes: [Release Notes 0.2.0-incubating](release-0.2.0-incubating.mdx)
 * Maven Search: [Apache XTable 0.2.0-incubating](https://central.sonatype.com/search?q=g:org.apache.xtable%20v:0.2.0-incubating&smo=true)

--- a/website/releases/release-0.4.0-incubating.mdx
+++ b/website/releases/release-0.4.0-incubating.mdx
@@ -25,8 +25,12 @@ $SPARK_HOME/bin/spark-submit \
   orders-job.jar
 ```
 
-It is published to Maven Central as `org.apache.xtable:xtable-spark-runtime_2.12:0.4.0-incubating`
-and supports Spark 3.4 and 3.5. See [Run an XTable sync on Apache Spark](/docs/how-to-spark-runtime).
+It is published to Maven Central as `org.apache.xtable:xtable-spark-runtime_2.12:0.4.0-incubating`.
+See [Run an XTable sync on Apache Spark](/docs/how-to-spark-runtime).
+
+:::note Spark version support
+`xtable-spark-runtime` 0.4.0-incubating supports Spark `3.4.x` and `3.5.x`, on Scala `2.12`.
+:::
 
 ### 🔄 New source formats
 


### PR DESCRIPTION
Closes #920.

I ran every command on the page end to end before writing this, against the released
`xtable-spark-runtime_2.12-0.4.0-incubating.jar` from Maven Central. Evidence below.

## Review round 2

1. **The examples could not run.** `xtable-spark-runtime` declares Hudi, Iceberg, Delta, Avro,
   `parquet-avro` and `jol-core` as `provided`, so the 4 MB jar carries none of them. New
   **Getting the engine libraries** section resolves them from the published POM with
   `dependency:build-classpath -DincludeScope=provided`, the recipe
   `demo/spark-runtime/README.md` already uses (21 jars), and every `spark-submit` now passes them
   through `spark.driver.extraClassPath` / `spark.executor.extraClassPath`. A note records why a
   flat classpath and not `--packages`: a child classloader separates the engines from Spark's own
   Avro and breaks cross-boundary casts.
2. **The partition spec was dropped.** Fixed with `--partitionspec city:VALUE` and
   `.partitionSpec("city:VALUE")`. Measured both ways on the Quickstart's `people` table:

   | | Iceberg `default-spec-id` | Delta `partitionColumns` |
   | --- | --- | --- |
   | without the flag | `0` (fields `[]`) | `[]` |
   | with `city:VALUE` | `1` (identity on `city`) | `['city']` |

3. **The `--datasetconfig` example listed tables the page never creates.** Confirmed by running it:
   `people` completes, `orders` fails, and the submit exits 1 with
   `IllegalStateException: 1 of 2 table sync(s) failed`. The runnable config now holds only
   `people`; a second entry is shown as a separate snippet with that behaviour stated.

## A fourth problem the run turned up

Following the Quickstart and then this page fails, whatever the classpath. The Quickstart's shell
uses `hudi-spark3.4-bundle_2.12:1.2.0`, which writes Hudi table version 9 and timeline layout
version 2. `0.4.0-incubating` is built against Hudi `0.14.0`, which accepts layout version 1, so
the sync dies before reading any data:

```
java.lang.IllegalArgumentException
  at org.apache.hudi.common.util.ValidationUtils.checkArgument(ValidationUtils.java:33)
  at org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion.<init>(TimelineLayoutVersion.java:40)
  at org.apache.hudi.common.table.HoodieTableConfig.getTimelineLayoutVersion(HoodieTableConfig.java:522)
  at org.apache.hudi.common.table.HoodieTableMetaClient.<init>(HoodieTableMetaClient.java:143)
  at org.apache.xtable.hudi.HudiConversionSourceProvider.getConversionSourceInstance(HudiConversionSourceProvider.java:41)
```

Written with `hudi-spark3.4-bundle_2.12:0.14.0` instead (table version 6), the same sync succeeds.
This PR adds a caution to Prerequisites saying so.

The underlying cause is outside this page: #904 bumped the Quickstart to Hudi `1.2.0` to match
`main`, where `hudi.version` is `1.2.0`, but the site documents the released `0.4.0-incubating`
artifacts, where it is `0.14.0`. Iceberg `1.9.2` and Delta `2.4.0` are the same on both, so Hudi is
the only one that diverges. Happy to file that separately.

## Test evidence

Ran on Spark `3.4.2` (matching `spark.version` at the tag) and Spark `3.5.3`, JDK 11, against the
released jar. All 16 combinations pass:

| Area | Cases | Result |
| --- | --- | --- |
| CLI single table | Hudi -> Iceberg / Delta / both / both-no-spec; Delta -> Hudi / Iceberg / both; Iceberg -> Hudi / Delta / both | 10/10 exit 0 |
| CLI `--datasetconfig` | valid config / config naming a missing table | exit 0 / exit 1 |
| In-job Scala | first sync, then an append | `mode=FULL`, then `mode=INCREMENTAL` |
| In-job Java | `mvn package` with the documented `provided` dep, then submit | exit 0, both targets `SUCCESS` |
| Spark 3.5.3 CLI | Hudi -> Delta | exit 0, logs `auto-enabling the Delta Kernel implementation` |
| Read-back | every synced table, in all three formats | identical rows each time |

Two things that verify claims the page makes rather than just asserting them:

- The Java job's jar is **3,659 bytes and contains only `com/example/PeopleJob.class`**, which is
  the point of the `provided` scope the "Building the job" section documents.
- A re-run after an `Append` returns `mode=INCREMENTAL` for both targets, which is the incremental
  watermark the page describes. An `Overwrite` correctly stays `FULL`.

`npm run build` succeeds with no new warnings; internal links on the three changed pages resolve to
a built page (`onBrokenLinks` is `'ignore'`); external links return 200. Rebased on current `main`.

## Scope

You asked what the broader changes solve. They are the review comments I left on #913 before it
merged, which were never applied; #920 lists them individually:

| #913 comment | Change |
| --- | --- |
| Cover building the job before running it, and `orders-job.jar` appears before anything introduces it | The in-job section is now Writing / Building / Running, so the code precedes the `spark-submit` that submits it |
| Other quickstarts use local paths, this one used S3 | All examples use `file:///tmp/hudi-dataset/people` |
| Say the Hudi table has to exist first | New Prerequisites section |
| Split single-table from config-file mode | A subsection each |
| Move the Delta paragraph into a note | Now a `:::note` |
| "and newer" implies Spark 4.x | Now `3.4.x` and `3.5.x`; the 0.4.0 build pins `spark.version` to `3.4.2` |

**The section order is unchanged from #913.** An earlier revision of this PR moved "Running a sync
as its own job" ahead of "Adding the sync to a Spark job"; that is reverted, so the page still
leads with the in-job section. The "a jar appears before anything introduces it" concern is handled
by the Writing / Building / Running split instead, which is the smaller change.

`downloads.mdx` links each release heading to its notes page and moves Downloads to the top of the
Releases sidebar. `release-0.4.0-incubating.mdx` moves the Spark support line into a callout.

Happy to split any of that out if you would rather this PR were only the engine-jars fix.

## Known gap, tracked separately

#921: Delta Kernel is auto-selected only by the `XTableSparkSync` CLI, not by the in-job
`XTableSyncService`. Reproduced while testing: on Spark 3.5 the in-job Delta sync without
`.useDeltaKernel(true)` returns `statusCode=ERROR`
(`DeprecatedRawLocalFileStatus cannot be cast to FileStatusWithMetadata`); with the flag it
returns `SUCCESS`. Worth noting on that issue that the in-job API reports this inside the returned
`SyncResult` rather than throwing, so a job that ignores the return value sees a run that appears
to succeed but synced nothing.

