### PR TITLE
[MINOR] Prefix Dependabot pull request titles with [MINOR]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    # The PR Title Validation workflow accepts "[<issue-number>] <description>",
+    # "[MINOR] <description>", or a Conventional Commits prefix. Dependabot names
+    # its pull requests "Bump <dependency> from <a> to <b>", which matches none of
+    # them, so every Dependabot pull request failed the check. Prefix the commit
+    # message and the title with [MINOR] instead.
+    #
+    # The trailing space in the prefix is deliberate. Dependabot appends a colon
+    # to any prefix that ends with an alphanumeric character or a closing bracket,
+    # which would produce "[MINOR]: Bump ..." and fail the check again. A prefix
+    # that already ends with a space is used verbatim.
+    commit-message:
+      prefix: "[MINOR] "


### PR DESCRIPTION
## What is the purpose of the pull request

Dependabot names its pull requests `Bump <dependency> from <a> to <b>`. That title matches none of the three formats `.github/workflows/pr_title_validation.yml` accepts, namely `[<issue-number>] <description>`, `[MINOR] <description>`, or a Conventional Commits prefix. Every Dependabot pull request therefore fails the `validate-pr-title` check, and a committer has to rename it by hand. #879 and #924 were both renamed this way.

This pull request sets `commit-message.prefix` so Dependabot writes the prefix itself.

## Brief change log

- Added `commit-message.prefix: "[MINOR] "` to the `github-actions` entry in `.github/dependabot.yml`.

The trailing space in the prefix value is deliberate, and a comment in the file records why. Dependabot appends a colon to any prefix that ends with an alphanumeric character or a closing bracket, so `"[MINOR]"` would produce `[MINOR]: Bump ...` and fail the check again. A prefix that already ends with a space is used verbatim. See [`title_builder.rb`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/pull_request_creator/message_builder/title_builder.rb#L91-L103) in dependabot-core.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

The behaviour was verified in two parts, because Dependabot only regenerates titles on its next scheduled run.

1. The resulting title is `[MINOR] Bump <dependency> from <a> to <b>`. The prefix comes from `TitleBuilder#build`, which returns `"#{prefix}#{name}"`, and the YAML value parses as `'[MINOR] '` with the space preserved.
2. That title passes the workflow check. Running the two `bash` regexes from `pr_title_validation.yml` against candidate titles gives:

- `[MINOR] Bump actions/setup-java from 5 to 6` matches `^\[MINOR\]\ .+`
- `[MINOR] bump actions/setup-java from 5 to 6` matches, so the check is insensitive to how Dependabot capitalises the first word
- `[MINOR]: Bump actions/setup-java from 5 to 6` does not match, which is the case the trailing space avoids
