### PR TITLE
fix(xtable-utilities): remove duplicate AWS SDK v2 modules from shaded jar

### DIFF
--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -178,6 +178,21 @@
             <artifactId>hudi-hadoop-common</artifactId>
             <version>${hudi.version}</version>
         </dependency>
+        <!--
+          Same story as hudi-hadoop-common above: xtable-aws declares this
+          provided (a real cluster supplies it), which doesn't propagate to
+          this standalone jar. Needed for org.apache.hudi.hive.MultiPartKeysValueExtractor,
+          referenced by Jackson when deserializing GlueCatalogConfig's
+          partition value extractor field. Without it, RunCatalogSync's Glue
+          catalog sync fails with NoClassDefFoundError at runtime despite
+          compiling fine (the reference is a string class name resolved via
+          reflection, so javac never catches the missing dependency).
+        -->
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-hive-sync</artifactId>
+            <version>${hudi.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-java-client</artifactId>
@@ -605,6 +620,7 @@
                             <include>org.apache.hudi:hudi-client-common</include>
                             <include>org.apache.hudi:hudi-common</include>
                             <include>org.apache.hudi:hudi-hadoop-common</include>
+                            <include>org.apache.hudi:hudi-hive-sync</include>
                             <include>org.apache.hudi:hudi-io</include>
                             <include>org.apache.hudi:hudi-java-client</include>
                             <include>org.apache.hudi:hudi-timeline-service</include>

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -270,6 +270,17 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <transformers>
+                        <!-- Several bundled Spark data sources (delta-spark, hudi-spark,
+                             parquet, avro, etc) each ship their own
+                             META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+                             file at the same path. Without merging them, shade keeps only one
+                             and silently drops the rest, including delta-spark's "delta"
+                             shortname registration, so Spark's ServiceLoader lookup for
+                             format("delta")/DeltaTable.forPath() finds nothing and falls back
+                             to guessing the legacy class name "delta.DefaultSource", which
+                             doesn't exist: ClassNotFoundException. This transformer merges
+                             same-path service files instead of overwriting. -->
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"> </transformer>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"> </transformer>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                             <resources>

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -759,12 +759,9 @@
                             <include>software.amazon.awssdk:netty-nio-client</include>
                             <include>software.amazon.awssdk:profiles</include>
                             <include>software.amazon.awssdk:protocol-core</include>
-                            <include>software.amazon.awssdk:regions</include>
                             <include>software.amazon.awssdk:retries</include>
                             <include>software.amazon.awssdk:retries-spi</include>
-                            <include>software.amazon.awssdk:sdk-core</include>
                             <include>software.amazon.awssdk:third-party-jackson-core</include>
-                            <include>software.amazon.awssdk:utils</include>
                             <include>software.amazon.eventstream:eventstream</include>
                             <include>stax:stax-api</include>
                             <include>tomcat:jasper-compiler</include>

--- a/xtable-utilities/pom.xml
+++ b/xtable-utilities/pom.xml
@@ -738,30 +738,19 @@
                             <include>org.xerial.snappy:snappy-java</include>
                             <include>org.yaml:snakeyaml</include>
                             <include>oro:oro</include>
-                            <include>software.amazon.awssdk:annotations</include>
-                            <include>software.amazon.awssdk:apache-client</include>
-                            <include>software.amazon.awssdk:auth</include>
-                            <include>software.amazon.awssdk:aws-core</include>
-                            <include>software.amazon.awssdk:aws-json-protocol</include>
+                            <!-- Only bundle; it already contains internally-consistent
+                                 copies of every individual software.amazon.awssdk:* module
+                                 (annotations/auth/aws-core/glue/profiles/etc). Including any
+                                 of those separately alongside bundle makes the shade plugin
+                                 merge two different builds of the same classes, pairing
+                                 (e.g.) bundle's auth/sts classes with an IoUtils/AttributeMap
+                                 from the standalone jar that's missing a method they call,
+                                 causing a NoSuchMethodError at JVM shutdown when closing S3A's
+                                 credentials provider. Compile-time resolution of the individual
+                                 modules is untouched (controlled by <dependencies>, not this
+                                 list); this only changes which copy's bytes end up in the
+                                 final jar. -->
                             <include>software.amazon.awssdk:bundle</include>
-                            <include>software.amazon.awssdk:checksums</include>
-                            <include>software.amazon.awssdk:checksums-spi</include>
-                            <include>software.amazon.awssdk:endpoints-spi</include>
-                            <include>software.amazon.awssdk:glue</include>
-                            <include>software.amazon.awssdk:http-auth</include>
-                            <include>software.amazon.awssdk:http-auth-aws</include>
-                            <include>software.amazon.awssdk:http-auth-aws-eventstream</include>
-                            <include>software.amazon.awssdk:http-auth-spi</include>
-                            <include>software.amazon.awssdk:http-client-spi</include>
-                            <include>software.amazon.awssdk:identity-spi</include>
-                            <include>software.amazon.awssdk:json-utils</include>
-                            <include>software.amazon.awssdk:metrics-spi</include>
-                            <include>software.amazon.awssdk:netty-nio-client</include>
-                            <include>software.amazon.awssdk:profiles</include>
-                            <include>software.amazon.awssdk:protocol-core</include>
-                            <include>software.amazon.awssdk:retries</include>
-                            <include>software.amazon.awssdk:retries-spi</include>
-                            <include>software.amazon.awssdk:third-party-jackson-core</include>
                             <include>software.amazon.eventstream:eventstream</include>
                             <include>stax:stax-api</include>
                             <include>tomcat:jasper-compiler</include>


### PR DESCRIPTION
software.amazon.awssdk:bundle already contains internally-consistent copies of regions/sdk-core/utils. Including them separately in the shade artifactSet caused the shade plugin to merge two different builds of these classes, so the bundle's STS classes (needed for IRSA/web-identity credentials on EKS) ended up paired with an IoUtils class missing a method they call -- NoSuchMethodError at JVM shutdown when closing the STS web-identity credentials provider.

## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

*(For example: This pull request implements the sync for delta format.)*

## Brief change log

*(for example:)*
- *Fixed JSON parsing error when persisting state*
- *Added unit tests for schema evolution*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end.*
- *Added TestConversionController to verify the change.*
- *Manually verified the change by running a job locally.*
